### PR TITLE
feat(build): wire build_unflags through all remaining platform compilers (#37)

### DIFF
--- a/crates/fbuild-build/src/apollo3/orchestrator.rs
+++ b/crates/fbuild-build/src/apollo3/orchestrator.rs
@@ -181,7 +181,8 @@ impl BuildOrchestrator for Apollo3Orchestrator {
             augmented_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 8. Create linker
         let linker_script = framework.get_linker_script();

--- a/crates/fbuild-build/src/avr/avr_compiler.rs
+++ b/crates/fbuild-build/src/avr/avr_compiler.rs
@@ -19,6 +19,9 @@ pub struct AvrCompiler {
     mcu_config: AvrMcuConfig,
     profile: BuildProfile,
     temp_dir: PathBuf,
+    /// PlatformIO `build_unflags` to strip from the effective compile
+    /// line. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl AvrCompiler {
@@ -47,7 +50,15 @@ impl AvrCompiler {
             mcu_config,
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags` to strip from every compile
+    /// command. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build the common AVR compiler flags.
@@ -87,6 +98,10 @@ impl Compiler for AvrCompiler {
             None,
             &[],
         )
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 
     fn gcc_path(&self) -> &Path {

--- a/crates/fbuild-build/src/avr/orchestrator.rs
+++ b/crates/fbuild-build/src/avr/orchestrator.rs
@@ -93,7 +93,8 @@ impl BuildOrchestrator for AvrOrchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 7. Create linker
         let linker = AvrLinker::new(

--- a/crates/fbuild-build/src/ch32v/ch32v_compiler.rs
+++ b/crates/fbuild-build/src/ch32v/ch32v_compiler.rs
@@ -21,6 +21,8 @@ pub struct Ch32vCompiler {
     temp_dir: PathBuf,
     /// Extra flags prepended to every compile (e.g. `-isystem` for multilib).
     extra_pre_flags: Vec<String>,
+    /// PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl Ch32vCompiler {
@@ -51,7 +53,14 @@ impl Ch32vCompiler {
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
             extra_pre_flags,
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build the common RISC-V compiler flags.
@@ -108,6 +117,10 @@ impl Compiler for Ch32vCompiler {
 
     fn cpp_flags(&self) -> Vec<String> {
         crate::compiler::build_cpp_flags(self.common_flags(), &self.mcu_config)
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 }
 

--- a/crates/fbuild-build/src/ch32v/orchestrator.rs
+++ b/crates/fbuild-build/src/ch32v/orchestrator.rs
@@ -149,7 +149,8 @@ impl BuildOrchestrator for Ch32vOrchestrator {
             params.profile,
             params.verbose,
             isystem_flags,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 7. Create linker (resolve linker script from system dir)
         // CH32V linker scripts are in system/<SERIES>/SRC/Ld/, not in variants/

--- a/crates/fbuild-build/src/esp8266/esp8266_compiler.rs
+++ b/crates/fbuild-build/src/esp8266/esp8266_compiler.rs
@@ -19,6 +19,8 @@ pub struct Esp8266Compiler {
     mcu_config: Esp8266McuConfig,
     profile: BuildProfile,
     temp_dir: PathBuf,
+    /// PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl Esp8266Compiler {
@@ -46,7 +48,14 @@ impl Esp8266Compiler {
             mcu_config,
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build common compiler flags from the MCU config.
@@ -133,6 +142,10 @@ impl Compiler for Esp8266Compiler {
 
     fn cpp_flags(&self) -> Vec<String> {
         crate::compiler::build_cpp_flags(self.common_flags(), &self.mcu_config)
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 }
 

--- a/crates/fbuild-build/src/esp8266/orchestrator.rs
+++ b/crates/fbuild-build/src/esp8266/orchestrator.rs
@@ -136,7 +136,8 @@ impl BuildOrchestrator for Esp8266Orchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // Resolve linker script from board config
         let ldscript = ctx

--- a/crates/fbuild-build/src/generic_arm/arm_compiler.rs
+++ b/crates/fbuild-build/src/generic_arm/arm_compiler.rs
@@ -19,6 +19,9 @@ pub struct ArmCompiler {
     mcu_config: ArmMcuConfig,
     profile: BuildProfile,
     temp_dir: PathBuf,
+    /// PlatformIO `build_unflags` to strip from the effective compile
+    /// line. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl ArmCompiler {
@@ -47,7 +50,14 @@ impl ArmCompiler {
             mcu_config,
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build the common ARM Cortex-M compiler flags.
@@ -103,6 +113,10 @@ impl Compiler for ArmCompiler {
 
     fn cpp_flags(&self) -> Vec<String> {
         crate::compiler::build_cpp_flags(self.common_flags(), &self.mcu_config)
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 }
 

--- a/crates/fbuild-build/src/nrf52/nrf52_compiler.rs
+++ b/crates/fbuild-build/src/nrf52/nrf52_compiler.rs
@@ -19,6 +19,8 @@ pub struct Nrf52Compiler {
     mcu_config: Nrf52McuConfig,
     profile: BuildProfile,
     temp_dir: PathBuf,
+    /// PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl Nrf52Compiler {
@@ -47,7 +49,14 @@ impl Nrf52Compiler {
             mcu_config,
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build the common ARM Cortex-M4F compiler flags.
@@ -103,6 +112,10 @@ impl Compiler for Nrf52Compiler {
 
     fn cpp_flags(&self) -> Vec<String> {
         crate::compiler::build_cpp_flags(self.common_flags(), &self.mcu_config)
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 }
 

--- a/crates/fbuild-build/src/nrf52/orchestrator.rs
+++ b/crates/fbuild-build/src/nrf52/orchestrator.rs
@@ -186,7 +186,8 @@ impl BuildOrchestrator for Nrf52Orchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 7. Create linker (resolve linker script from board config)
         let ldscript_name = ctx

--- a/crates/fbuild-build/src/renesas/orchestrator.rs
+++ b/crates/fbuild-build/src/renesas/orchestrator.rs
@@ -109,7 +109,8 @@ impl BuildOrchestrator for RenesasOrchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 7. Create linker (resolve linker script from framework variant)
         let linker_script_path = framework.get_linker_script(&ctx.board.variant);

--- a/crates/fbuild-build/src/renesas/renesas_compiler.rs
+++ b/crates/fbuild-build/src/renesas/renesas_compiler.rs
@@ -19,6 +19,8 @@ pub struct RenesasCompiler {
     mcu_config: RenesasMcuConfig,
     profile: BuildProfile,
     temp_dir: PathBuf,
+    /// PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl RenesasCompiler {
@@ -47,7 +49,14 @@ impl RenesasCompiler {
             mcu_config,
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build the common ARM Cortex-M4 compiler flags.
@@ -103,6 +112,10 @@ impl Compiler for RenesasCompiler {
 
     fn cpp_flags(&self) -> Vec<String> {
         crate::compiler::build_cpp_flags(self.common_flags(), &self.mcu_config)
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 }
 

--- a/crates/fbuild-build/src/rp2040/orchestrator.rs
+++ b/crates/fbuild-build/src/rp2040/orchestrator.rs
@@ -156,7 +156,8 @@ impl BuildOrchestrator for Rp2040Orchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 7. Generate the linker script the same way upstream does.
         let linker_script =

--- a/crates/fbuild-build/src/sam/orchestrator.rs
+++ b/crates/fbuild-build/src/sam/orchestrator.rs
@@ -130,7 +130,8 @@ impl BuildOrchestrator for SamOrchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 7. Create linker (resolve linker script from framework variant)
         let mut linker = SamLinker::new(

--- a/crates/fbuild-build/src/sam/sam_compiler.rs
+++ b/crates/fbuild-build/src/sam/sam_compiler.rs
@@ -19,6 +19,8 @@ pub struct SamCompiler {
     mcu_config: SamMcuConfig,
     profile: BuildProfile,
     temp_dir: PathBuf,
+    /// PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl SamCompiler {
@@ -47,7 +49,14 @@ impl SamCompiler {
             mcu_config,
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build the common ARM Cortex-M3 compiler flags.
@@ -103,6 +112,10 @@ impl Compiler for SamCompiler {
 
     fn cpp_flags(&self) -> Vec<String> {
         crate::compiler::build_cpp_flags(self.common_flags(), &self.mcu_config)
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 }
 

--- a/crates/fbuild-build/src/silabs/orchestrator.rs
+++ b/crates/fbuild-build/src/silabs/orchestrator.rs
@@ -99,7 +99,8 @@ impl BuildOrchestrator for SilabsOrchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         let linker_script = stack_dir.join("linkerfile.ld");
         let gsdk = stack_dir.join("gsdk.a");

--- a/crates/fbuild-build/src/silabs/silabs_compiler.rs
+++ b/crates/fbuild-build/src/silabs/silabs_compiler.rs
@@ -19,6 +19,8 @@ pub struct SilabsCompiler {
     mcu_config: SilabsMcuConfig,
     profile: BuildProfile,
     temp_dir: PathBuf,
+    /// PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl SilabsCompiler {
@@ -47,7 +49,14 @@ impl SilabsCompiler {
             mcu_config,
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build the common ARM Cortex-M33 compiler flags.
@@ -103,6 +112,10 @@ impl Compiler for SilabsCompiler {
 
     fn cpp_flags(&self) -> Vec<String> {
         crate::compiler::build_cpp_flags(self.common_flags(), &self.mcu_config)
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 }
 

--- a/crates/fbuild-build/src/stm32/orchestrator.rs
+++ b/crates/fbuild-build/src/stm32/orchestrator.rs
@@ -197,7 +197,8 @@ impl BuildOrchestrator for Stm32Orchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 7. Create linker (linker script from variant dir)
         let linker_script = match ctx.board.ldscript.as_deref() {
@@ -343,7 +344,8 @@ fn build_arduino_mbed_stm32(
         mcu_config.clone(),
         params.profile,
         params.verbose,
-    );
+    )
+    .with_build_unflags(ctx.build_unflags.clone());
 
     let linker = ArmLinker::new(
         toolchain.get_gcc_path(),

--- a/crates/fbuild-build/src/teensy/orchestrator.rs
+++ b/crates/fbuild-build/src/teensy/orchestrator.rs
@@ -99,7 +99,8 @@ impl BuildOrchestrator for TeensyOrchestrator {
             mcu_config.clone(),
             params.profile,
             params.verbose,
-        );
+        )
+        .with_build_unflags(ctx.build_unflags.clone());
 
         // 7. Create linker (with linker script from board config)
         let linker_scripts = match ctx.board.ldscript.as_deref() {

--- a/crates/fbuild-build/src/teensy/teensy_compiler.rs
+++ b/crates/fbuild-build/src/teensy/teensy_compiler.rs
@@ -19,6 +19,9 @@ pub struct TeensyCompiler {
     mcu_config: TeensyMcuConfig,
     profile: BuildProfile,
     temp_dir: PathBuf,
+    /// PlatformIO `build_unflags` to strip from the effective compile
+    /// line. See FastLED/fbuild#37.
+    build_unflags: Vec<String>,
 }
 
 impl TeensyCompiler {
@@ -47,7 +50,15 @@ impl TeensyCompiler {
             mcu_config,
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
+            build_unflags: Vec::new(),
         }
+    }
+
+    /// Attach PlatformIO `build_unflags` to strip from every compile
+    /// command. See FastLED/fbuild#37.
+    pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
+        self.build_unflags = build_unflags;
+        self
     }
 
     /// Build the common ARM Cortex-M7 compiler flags.
@@ -103,6 +114,10 @@ impl Compiler for TeensyCompiler {
 
     fn cpp_flags(&self) -> Vec<String> {
         crate::compiler::build_cpp_flags(self.common_flags(), &self.mcu_config)
+    }
+
+    fn build_unflags(&self) -> &[String] {
+        &self.build_unflags
     }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to PR #63 (ESP32 reference impl). Applies the same one-line builder-pattern wiring to every other platform, so PlatformIO \`build_unflags\` now strips framework/toolchain-contributed flags on:

- AVR
- Teensy
- Generic ARM (STM32, RP2040, Apollo3)
- nRF52, Renesas, Silabs
- CH32V
- SAM
- ESP8266

## Per-compiler changes
Identical shape across 9 compiler files:
- Add \`build_unflags: Vec<String>\` field, initialized empty in constructor
- Add \`with_build_unflags(...)\` builder method
- Override \`Compiler::build_unflags()\` to return \`&self.build_unflags\`

## Per-orchestrator changes
Each orchestrator chains \`.with_build_unflags(ctx.build_unflags.clone())\` on every \`XxxCompiler::new(...)\` site (one per orchestrator; stm32 has two). Default-impl \`compile_c\` / \`compile_cpp\` in the \`Compiler\` trait already filter both platform and \`extra_flags\` through this set when non-empty (added in PR #63), so wiring each platform picks up framework-scope filtering automatically.

## Test plan
- [x] \`uv run cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`uv run cargo test -p fbuild-build --lib\` — 447 passed
- [ ] CI green on Linux / macOS / Windows

Closes the remaining scope of FastLED/fbuild#37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)