### PR TITLE
ci: replace manual zccache pip setup with zackees/zccache action

### DIFF
--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,46 +19,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: "true"
-      - name: Restore zccache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.zccache
-          key: zccache-${{ runner.os }}-check-${{ github.sha }}
-          restore-keys: |
-            zccache-${{ runner.os }}-check-
-            zccache-${{ runner.os }}-
       - name: Setup zccache
-        shell: bash
-        run: |
-          pip install zccache
-          # Fix all zccache binaries (entry point + bundled daemon)
-          SITE_PKGS=$(pip show zccache | grep Location | cut -d' ' -f2)
-          find "$SITE_PKGS/zccache" -type f ! -perm -u=x -exec chmod +x {} + 2>/dev/null || true
-          find /Library/Frameworks/Python.framework -name 'zccache*' -type f -exec chmod +x {} + 2>/dev/null || true
-          find ~/.local -name 'zccache*' -type f -exec chmod +x {} + 2>/dev/null || true
-          zccache start
+        uses: zackees/zccache@main
+        with:
+          shared-key: ${{ runner.os }}-check
+
       - name: Check
         run: cargo check --workspace --all-targets
-        env:
-          RUSTC_WRAPPER: zccache
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
-        env:
-          RUSTC_WRAPPER: zccache
       - name: Test
         run: cargo test --workspace
-        env:
-          RUSTC_WRAPPER: zccache
-      - name: Stop zccache
+
+      - name: Cleanup zccache
         if: always()
-        shell: bash
-        run: zccache stop || true
-      - name: Save zccache
-        if: always()
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.zccache
-          key: zccache-${{ runner.os }}-check-${{ github.sha }}
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -19,42 +19,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: "true"
-      - name: Restore zccache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.zccache
-          key: zccache-${{ runner.os }}-check-${{ github.sha }}
-          restore-keys: |
-            zccache-${{ runner.os }}-check-
-            zccache-${{ runner.os }}-
       - name: Setup zccache
-        shell: bash
-        run: |
-          pip install zccache
-          find ~/.local -name 'zccache*' -type f -exec chmod +x {} + 2>/dev/null || true
-          zccache start
+        uses: zackees/zccache@main
+        with:
+          shared-key: ${{ runner.os }}-check
+
       - name: Check
         run: cargo check --workspace --all-targets
-        env:
-          RUSTC_WRAPPER: zccache
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
-        env:
-          RUSTC_WRAPPER: zccache
       - name: Test
         run: cargo test --workspace
-        env:
-          RUSTC_WRAPPER: zccache
-      - name: Stop zccache
+
+      - name: Cleanup zccache
         if: always()
-        shell: bash
-        run: zccache stop || true
-      - name: Save zccache
-        if: always()
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.zccache
-          key: zccache-${{ runner.os }}-check-${{ github.sha }}
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,42 +19,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: "true"
-      - name: Restore zccache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.zccache
-          key: zccache-${{ runner.os }}-check-${{ github.sha }}
-          restore-keys: |
-            zccache-${{ runner.os }}-check-
-            zccache-${{ runner.os }}-
       - name: Setup zccache
-        shell: bash
-        run: |
-          pip install zccache
-          find ~/.local -name 'zccache*' -type f -exec chmod +x {} + 2>/dev/null || true
-          zccache start
+        uses: zackees/zccache@main
+        with:
+          shared-key: ${{ runner.os }}-check
+
       - name: Check
         run: cargo check --workspace --all-targets
-        env:
-          RUSTC_WRAPPER: zccache
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
-        env:
-          RUSTC_WRAPPER: zccache
       - name: Test
         run: cargo test --workspace
-        env:
-          RUSTC_WRAPPER: zccache
-      - name: Stop zccache
+
+      - name: Cleanup zccache
         if: always()
-        shell: bash
-        run: zccache stop || true
-      - name: Save zccache
-        if: always()
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.zccache
-          key: zccache-${{ runner.os }}-check-${{ github.sha }}
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - name: Setup zccache
-        run: |
-          pip install zccache
-          find ~/.local -name 'zccache*' -type f -exec chmod +x {} + 2>/dev/null || true
-          zccache start
+        uses: zackees/zccache@main
+        with:
+          shared-key: docs
+
       - name: Build docs
         run: cargo doc --workspace --no-deps
-        env:
-          RUSTC_WRAPPER: zccache
+
+      - name: Cleanup zccache
+        if: always()
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -13,13 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.75.0
-      - uses: Swatinem/rust-cache@v2
       - name: Setup zccache
