### PR TITLE
Add native PlatformIO source filters and debug flag support

### DIFF
--- a/crates/fbuild-build/src/apollo3/orchestrator.rs
+++ b/crates/fbuild-build/src/apollo3/orchestrator.rs
@@ -58,7 +58,11 @@ impl BuildOrchestrator for Apollo3Orchestrator {
         let variant_dir = framework.get_variant_dir(&ctx.board.variant);
 
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let sources = scanner.scan_all(Some(&core_dir), Some(&variant_dir))?;
+        let sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            Some(&variant_dir),
+            ctx.source_filter.as_deref(),
+        )?;
 
         let variant_config_dir = variant_dir.join("config");
 

--- a/crates/fbuild-build/src/avr/orchestrator.rs
+++ b/crates/fbuild-build/src/avr/orchestrator.rs
@@ -57,7 +57,11 @@ impl BuildOrchestrator for AvrOrchestrator {
 
         // 5. Scan sources
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let sources = scanner.scan_all(Some(&core_dir), Some(&variant_dir))?;
+        let sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            Some(&variant_dir),
+            ctx.source_filter.as_deref(),
+        )?;
 
         tracing::info!(
             "sources: {} sketch, {} core, {} variant",

--- a/crates/fbuild-build/src/ch32v/orchestrator.rs
+++ b/crates/fbuild-build/src/ch32v/orchestrator.rs
@@ -79,7 +79,11 @@ impl BuildOrchestrator for Ch32vOrchestrator {
         let variant_dir = resolve_variant_dir(&framework_dir, &ctx.board.variant, &system_series);
 
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let sources = scanner.scan_all(Some(&core_dir), Some(&variant_dir))?;
+        let sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            Some(&variant_dir),
+            ctx.source_filter.as_deref(),
+        )?;
 
         tracing::info!(
             "sources: {} sketch, {} core, {} variant",

--- a/crates/fbuild-build/src/esp32/orchestrator.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator.rs
@@ -820,7 +820,11 @@ impl BuildOrchestrator for Esp32Orchestrator {
         } else {
             None
         };
-        let sources = scanner.scan_all(Some(&core_dir), variant_dir_opt)?;
+        let sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            variant_dir_opt,
+            ctx.source_filter.as_deref(),
+        )?;
 
         tracing::info!(
             "sources: {} sketch, {} core, {} variant",

--- a/crates/fbuild-build/src/esp8266/orchestrator.rs
+++ b/crates/fbuild-build/src/esp8266/orchestrator.rs
@@ -80,7 +80,11 @@ impl BuildOrchestrator for Esp8266Orchestrator {
         } else {
             None
         };
-        let sources = scanner.scan_all(Some(&core_dir), variant_dir_opt)?;
+        let sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            variant_dir_opt,
+            ctx.source_filter.as_deref(),
+        )?;
 
         tracing::info!(
             "sources: {} sketch, {} core, {} variant",

--- a/crates/fbuild-build/src/nrf52/orchestrator.rs
+++ b/crates/fbuild-build/src/nrf52/orchestrator.rs
@@ -60,7 +60,11 @@ impl BuildOrchestrator for Nrf52Orchestrator {
         let variant_dir = framework.get_variant_dir(&ctx.board.variant);
 
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let mut sources = scanner.scan_all(Some(&core_dir), Some(&variant_dir))?;
+        let mut sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            Some(&variant_dir),
+            ctx.source_filter.as_deref(),
+        )?;
 
         // Add TinyUSB sources (USB CDC Serial support for nRF52840).
         // Compile arduino/ wrapper + device stack + CDC class + nRF5x port.

--- a/crates/fbuild-build/src/pipeline.rs
+++ b/crates/fbuild-build/src/pipeline.rs
@@ -27,6 +27,7 @@ pub struct BuildContext {
     pub core_build_dir: PathBuf,
     pub src_build_dir: PathBuf,
     pub src_dir: PathBuf,
+    pub source_filter: Option<String>,
     pub user_flags: Vec<String>,
     pub src_flags: Vec<String>,
     pub all_src_flags: Vec<String>,
@@ -112,13 +113,29 @@ impl BuildContext {
         } else {
             project_dir.to_path_buf()
         };
+        let source_filter = config.get_source_filter(env_name)?;
 
         // 6. Collect user flags
+        let build_type = config.get_build_type(env_name)?;
         let user_flags = config.get_build_flags(env_name)?;
         crate::warn_debug_build_flags(&user_flags);
         let src_flags = config.get_build_src_flags(env_name)?;
-        let all_src_flags: Vec<String> =
-            user_flags.iter().chain(src_flags.iter()).cloned().collect();
+        let overlay_link_flags = overlay.link.flags.clone();
+        let (user_flags, src_flags, mut overlay_link_flags) = if build_type == "debug" {
+            let debug_build_flags = config.get_debug_build_flags(env_name)?;
+            apply_debug_build_type(
+                user_flags,
+                src_flags,
+                overlay_link_flags,
+                &debug_build_flags,
+            )
+        } else {
+            (user_flags, src_flags, overlay_link_flags)
+        };
+        let build_unflags = config.get_build_unflags(env_name)?;
+        let (user_flags, src_flags, all_src_flags) =
+            apply_build_unflags(user_flags, src_flags, &build_unflags);
+        remove_unflagged_tokens(&mut overlay_link_flags, &build_unflags);
 
         Ok(Self {
             config,
@@ -128,15 +145,130 @@ impl BuildContext {
             core_build_dir,
             src_build_dir,
             src_dir,
+            source_filter,
             user_flags,
             src_flags,
             all_src_flags,
             global_compile_overlay: overlay.global_compile,
             project_compile_overlay: overlay.project_compile,
-            overlay_link_flags: overlay.link.flags,
+            overlay_link_flags,
             overlay_link_libs: overlay.link.libs,
         })
     }
+}
+
+fn apply_build_unflags(
+    mut user_flags: Vec<String>,
+    mut src_flags: Vec<String>,
+    build_unflags: &[String],
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    if build_unflags.is_empty() {
+        let all_src_flags = user_flags.iter().chain(src_flags.iter()).cloned().collect();
+        return (user_flags, src_flags, all_src_flags);
+    }
+
+    remove_unflagged_tokens(&mut user_flags, build_unflags);
+    remove_unflagged_tokens(&mut src_flags, build_unflags);
+    let all_src_flags = user_flags.iter().chain(src_flags.iter()).cloned().collect();
+    (user_flags, src_flags, all_src_flags)
+}
+
+fn apply_debug_build_type(
+    mut user_flags: Vec<String>,
+    mut src_flags: Vec<String>,
+    mut link_flags: Vec<String>,
+    debug_build_flags: &[String],
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    cleanup_platformio_debug_scope(&mut user_flags);
+    cleanup_platformio_debug_scope(&mut src_flags);
+    cleanup_platformio_debug_scope(&mut link_flags);
+
+    let mut compile_debug_flags = vec!["-D__PLATFORMIO_BUILD_DEBUG__".to_string()];
+    compile_debug_flags.extend(debug_build_flags.iter().cloned());
+
+    user_flags.extend(compile_debug_flags.iter().cloned());
+    src_flags.extend(compile_debug_flags);
+
+    let link_debug_flags: Vec<String> = debug_build_flags
+        .iter()
+        .filter(|flag| is_platformio_debug_link_flag(flag))
+        .cloned()
+        .collect();
+    link_flags.extend(link_debug_flags);
+
+    (user_flags, src_flags, link_flags)
+}
+
+fn remove_unflagged_tokens(flags: &mut Vec<String>, build_unflags: &[String]) {
+    let mut i = 0;
+    while i < build_unflags.len() {
+        let token = &build_unflags[i];
+        if flag_takes_value(token) && i + 1 < build_unflags.len() {
+            remove_flag_value_pair(flags, token, &build_unflags[i + 1]);
+            i += 2;
+        } else {
+            flags.retain(|flag| flag != token);
+            i += 1;
+        }
+    }
+}
+
+fn remove_flag_value_pair(flags: &mut Vec<String>, option: &str, value: &str) {
+    let mut filtered = Vec::with_capacity(flags.len());
+    let mut i = 0;
+    while i < flags.len() {
+        let current = &flags[i];
+        if current == option && i + 1 < flags.len() && flags[i + 1] == value {
+            i += 2;
+            continue;
+        }
+        filtered.push(current.clone());
+        i += 1;
+    }
+    *flags = filtered;
+}
+
+fn cleanup_platformio_debug_scope(flags: &mut Vec<String>) {
+    flags.retain(|flag| !is_platformio_debug_cleanup_flag(flag));
+}
+
+fn is_platformio_debug_cleanup_flag(flag: &str) -> bool {
+    if flag == "-Os" || flag == "-g" {
+        return true;
+    }
+    if flag.len() == 3 {
+        let bytes = flag.as_bytes();
+        if bytes[0] == b'-' && matches!(bytes[2], b'0' | b'1' | b'2' | b'3') {
+            return matches!(bytes[1], b'O' | b'g');
+        }
+    }
+    if flag.len() == 6 && flag.starts_with("-ggdb") {
+        return matches!(flag.as_bytes()[5], b'0' | b'1' | b'2' | b'3');
+    }
+    false
+}
+
+fn is_platformio_debug_link_flag(flag: &str) -> bool {
+    flag.starts_with("-O") || flag == "-g" || flag.starts_with("-g")
+}
+
+fn flag_takes_value(flag: &str) -> bool {
+    matches!(
+        flag,
+        "-include"
+            | "-imacros"
+            | "-isystem"
+            | "-iquote"
+            | "-iprefix"
+            | "-iwithprefix"
+            | "-iwithprefixbefore"
+            | "-Xlinker"
+            | "-Wa"
+            | "-Wl"
+            | "-Wp"
+            | "-L"
+            | "-T"
+    )
 }
 
 /// Add the project's `include/` directory and `lib/` subdirectories to include paths.
@@ -722,6 +854,120 @@ pub fn pick_archiver<'a>(
         gcc_ar_path
     } else {
         ar_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_apply_build_unflags_removes_exact_tokens_from_global_and_src_flags() {
+        let (user_flags, src_flags, all_src_flags) = super::apply_build_unflags(
+            vec![
+                "-Os".to_string(),
+                "-DDEBUG".to_string(),
+                "-Wall".to_string(),
+            ],
+            vec!["-DDEBUG".to_string(), "-Winvalid-pch".to_string()],
+            &["-DDEBUG".to_string(), "-Os".to_string()],
+        );
+
+        assert_eq!(user_flags, vec!["-Wall"]);
+        assert_eq!(src_flags, vec!["-Winvalid-pch"]);
+        assert_eq!(all_src_flags, vec!["-Wall", "-Winvalid-pch"]);
+    }
+
+    #[test]
+    fn test_apply_build_unflags_removes_common_option_value_pair() {
+        let (user_flags, src_flags, all_src_flags) = super::apply_build_unflags(
+            vec![
+                "-include".to_string(),
+                "config/common.h".to_string(),
+                "-Wall".to_string(),
+            ],
+            vec![
+                "-include".to_string(),
+                "config/common.h".to_string(),
+                "-Winvalid-pch".to_string(),
+            ],
+            &["-include".to_string(), "config/common.h".to_string()],
+        );
+
+        assert_eq!(user_flags, vec!["-Wall"]);
+        assert_eq!(src_flags, vec!["-Winvalid-pch"]);
+        assert_eq!(all_src_flags, vec!["-Wall", "-Winvalid-pch"]);
+    }
+
+    #[test]
+    fn test_apply_debug_build_type_replaces_opt_flags_and_adds_debug_define() {
+        let (user_flags, src_flags, link_flags) = super::apply_debug_build_type(
+            vec!["-Os".to_string(), "-Wall".to_string()],
+            vec!["-O2".to_string(), "-Winvalid-pch".to_string()],
+            Vec::new(),
+            &["-Og".to_string(), "-g2".to_string(), "-ggdb2".to_string()],
+        );
+
+        assert_eq!(
+            user_flags,
+            vec![
+                "-Wall",
+                "-D__PLATFORMIO_BUILD_DEBUG__",
+                "-Og",
+                "-g2",
+                "-ggdb2"
+            ]
+        );
+        assert_eq!(
+            src_flags,
+            vec![
+                "-Winvalid-pch",
+                "-D__PLATFORMIO_BUILD_DEBUG__",
+                "-Og",
+                "-g2",
+                "-ggdb2"
+            ]
+        );
+        assert_eq!(link_flags, vec!["-Og", "-g2", "-ggdb2"]);
+    }
+
+    #[test]
+    fn test_debug_mode_then_build_unflags_can_remove_debug_flags_again() {
+        let (user_flags, src_flags, mut link_flags) = super::apply_debug_build_type(
+            vec!["-Os".to_string(), "-Wall".to_string()],
+            vec!["-Winvalid-pch".to_string()],
+            Vec::new(),
+            &["-Og".to_string(), "-g2".to_string(), "-ggdb2".to_string()],
+        );
+        let (user_flags, src_flags, all_src_flags) =
+            super::apply_build_unflags(user_flags, src_flags, &["-g2".to_string()]);
+        super::remove_unflagged_tokens(&mut link_flags, &["-g2".to_string()]);
+
+        assert_eq!(
+            user_flags,
+            vec!["-Wall", "-D__PLATFORMIO_BUILD_DEBUG__", "-Og", "-ggdb2"]
+        );
+        assert_eq!(
+            src_flags,
+            vec![
+                "-Winvalid-pch",
+                "-D__PLATFORMIO_BUILD_DEBUG__",
+                "-Og",
+                "-ggdb2"
+            ]
+        );
+        assert_eq!(
+            all_src_flags,
+            vec![
+                "-Wall",
+                "-D__PLATFORMIO_BUILD_DEBUG__",
+                "-Og",
+                "-ggdb2",
+                "-Winvalid-pch",
+                "-D__PLATFORMIO_BUILD_DEBUG__",
+                "-Og",
+                "-ggdb2"
+            ]
+        );
+        assert_eq!(link_flags, vec!["-Og", "-ggdb2"]);
     }
 }
 

--- a/crates/fbuild-build/src/renesas/orchestrator.rs
+++ b/crates/fbuild-build/src/renesas/orchestrator.rs
@@ -60,7 +60,11 @@ impl BuildOrchestrator for RenesasOrchestrator {
         let variant_dir = framework.get_variant_dir(&ctx.board.variant);
 
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let sources = scanner.scan_all(Some(&core_dir), Some(&variant_dir))?;
+        let sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            Some(&variant_dir),
+            ctx.source_filter.as_deref(),
+        )?;
 
         tracing::info!(
             "sources: {} sketch, {} core, {} variant",

--- a/crates/fbuild-build/src/rp2040/orchestrator.rs
+++ b/crates/fbuild-build/src/rp2040/orchestrator.rs
@@ -70,7 +70,11 @@ impl BuildOrchestrator for Rp2040Orchestrator {
         let variant_dir = framework.get_variant_dir(&ctx.board.variant);
 
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let sources = scanner.scan_all(Some(&core_dir), Some(&variant_dir))?;
+        let sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            Some(&variant_dir),
+            ctx.source_filter.as_deref(),
+        )?;
 
         tracing::info!(
             "sources: {} sketch, {} core, {} variant",

--- a/crates/fbuild-build/src/sam/orchestrator.rs
+++ b/crates/fbuild-build/src/sam/orchestrator.rs
@@ -70,7 +70,11 @@ impl BuildOrchestrator for SamOrchestrator {
 
         // 5. Scan sources
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let sources = scanner.scan_all(Some(&core_dir), Some(&variant_dir))?;
+        let sources = scanner.scan_all_filtered(
+            Some(&core_dir),
+            Some(&variant_dir),
+            ctx.source_filter.as_deref(),
+        )?;
 
         tracing::info!(
             "sources: {} sketch, {} core, {} variant",

--- a/crates/fbuild-build/src/script_runtime.rs
+++ b/crates/fbuild-build/src/script_runtime.rs
@@ -15,6 +15,9 @@ struct ScriptRuntimeInput<'a> {
     env_name: &'a str,
     extra_scripts: &'a [String],
     project_options: &'a HashMap<String, String>,
+    board_config: HashMap<String, String>,
+    platform_name: Option<String>,
+    platformio_home: String,
 }
 
 pub fn resolve_extra_script_overlay(
@@ -28,11 +31,17 @@ pub fn resolve_extra_script_overlay(
     }
 
     let project_options = config.get_env_config(env_name)?;
+    let board_config = build_script_runtime_board_config(project_options)?;
     let input = ScriptRuntimeInput {
         project_dir: &project_dir.to_string_lossy(),
         env_name,
         extra_scripts: &extra_scripts,
         project_options,
+        board_config,
+        platform_name: project_options.get("platform").cloned(),
+        platformio_home: fbuild_paths::get_platformio_home()
+            .to_string_lossy()
+            .to_string(),
     };
 
     let python = find_python().ok_or_else(|| {
@@ -276,10 +285,60 @@ fn find_python() -> Option<Vec<String>> {
     None
 }
 
+fn build_script_runtime_board_config(
+    project_options: &HashMap<String, String>,
+) -> fbuild_core::Result<HashMap<String, String>> {
+    let mut result = HashMap::new();
+    let Some(board_id) = project_options.get("board") else {
+        return Ok(result);
+    };
+
+    let board = fbuild_config::BoardConfig::from_board_id(board_id, &HashMap::new())?;
+    result.insert("name".to_string(), board.name.clone());
+    result.insert("build.mcu".to_string(), board.mcu.clone());
+    result.insert("build.f_cpu".to_string(), board.f_cpu.clone());
+    result.insert("build.board".to_string(), board.board.clone());
+    result.insert("build.core".to_string(), board.core.clone());
+    result.insert("build.variant".to_string(), board.variant.clone());
+    if let Some(value) = &board.extra_flags {
+        result.insert("build.extra_flags".to_string(), value.clone());
+    }
+    if let Some(value) = &board.flash_mode {
+        result.insert("build.flash_mode".to_string(), value.clone());
+    }
+    if let Some(value) = &board.memory_type {
+        result.insert("build.memory_type".to_string(), value.clone());
+    }
+    if let Some(value) = &board.psram_type {
+        result.insert("build.psram_type".to_string(), value.clone());
+    }
+    if let Some(value) = &board.partitions {
+        result.insert("build.partitions".to_string(), value.clone());
+    }
+    if let Some(value) = &board.ldscript {
+        result.insert("build.ldscript".to_string(), value.clone());
+    }
+    if let Some(value) = &board.platform_str {
+        result.insert("platform".to_string(), value.clone());
+    }
+    if let Some(value) = &board.upload_protocol {
+        result.insert("upload.protocol".to_string(), value.clone());
+    }
+    if let Some(value) = &board.upload_speed {
+        result.insert("upload.speed".to_string(), value.clone());
+    }
+    if let Some(value) = project_options.get("framework") {
+        result.insert("frameworks".to_string(), value.clone());
+    }
+
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::flag_overlay::ScriptScopeState;
+    use std::fs;
 
     #[test]
     fn test_cppdefines_to_flags_string_and_kv() {
@@ -367,5 +426,182 @@ mod tests {
                 .to_string_lossy()
                 .to_string()
         );
+    }
+
+    #[test]
+    fn test_resolve_extra_script_overlay_supports_dump_shim() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let project_dir = temp.path();
+        fs::write(
+            project_dir.join("platformio.ini"),
+            "\
+[env:demo]
+platform = atmelavr
+board = uno
+framework = arduino
+extra_scripts = post:dump_test.py
+",
+        )
+        .unwrap();
+        fs::write(
+            project_dir.join("dump_test.py"),
+            "\
+Import(\"env\", \"projenv\")
+state = env.Dump()
+proj_state = projenv.Dump()
+if \"CPPDEFINES\" not in state or \"CPPDEFINES\" not in proj_state:
+    raise RuntimeError(\"missing dump scopes\")
+env.Append(CPPDEFINES=[\"DUMP_SHIM_OK\"])
+",
+        )
+        .unwrap();
+
+        let config =
+            fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini"))
+                .unwrap();
+        let overlay = resolve_extra_script_overlay(project_dir, "demo", &config).unwrap();
+        assert!(overlay
+            .global_compile
+            .common
+            .contains(&"-DDUMP_SHIM_OK".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_extra_script_overlay_supports_common_noop_scons_helpers() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let project_dir = temp.path();
+        fs::write(
+            project_dir.join("platformio.ini"),
+            "\
+[env:demo]
+platform = atmelavr
+board = uno
+framework = arduino
+extra_scripts = post:helpers_test.py
+",
+        )
+        .unwrap();
+        fs::write(
+            project_dir.join("helpers_test.py"),
+            "\
+Import(\"env\")
+if env.IsCleanTarget():
+    raise RuntimeError(\"unexpected clean target\")
+if env.IsIntegrationDump():
+    raise RuntimeError(\"unexpected integration dump\")
+flattened = env.Flatten([[\"a\"], [\"b\", [\"c\"]]])
+if flattened != [\"a\", \"b\", \"c\"]:
+    raise RuntimeError(\"unexpected flatten result\")
+env.Execute(env.VerboseAction(\"echo noop\", \"noop\"))
+env.Append(CPPDEFINES=[\"HELPERS_SHIM_OK\"])
+",
+        )
+        .unwrap();
+
+        let config =
+            fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini"))
+                .unwrap();
+        let overlay = resolve_extra_script_overlay(project_dir, "demo", &config).unwrap();
+        assert!(overlay
+            .global_compile
+            .common
+            .contains(&"-DHELPERS_SHIM_OK".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_extra_script_overlay_supports_board_config_shim() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let project_dir = temp.path();
+        fs::write(
+            project_dir.join("platformio.ini"),
+            "\
+[env:demo]
+platform = atmelavr
+board = uno
+framework = arduino
+extra_scripts = post:board_config_test.py
+",
+        )
+        .unwrap();
+        fs::write(
+            project_dir.join("board_config_test.py"),
+            "\
+Import(\"env\")
+board = env.BoardConfig()
+if board.get(\"build.mcu\") != \"atmega328p\":
+    raise RuntimeError(\"unexpected board mcu\")
+if board.get(\"build.f_cpu\") != \"16000000L\":
+    raise RuntimeError(\"unexpected board f_cpu\")
+env.Append(CPPDEFINES=[\"BOARD_CONFIG_SHIM_OK\"])
+",
+        )
+        .unwrap();
+
+        let config =
+            fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini"))
+                .unwrap();
+        let overlay = resolve_extra_script_overlay(project_dir, "demo", &config).unwrap();
+        assert!(overlay
+            .global_compile
+            .common
+            .contains(&"-DBOARD_CONFIG_SHIM_OK".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_extra_script_overlay_supports_pio_platform_shim() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let project_dir = temp.path();
+        fs::write(
+            project_dir.join("platformio.ini"),
+            "\
+[env:demo]
+platform = atmelavr
+board = uno
+framework = arduino
+extra_scripts = post:pio_platform_test.py
+",
+        )
+        .unwrap();
+        fs::write(
+            project_dir.join("pio_platform_test.py"),
+            "\
+Import(\"env\")
+platform = env.PioPlatform()
+if platform.name != \"atmelavr\":
+    raise RuntimeError(\"unexpected platform name\")
+if not platform.is_embedded():
+    raise RuntimeError(\"expected embedded platform\")
+pkg = platform.get_package_dir(\"tool-avrdude\")
+if not pkg.endswith(\"tool-avrdude\"):
+    raise RuntimeError(\"unexpected package path\")
+env.Append(CPPDEFINES=[\"PIO_PLATFORM_SHIM_OK\"])
+",
+        )
+        .unwrap();
+
+        let config =
+            fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini"))
+                .unwrap();
+        let overlay = resolve_extra_script_overlay(project_dir, "demo", &config).unwrap();
+        assert!(overlay
+            .global_compile
+            .common
+            .contains(&"-DPIO_PLATFORM_SHIM_OK".to_string()));
     }
 }

--- a/crates/fbuild-build/src/script_runtime_harness.py
+++ b/crates/fbuild-build/src/script_runtime_harness.py
@@ -34,12 +34,37 @@ class RuntimeFailure(Exception):
     pass
 
 
+class MockPioPlatform:
+    def __init__(self, name, platformio_home):
+        self.name = name or ""
+        self._platformio_home = platformio_home
+
+    def is_embedded(self):
+        return True
+
+    def get_package_dir(self, package_name):
+        return os.path.join(self._platformio_home, "packages", package_name)
+
+
 class MockEnv:
-    def __init__(self, label, project_dir, env_name, project_options, notes, unsupported):
+    def __init__(
+        self,
+        label,
+        project_dir,
+        env_name,
+        project_options,
+        board_config,
+        platform_name,
+        platformio_home,
+        notes,
+        unsupported,
+    ):
         self._label = label
         self._project_dir = project_dir
         self._env_name = env_name
         self._project_options = project_options
+        self._board_config = board_config
+        self._pio_platform = MockPioPlatform(platform_name, platformio_home)
         self._notes = notes
         self._unsupported = unsupported
         self._scopes = {key: [] for key in SUPPORTED_SCOPES}
@@ -142,6 +167,45 @@ class MockEnv:
 
     def StringifyMacro(self, value):
         return stringify_macro(value)
+
+    def Dump(self):
+        data = dict(self._vars)
+        data.update({scope: list(values) for scope, values in self._scopes.items()})
+        return data
+
+    def BoardConfig(self):
+        return dict(self._board_config)
+
+    def PioPlatform(self):
+        return self._pio_platform
+
+    def IsCleanTarget(self):
+        return False
+
+    def IsIntegrationDump(self):
+        return False
+
+    def Flatten(self, value):
+        items = []
+
+        def visit(node):
+            if isinstance(node, (list, tuple)):
+                for child in node:
+                    visit(child)
+            else:
+                items.append(node)
+
+        visit(value)
+        return items
+
+    def VerboseAction(self, action, message=None):
+        if message:
+            self._notes.append(f"{self._label}.VerboseAction ignored message: {message}")
+        return action
+
+    def Execute(self, action):
+        self._notes.append(f"{self._label}.Execute ignored by native extra_scripts runtime")
+        return 0
 
     def subst(self, text):
         text = str(text)
@@ -246,8 +310,31 @@ def main():
     project_options = data.get("project_options", {})
     notes = []
     unsupported = []
-    env = MockEnv("env", project_dir, env_name, project_options, notes, unsupported)
-    projenv = MockEnv("projenv", project_dir, env_name, project_options, notes, unsupported)
+    board_config = data.get("board_config", {})
+    platform_name = data.get("platform_name")
+    platformio_home = data.get("platformio_home", os.path.expanduser("~/.platformio"))
+    env = MockEnv(
+        "env",
+        project_dir,
+        env_name,
+        project_options,
+        board_config,
+        platform_name,
+        platformio_home,
+        notes,
+        unsupported,
+    )
+    projenv = MockEnv(
+        "projenv",
+        project_dir,
+        env_name,
+        project_options,
+        board_config,
+        platform_name,
+        platformio_home,
+        notes,
+        unsupported,
+    )
 
     script_entries = [resolve_script_entry(env, item) for item in data.get("extra_scripts", [])]
     pre_scripts = [path for scope, path in script_entries if scope == "pre"]

--- a/crates/fbuild-build/src/silabs/orchestrator.rs
+++ b/crates/fbuild-build/src/silabs/orchestrator.rs
@@ -57,7 +57,8 @@ impl BuildOrchestrator for SilabsOrchestrator {
         }
 
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let mut sources = scanner.scan_all(Some(&core_dir), None)?;
+        let mut sources =
+            scanner.scan_all_filtered(Some(&core_dir), None, ctx.source_filter.as_deref())?;
         sources.variant_sources = scan_variant_root_sources(&variant_dir);
 
         tracing::info!(

--- a/crates/fbuild-build/src/source_scanner.rs
+++ b/crates/fbuild-build/src/source_scanner.rs
@@ -58,6 +58,18 @@ pub struct SourceScanner {
     build_dir: PathBuf,
 }
 
+#[derive(Debug)]
+struct SourceFilter {
+    rules: Vec<SourceFilterRule>,
+    has_include_rules: bool,
+}
+
+#[derive(Debug)]
+struct SourceFilterRule {
+    include: bool,
+    matcher: Regex,
+}
+
 impl SourceScanner {
     pub fn new(src_dir: &Path, build_dir: &Path) -> Self {
         Self {
@@ -73,6 +85,14 @@ impl SourceScanner {
     /// When a `main.cpp` already `#include`s `.ino` files (PlatformIO convention),
     /// the `.ino` files are NOT preprocessed separately to avoid duplicate symbols.
     pub fn scan_sketch_sources(&self) -> fbuild_core::Result<Vec<PathBuf>> {
+        self.scan_sketch_sources_filtered(None)
+    }
+
+    /// Scan sketch sources applying a PlatformIO-style source filter, when provided.
+    pub fn scan_sketch_sources_filtered(
+        &self,
+        filter_spec: Option<&str>,
+    ) -> fbuild_core::Result<Vec<PathBuf>> {
         if !self.src_dir.exists() {
             return Ok(Vec::new());
         }
@@ -80,8 +100,13 @@ impl SourceScanner {
         let mut sources = Vec::new();
         let mut ino_files = Vec::new();
         let mut has_main_cpp = false;
+        let filter = SourceFilter::parse(filter_spec)?;
 
         for entry in walk_sources(&self.src_dir) {
+            if !filter.matches(&self.src_dir, &entry) {
+                continue;
+            }
+
             let ext = entry
                 .extension()
                 .unwrap_or_default()
@@ -170,7 +195,17 @@ impl SourceScanner {
         core_dir: Option<&Path>,
         variant_dir: Option<&Path>,
     ) -> fbuild_core::Result<SourceCollection> {
-        let sketch_sources = self.scan_sketch_sources()?;
+        self.scan_all_filtered(core_dir, variant_dir, None)
+    }
+
+    /// Scan everything, applying a source filter to sketch files only.
+    pub fn scan_all_filtered(
+        &self,
+        core_dir: Option<&Path>,
+        variant_dir: Option<&Path>,
+        filter_spec: Option<&str>,
+    ) -> fbuild_core::Result<SourceCollection> {
+        let sketch_sources = self.scan_sketch_sources_filtered(filter_spec)?;
         let core_sources = core_dir
             .map(|d| self.scan_core_sources(d))
             .unwrap_or_default();
@@ -264,6 +299,128 @@ impl SourceScanner {
 
         Ok(output_path)
     }
+}
+
+impl SourceFilter {
+    fn parse(spec: Option<&str>) -> fbuild_core::Result<Self> {
+        let mut rules = Vec::new();
+        let mut has_include_rules = false;
+
+        let Some(spec) = spec else {
+            return Ok(Self {
+                rules,
+                has_include_rules,
+            });
+        };
+
+        for raw in spec.lines().flat_map(|line| line.split(',')) {
+            let token = raw.trim();
+            if token.is_empty() {
+                continue;
+            }
+
+            let (include, inner) = if token.starts_with("+<") && token.ends_with('>') {
+                (true, &token[2..token.len() - 1])
+            } else if token.starts_with("-<") && token.ends_with('>') {
+                (false, &token[2..token.len() - 1])
+            } else {
+                return Err(fbuild_core::FbuildError::ConfigError(format!(
+                    "invalid source filter rule '{}': expected +/-<pattern>",
+                    token
+                )));
+            };
+
+            let pattern = inner.trim().replace('\\', "/");
+            if pattern.is_empty() {
+                return Err(fbuild_core::FbuildError::ConfigError(
+                    "source filter rule must not be empty".to_string(),
+                ));
+            }
+
+            if include {
+                has_include_rules = true;
+            }
+
+            rules.push(SourceFilterRule {
+                include,
+                matcher: compile_source_filter_pattern(&pattern)?,
+            });
+        }
+
+        Ok(Self {
+            rules,
+            has_include_rules,
+        })
+    }
+
+    fn matches(&self, root: &Path, path: &Path) -> bool {
+        if self.rules.is_empty() {
+            return true;
+        }
+
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let mut included = !self.has_include_rules;
+        for rule in &self.rules {
+            if rule.matcher.is_match(&rel) {
+                included = rule.include;
+            }
+        }
+        included
+    }
+}
+
+fn compile_source_filter_pattern(pattern: &str) -> fbuild_core::Result<Regex> {
+    let normalized = pattern.replace('\\', "/");
+    let regex_body = if normalized == "*" {
+        String::from(".*")
+    } else if normalized.ends_with('/') {
+        format!(
+            "{}(?:/.*)?",
+            glob_fragment_to_regex(normalized.trim_end_matches('/'))
+        )
+    } else if normalized.contains('/') {
+        glob_fragment_to_regex(&normalized)
+    } else {
+        format!("(?:.*/)?{}", glob_fragment_to_regex(&normalized))
+    };
+
+    Regex::new(&format!("^{}$", regex_body)).map_err(|e| {
+        fbuild_core::FbuildError::ConfigError(format!(
+            "invalid source filter pattern '{}': {}",
+            normalized, e
+        ))
+    })
+}
+
+fn glob_fragment_to_regex(pattern: &str) -> String {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '*' => {
+                if i + 1 < chars.len() && chars[i + 1] == '*' {
+                    out.push_str(".*");
+                    i += 1;
+                } else {
+                    out.push_str("[^/]*");
+                }
+            }
+            '?' => out.push_str("[^/]"),
+            c if ".+()[]{}^$|\\".contains(c) => {
+                out.push('\\');
+                out.push(c);
+            }
+            c => out.push(c),
+        }
+        i += 1;
+    }
+    out
 }
 
 fn write_if_changed(path: &Path, contents: &str) -> std::io::Result<()> {
@@ -619,5 +776,38 @@ mod tests {
         assert_eq!(collection.core_sources.len(), 1);
         assert_eq!(collection.variant_sources.len(), 1);
         assert_eq!(collection.all_sources().len(), 3);
+    }
+
+    #[test]
+    fn test_scan_sketch_sources_filtered_excludes_subdirectory() {
+        let (_tmp, src_dir, build_dir) = setup_project(&[
+            ("main.cpp", "int main() { return 0; }"),
+            ("generated/skip.cpp", "void skip() {}"),
+        ]);
+        let scanner = SourceScanner::new(&src_dir, &build_dir);
+        let sources = scanner
+            .scan_sketch_sources_filtered(Some("+<*>\n-<generated/>"))
+            .unwrap();
+        assert_eq!(sources.len(), 1);
+        assert!(sources[0].ends_with("main.cpp"));
+    }
+
+    #[test]
+    fn test_scan_sketch_sources_filtered_includes_only_selected_files() {
+        let (_tmp, src_dir, build_dir) = setup_project(&[
+            ("main.cpp", "int main() { return 0; }"),
+            ("helper.cpp", "void helper() {}"),
+            ("sub/util.c", "void util() {}"),
+        ]);
+        let scanner = SourceScanner::new(&src_dir, &build_dir);
+        let sources = scanner
+            .scan_sketch_sources_filtered(Some("+<main.cpp>\n+<sub/util.c>"))
+            .unwrap();
+        assert_eq!(sources.len(), 2);
+        assert!(sources.iter().any(|p| p.ends_with("main.cpp")));
+        assert!(sources
+            .iter()
+            .any(|p| p.ends_with("sub\\util.c") || p.ends_with("sub/util.c")));
+        assert!(!sources.iter().any(|p| p.ends_with("helper.cpp")));
     }
 }

--- a/crates/fbuild-build/src/stm32/orchestrator.rs
+++ b/crates/fbuild-build/src/stm32/orchestrator.rs
@@ -84,7 +84,8 @@ impl BuildOrchestrator for Stm32Orchestrator {
         // sources manually because the variant dir contains files for multiple
         // board variants (MALYAN, AFROFLIGHT, etc.) and startup files that
         // conflict with the generic one in cores/arduino/stm32/.
-        let mut sources = scanner.scan_all(Some(&core_dir), None)?;
+        let mut sources =
+            scanner.scan_all_filtered(Some(&core_dir), None, ctx.source_filter.as_deref())?;
         sources.variant_sources = scanner
             .scan_variant_sources(&variant_dir)
             .into_iter()
@@ -268,7 +269,7 @@ fn build_arduino_mbed_stm32(
 
     let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
     let sources = SourceCollection {
-        sketch_sources: scanner.scan_sketch_sources()?,
+        sketch_sources: scanner.scan_sketch_sources_filtered(ctx.source_filter.as_deref())?,
         core_sources: framework.get_core_sources(),
         variant_sources: framework.get_variant_sources(&ctx.board.variant),
         headers: Vec::new(),

--- a/crates/fbuild-build/src/teensy/orchestrator.rs
+++ b/crates/fbuild-build/src/teensy/orchestrator.rs
@@ -66,7 +66,8 @@ impl BuildOrchestrator for TeensyOrchestrator {
         let core_dir = framework.get_core_dir(&ctx.board.core);
 
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
-        let mut sources = scanner.scan_all(Some(&core_dir), None)?;
+        let mut sources =
+            scanner.scan_all_filtered(Some(&core_dir), None, ctx.source_filter.as_deref())?;
         sources
             .core_sources
             .retain(|p| p.file_name().map(|f| f != "Blink.cc").unwrap_or(true));

--- a/crates/fbuild-config/src/ini_parser.rs
+++ b/crates/fbuild-config/src/ini_parser.rs
@@ -143,6 +143,77 @@ impl PlatformIOConfig {
         }
     }
 
+    /// Get build_unflags for an environment.
+    ///
+    /// Priority:
+    /// 1. `PLATFORMIO_BUILD_UNFLAGS` forwarded override
+    /// 2. `build_unflags`
+    pub fn get_build_unflags(&self, env_name: &str) -> fbuild_core::Result<Vec<String>> {
+        if let Some(flags) = self.overrides.get_build_unflags() {
+            return Ok(parse_flags(flags));
+        }
+
+        let config = self.get_env_config(env_name)?;
+        match config.get("build_unflags") {
+            Some(flags) => Ok(parse_flags(flags)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Get build_type for an environment.
+    ///
+    /// PlatformIO defaults this to `release`.
+    pub fn get_build_type(&self, env_name: &str) -> fbuild_core::Result<String> {
+        let config = self.get_env_config(env_name)?;
+        Ok(config
+            .get("build_type")
+            .map(|value| strip_inline_comment(value))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "release".to_string()))
+    }
+
+    /// Get debug_build_flags for an environment.
+    ///
+    /// PlatformIO defaults to `-Og -g2 -ggdb2` when the option is not set.
+    pub fn get_debug_build_flags(&self, env_name: &str) -> fbuild_core::Result<Vec<String>> {
+        let config = self.get_env_config(env_name)?;
+        match config.get("debug_build_flags") {
+            Some(flags) => Ok(parse_flags(flags)),
+            None => Ok(vec![
+                "-Og".to_string(),
+                "-g2".to_string(),
+                "-ggdb2".to_string(),
+            ]),
+        }
+    }
+
+    /// Get source filter rules for an environment.
+    ///
+    /// Priority:
+    /// 1. `PLATFORMIO_BUILD_SRC_FILTER` forwarded override
+    /// 2. `build_src_filter`
+    /// 3. legacy `src_filter`
+    pub fn get_source_filter(&self, env_name: &str) -> fbuild_core::Result<Option<String>> {
+        if let Some(value) = self.overrides.get_build_src_filter() {
+            let cleaned = strip_inline_comment(value);
+            if !cleaned.is_empty() {
+                return Ok(Some(cleaned.to_string()));
+            }
+        }
+
+        let config = self.get_env_config(env_name)?;
+        for key in ["build_src_filter", "src_filter"] {
+            if let Some(value) = config.get(key) {
+                let cleaned = strip_inline_comment(value);
+                if !cleaned.is_empty() {
+                    return Ok(Some(cleaned.to_string()));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Get library dependencies for an environment.
     pub fn get_lib_deps(&self, env_name: &str) -> fbuild_core::Result<Vec<String>> {
         let config = self.get_env_config(env_name)?;
@@ -1250,5 +1321,158 @@ board_build.embed_txtfiles = config/timezones.json
         let config = PlatformIOConfig::from_path(f.path()).unwrap();
         assert!(config.get_embed_files("uno").unwrap().is_empty());
         assert!(config.get_embed_txtfiles("uno").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_get_source_filter_prefers_build_src_filter() {
+        let f = write_ini(
+            "\
+[env:demo]
+platform = espressif32
+board = esp32dev
+framework = arduino
+src_filter = +<legacy.cpp>
+build_src_filter =
+    +<*>
+    -<generated/>
+",
+        );
+        let config = PlatformIOConfig::from_path(f.path()).unwrap();
+        assert_eq!(
+            config.get_source_filter("demo").unwrap(),
+            Some("+<*>\n-<generated/>".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_source_filter_falls_back_to_src_filter() {
+        let f = write_ini(
+            "\
+[env:demo]
+platform = ststm32
+board = bluepill_f103c8
+framework = stm32cube
+src_filter =
+    +<main.cpp>
+    -<legacy/>
+",
+        );
+        let config = PlatformIOConfig::from_path(f.path()).unwrap();
+        assert_eq!(
+            config.get_source_filter("demo").unwrap(),
+            Some("+<main.cpp>\n-<legacy/>".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_build_unflags_prefers_env_override() {
+        let f = write_ini(
+            "\
+[env:demo]
+platform = espressif32
+board = esp32dev
+framework = arduino
+build_unflags = -std=gnu++11
+",
+        );
+        let overrides = crate::pio_env::PioEnvOverrides::from_map(
+            [(
+                "PLATFORMIO_BUILD_UNFLAGS".to_string(),
+                "-std=gnu++17 -DDEBUG".to_string(),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let config = PlatformIOConfig::from_path_with_overrides(f.path(), overrides).unwrap();
+        assert_eq!(
+            config.get_build_unflags("demo").unwrap(),
+            vec!["-std=gnu++17", "-DDEBUG"]
+        );
+    }
+
+    #[test]
+    fn test_get_build_unflags_from_ini() {
+        let f = write_ini(
+            "\
+[env:demo]
+platform = ststm32
+board = bluepill_f103c8
+framework = stm32cube
+build_unflags =
+    -Os
+    -DDEBUG
+",
+        );
+        let config = PlatformIOConfig::from_path(f.path()).unwrap();
+        assert_eq!(
+            config.get_build_unflags("demo").unwrap(),
+            vec!["-Os", "-DDEBUG"]
+        );
+    }
+
+    #[test]
+    fn test_get_build_type_defaults_to_release() {
+        let f = write_ini(
+            "\
+[env:demo]
+platform = atmelavr
+board = uno
+framework = arduino
+",
+        );
+        let config = PlatformIOConfig::from_path(f.path()).unwrap();
+        assert_eq!(config.get_build_type("demo").unwrap(), "release");
+    }
+
+    #[test]
+    fn test_get_build_type_reads_debug() {
+        let f = write_ini(
+            "\
+[env:demo]
+platform = espressif32
+board = esp32dev
+framework = arduino
+build_type = debug
+",
+        );
+        let config = PlatformIOConfig::from_path(f.path()).unwrap();
+        assert_eq!(config.get_build_type("demo").unwrap(), "debug");
+    }
+
+    #[test]
+    fn test_get_debug_build_flags_uses_platformio_defaults() {
+        let f = write_ini(
+            "\
+[env:demo]
+platform = espressif32
+board = esp32dev
+framework = arduino
+build_type = debug
+",
+        );
+        let config = PlatformIOConfig::from_path(f.path()).unwrap();
+        assert_eq!(
+            config.get_debug_build_flags("demo").unwrap(),
+            vec!["-Og", "-g2", "-ggdb2"]
+        );
+    }
+
+    #[test]
+    fn test_get_debug_build_flags_reads_ini_override() {
+        let f = write_ini(
+            "\
+[env:demo]
+platform = espressif32
+board = esp32dev
+framework = arduino
+build_type = debug
+debug_build_flags = -Og -g3
+",
+        );
+        let config = PlatformIOConfig::from_path(f.path()).unwrap();
+        assert_eq!(
+            config.get_debug_build_flags("demo").unwrap(),
+            vec!["-Og", "-g3"]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add native `build_src_filter` / `src_filter` support and apply it to sketch source discovery across native orchestrators
- add native handling for `build_unflags`, `build_type=debug`, and `debug_build_flags` in the build pipeline
- extend the extra-scripts runtime with small deterministic shims used by sampled PlatformIO repos, including `Dump`, `BoardConfig()`, and `PioPlatform()`

## Testing
- `cargo test -p fbuild-config --lib`
- `cargo test -p fbuild-build --lib`

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added source filtering support during builds to selectively include/exclude sketch sources based on configurable patterns.
  * Added debug build type support with automatic flag injection and configuration.
  * Added build unflags configuration to remove specified compiler/linker flags.
  * Extended build configuration options for platform-specific settings.

* **Documentation**
  * Expanded script runtime capabilities with board configuration and platform information access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->