### PR TITLE
fix(deploy): esptool v5 non-deprecated argv spellings

### DIFF
--- a/crates/fbuild-build/src/esp32/configs/esp32.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32.json
@@ -145,8 +145,8 @@
     "default_flash_freq": "80m",
     "default_flash_size": "4MB",
     "default_baud": 460800,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/configs/esp32c2.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32c2.json
@@ -139,8 +139,8 @@
     "default_flash_freq": "60m",
     "default_flash_size": "4MB",
     "default_baud": 460800,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/configs/esp32c3.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32c3.json
@@ -138,8 +138,8 @@
     "default_flash_freq": "80m",
     "default_flash_size": "4MB",
     "default_baud": 460800,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/configs/esp32c5.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32c5.json
@@ -145,8 +145,8 @@
     "default_flash_freq": "80m",
     "default_flash_size": "4MB",
     "default_baud": 460800,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/configs/esp32c6.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32c6.json
@@ -146,8 +146,8 @@
     "default_flash_freq": "80m",
     "default_flash_size": "4MB",
     "default_baud": 460800,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/configs/esp32h2.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32h2.json
@@ -139,8 +139,8 @@
     "default_flash_freq": "48m",
     "default_flash_size": "4MB",
     "default_baud": 460800,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/configs/esp32p4.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32p4.json
@@ -143,8 +143,8 @@
     "default_flash_freq": "80m",
     "default_flash_size": "4MB",
     "default_baud": 460800,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/configs/esp32s2.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32s2.json
@@ -140,8 +140,8 @@
     "default_flash_freq": "80m",
     "default_flash_size": "4MB",
     "default_baud": 460800,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/configs/esp32s3.json
+++ b/crates/fbuild-build/src/esp32/configs/esp32s3.json
@@ -146,8 +146,8 @@
     "default_flash_freq": "80m",
     "default_flash_size": "4MB",
     "default_baud": 921600,