-        run: |
-          pip install zccache
-          find ~/.local -name 'zccache*' -type f -exec chmod +x {} + 2>/dev/null || true
-          zccache start
+        uses: zackees/zccache@main
+        with:
+          shared-key: msrv
+
       - name: Check MSRV
         run: cargo check --workspace
-        env:
-          RUSTC_WRAPPER: zccache
+
+      - name: Cleanup zccache
+        if: always()
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,20 +35,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+      - name: Setup zccache
+        uses: zackees/zccache@main
         with:
-          key: platform-build-v1
-          save-if: "true"
-
-      - name: Restore zccache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.zccache
-          key: zccache-${{ runner.os }}-${{ inputs.env-name }}-${{ github.sha }}
-          restore-keys: |
-            zccache-${{ runner.os }}-${{ inputs.env-name }}-
-            zccache-${{ runner.os }}-
+          shared-key: ${{ runner.os }}-${{ inputs.env-name }}
 
       - name: Restore fbuild toolchains
         uses: actions/cache/restore@v5
@@ -76,17 +66,9 @@ jobs:
         if: inputs.firmware-ext == 'bin'
         run: pip install esptool
 
-      - name: Setup zccache
-        run: |
-          pip install zccache
-          find ~/.local -name 'zccache*' -type f -exec chmod +x {} + 2>/dev/null || true
-          zccache start
-
       - name: Build fbuild binaries
         run: |
           cargo build -p fbuild-cli -p fbuild-daemon
-        env:
-          RUSTC_WRAPPER: zccache
 
       - name: Add fbuild to PATH
         run: echo "${{ github.workspace }}/target/debug" >> $GITHUB_PATH
@@ -107,17 +89,9 @@ jobs:
           test -f ${{ inputs.test-dir }}/.fbuild/build/${{ inputs.env-name }}/release/firmware.${{ inputs.firmware-ext }}
           echo "Release build successful - firmware.${{ inputs.firmware-ext }} generated"
 
-      - name: Stop zccache
+      - name: Cleanup zccache
         if: always()
-        shell: bash
-        run: zccache stop || true
-
-      - name: Save zccache
-        if: always()
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.zccache
-          key: zccache-${{ runner.os }}-${{ inputs.env-name }}-${{ github.sha }}
+        uses: zackees/zccache/action/cleanup@main
 
       - name: Save fbuild toolchains
         if: always()

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -60,9 +60,10 @@ jobs:
         with:
           python-version: "3.13"
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Setup zccache
+        uses: zackees/zccache@main
         with:
-          key: ${{ inputs.target }}-v2
+          shared-key: ${{ inputs.target }}
 
       # Linux musl toolchain (libudev is auto-excluded for musl targets by serialport)
       - name: Install Linux dependencies
@@ -80,18 +81,8 @@ jobs:
         if: runner.os == 'Linux'
         run: pip install cargo-zigbuild
 
-      - name: Setup zccache
-        shell: bash
-        run: |
-          pip install zccache
-          SCRIPTS_DIR=$(python -c "import sysconfig; print(sysconfig.get_path('scripts'))")
-          chmod +x "$SCRIPTS_DIR"/zccache* 2>/dev/null || true
-          zccache start
-
       - name: Build release binaries
         shell: bash
-        env:
-          RUSTC_WRAPPER: zccache
         run: |
           if [ "${{ inputs.linux_cross }}" = "true" ]; then
             cargo-zigbuild build --release --target ${{ inputs.target }} -p fbuild-cli
@@ -184,3 +175,7 @@ jobs:
           name: binaries-${{ inputs.target }}
           path: staging/
           if-no-files-found: error
+
+      - name: Cleanup zccache
+        if: always()
+        uses: zackees/zccache/action/cleanup@main


### PR DESCRIPTION
## Summary
- Replace `Swatinem/rust-cache@v2` + manual `pip install zccache` + `actions/cache` save/restore with the unified `zackees/zccache@main` GitHub Action across all 7 workflow templates
- Add `zackees/zccache/action/cleanup@main` cleanup step to all templates
- Remove per-step `RUSTC_WRAPPER: zccache` env vars (handled by the action)

Net -154/+49 lines.

## Test plan
- [ ] check-ubuntu passes
- [ ] check-macos passes
- [ ] check-windows passes
- [ ] msrv passes
- [ ] docs passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline infrastructure by streamlining build caching mechanisms across multiple workflows, resulting in more efficient and maintainable build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->