-    "before_reset": "default_reset",
-    "after_reset": "hard_reset"
+    "before_reset": "default-reset",
+    "after_reset": "hard-reset"
   },
 
   "defines": [

--- a/crates/fbuild-build/src/esp32/mcu_config.rs
+++ b/crates/fbuild-build/src/esp32/mcu_config.rs
@@ -35,9 +35,9 @@ pub struct EsptoolConfig {
     pub default_flash_size: String,
     /// Default baud rate for flashing.
     pub default_baud: u32,
-    /// Reset mode before flashing (e.g. "default_reset").
+    /// Reset mode before flashing (e.g. "default-reset").
     pub before_reset: String,
-    /// Reset mode after flashing (e.g. "hard_reset").
+    /// Reset mode after flashing (e.g. "hard-reset").
     pub after_reset: String,
 }
 
@@ -153,12 +153,12 @@ impl Esp32McuConfig {
         self.esptool.default_baud
     }
 
-    /// Reset mode before flashing (e.g. "default_reset").
+    /// Reset mode before flashing (e.g. "default-reset").
     pub fn before_reset(&self) -> &str {
         &self.esptool.before_reset
     }
 
-    /// Reset mode after flashing (e.g. "hard_reset").
+    /// Reset mode after flashing (e.g. "hard-reset").
     pub fn after_reset(&self) -> &str {
         &self.esptool.after_reset
     }

--- a/crates/fbuild-deploy/src/esp32.rs
+++ b/crates/fbuild-deploy/src/esp32.rs
@@ -174,7 +174,7 @@ impl Esp32Deployer {
     /// only when esptool itself failed to run (port not found, stub
     /// upload failed, etc.).
     ///
-    /// On success the chip is hard-reset by esptool's `--after hard_reset`,
+    /// On success the chip is hard-reset by esptool's `--after hard-reset`,
     /// matching the post-flash behavior — so callers can treat a `true`
     /// return as "device is now running the requested firmware" without
     /// any extra reset.
@@ -255,7 +255,7 @@ pub struct RegionVerifyResult {
 pub enum VerifyOutcome {
     /// All flashed regions match the candidate image; flashing would be
     /// a no-op. The device has been hard-reset by esptool's
-    /// `--after hard_reset` so it's already running the requested image.
+    /// `--after hard-reset` so it's already running the requested image.
     Match { stdout: String, stderr: String },
     /// At least one region differs from the local files. `regions` carries
     /// the parsed per-region verdict when stdout was understood; empty
@@ -804,7 +804,7 @@ impl Esp32Deployer {
             self.before_reset.clone(),
             "--after".to_string(),
             self.after_reset.clone(),
-            "write_flash".to_string(),
+            "write-flash".to_string(),
             "-z".to_string(),
             "--flash-mode".to_string(),
             self.flash_mode.clone(),
@@ -983,8 +983,8 @@ mod tests {
             flash_mode: "dio".to_string(),
             flash_freq: "80m".to_string(),
             default_baud: "460800".to_string(),
-            before_reset: "default_reset".to_string(),
-            after_reset: "hard_reset".to_string(),
+            before_reset: "default-reset".to_string(),
+            after_reset: "hard-reset".to_string(),
         }
     }
 
@@ -999,7 +999,7 @@ mod tests {
         assert_eq!(deployer.bootloader_offset, "0x0");
         assert_eq!(deployer.firmware_offset, "0x10000");
         assert_eq!(deployer.flash_mode, "dio");
-        assert_eq!(deployer.before_reset, "default_reset");
+        assert_eq!(deployer.before_reset, "default-reset");
     }
 
     #[test]
@@ -1381,7 +1381,7 @@ Verification successful (digest matched).\n";
         );
     }
 
-    /// The selective write-flash argv must include the write_flash
+    /// The selective write-flash argv must include the write-flash
     /// subcommand and only the requested region's offset/file pair.
     /// Skipping bootloader + partitions is the ~1s save targeted by #67.
     #[test]
@@ -1398,7 +1398,7 @@ Verification successful (digest matched).\n";
 
         let args = deployer.build_write_flash_args(&fw, "COM13", Some(&[FlashRegion::Firmware]));
 
-        assert!(args.contains(&"write_flash".to_string()));
+        assert!(args.contains(&"write-flash".to_string()));
         assert!(!args.iter().any(|a| a.ends_with("bootloader.bin")));
         assert!(!args.iter().any(|a| a.ends_with("partitions.bin")));
         assert!(args.contains(&"0x10000".to_string()));
@@ -1427,7 +1427,7 @@ Verification successful (digest matched).\n";
     }
 
     /// If a caller requests a region whose file is missing on disk, fail
-    /// with a clear error rather than silently emitting a write_flash
+    /// with a clear error rather than silently emitting a write-flash
     /// call with no offset/file pair (which would produce an opaque
     /// esptool usage error). Addresses CodeRabbit review on PR #71.
     #[test]
@@ -1553,8 +1553,8 @@ Verification successful (digest matched).\n";
             flash_mode: "dio".to_string(),
             flash_freq: "80m".to_string(),
             default_baud: "921600".to_string(),
-            before_reset: "default_reset".to_string(),
-            after_reset: "hard_reset".to_string(),
+            before_reset: "default-reset".to_string(),
+            after_reset: "hard-reset".to_string(),
         };
         let deployer = Esp32Deployer::new(
             chip,


### PR DESCRIPTION
## Summary

Closes #77.

esptool v5 deprecated the underscored argv tokens used by `fbuild deploy`:

- `write_flash` -> `write-flash`
- `--before default_reset` -> `--before default-reset`
- `--after hard_reset` -> `--after hard-reset`

Running a deploy today emits three deprecation warnings before proceeding. This PR updates the exact argv strings passed to esptool so deploys are warning-free on esptool v5.

## Scope

- `crates/fbuild-deploy/src/esp32.rs`: change the `write_flash` subcommand literal, test-fixture defaults (`before_reset`/`after_reset`), and the matching assertion. Also updated the `/// --after hard_reset` doc-comment literals that describe the effective CLI semantics.
- `crates/fbuild-build/src/esp32/configs/esp32*.json` (9 files): update `before_reset`/`after_reset` values, since they flow directly into the `--before`/`--after` argv passed to esptool.
- `crates/fbuild-build/src/esp32/mcu_config.rs`: update the doc-comment examples to match the new values.

Rust identifiers (`before_reset`, `after_reset` struct fields, `build_write_flash_args` function) are unchanged - this is a pure value/argv rename.

## Test plan

- [x] `./_cargo test -p fbuild-deploy` - 32 passed, 8 ignored (real-hardware tests)
- [x] `./_cargo clippy --workspace --all-targets -- -D warnings` - clean
- [x] `./_cargo fmt --all` - no changes
- [ ] Manual: deploy to an ESP32 with esptool v5 installed and verify no deprecation warnings appear in the flash output.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>