### PR TITLE
docs: split README into decentralized docs (#81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 ![fbuild](https://github.com/user-attachments/assets/7db78eba-b10f-44c7-ae32-7fc0b5e46642)
 
-*A fast, next-generation multi-platform compiler, deployer, and monitor for embedded development, directly compatible with platformio.ini*
+*A fast, next-generation multi-platform compiler, deployer, and monitor for embedded development, directly compatible with `platformio.ini`.*
 
-## Build Status
+## CI status
 
-### CI
 [![Check Ubuntu](https://github.com/fastled/fbuild/actions/workflows/check-ubuntu.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/check-ubuntu.yml)
 [![Check macOS](https://github.com/fastled/fbuild/actions/workflows/check-macos.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/check-macos.yml)
 [![Check Windows](https://github.com/fastled/fbuild/actions/workflows/check-windows.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/check-windows.yml)
@@ -12,159 +11,104 @@
 [![Min Rust Version](https://github.com/fastled/fbuild/actions/workflows/msrv.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/msrv.yml)
 [![Documentation](https://github.com/fastled/fbuild/actions/workflows/docs.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/docs.yml)
 [![Validate Boards](https://github.com/fastled/fbuild/actions/workflows/validate-boards.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/validate-boards.yml)
-
-### Native Binaries
 [![Build Native Binaries](https://github.com/fastled/fbuild/actions/workflows/build.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build.yml)
 
-### AVR
-[![Build Arduino Uno](https://github.com/fastled/fbuild/actions/workflows/build-uno.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-uno.yml)
-[![Build Leonardo](https://github.com/fastled/fbuild/actions/workflows/build-leonardo.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-leonardo.yml)
-[![Build ATmega8A](https://github.com/fastled/fbuild/actions/workflows/build-atmega8a.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-atmega8a.yml)
-[![Build ATtiny85](https://github.com/fastled/fbuild/actions/workflows/build-attiny85.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny85.yml)
-[![Build ATtiny88](https://github.com/fastled/fbuild/actions/workflows/build-attiny88.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny88.yml)
-[![Build ATtiny4313](https://github.com/fastled/fbuild/actions/workflows/build-attiny4313.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny4313.yml)
-
-### MegaAVR
-[![Build ATtiny1604](https://github.com/fastled/fbuild/actions/workflows/build-attiny1604.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny1604.yml)
-[![Build ATtiny1616](https://github.com/fastled/fbuild/actions/workflows/build-attiny1616.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny1616.yml)
-[![Build Nano Every](https://github.com/fastled/fbuild/actions/workflows/build-nano_every.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nano_every.yml)
-
-### Renesas
-[![Build UNO R4 WiFi](https://github.com/fastled/fbuild/actions/workflows/build-uno_r4_wifi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-uno_r4_wifi.yml)
-
-### ESP8266
-[![Build ESP8266](https://github.com/fastled/fbuild/actions/workflows/build-esp8266.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp8266.yml)
-
-### ESP32
-[![Build ESP32 Dev](https://github.com/fastled/fbuild/actions/workflows/build-esp32dev.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32dev.yml)
-[![Build ESP32-C2](https://github.com/fastled/fbuild/actions/workflows/build-esp32c2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c2.yml)
-[![Build ESP32-C3](https://github.com/fastled/fbuild/actions/workflows/build-esp32c3.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c3.yml)
-[![Build ESP32-C5](https://github.com/fastled/fbuild/actions/workflows/build-esp32c5.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c5.yml)
-[![Build ESP32-C6](https://github.com/fastled/fbuild/actions/workflows/build-esp32c6.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c6.yml)
-[![Build ESP32-H2](https://github.com/fastled/fbuild/actions/workflows/build-esp32h2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32h2.yml)
-[![Build ESP32-P4](https://github.com/fastled/fbuild/actions/workflows/build-esp32p4.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32p4.yml)
-[![Build ESP32-S2](https://github.com/fastled/fbuild/actions/workflows/build-esp32s2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32s2.yml)
-[![Build ESP32-S3](https://github.com/fastled/fbuild/actions/workflows/build-esp32s3.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32s3.yml)
-
-### CH32V (RISC-V)
-[![Build CH32V003](https://github.com/fastled/fbuild/actions/workflows/build-ch32v003.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v003.yml)
-[![Build CH32V103](https://github.com/fastled/fbuild/actions/workflows/build-ch32v103.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v103.yml)
-[![Build CH32V203](https://github.com/fastled/fbuild/actions/workflows/build-ch32v203.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v203.yml)
-[![Build CH32V208](https://github.com/fastled/fbuild/actions/workflows/build-ch32v208.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v208.yml)
-[![Build CH32V303](https://github.com/fastled/fbuild/actions/workflows/build-ch32v303.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v303.yml)
-[![Build CH32V307](https://github.com/fastled/fbuild/actions/workflows/build-ch32v307.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v307.yml)
-
-### CH32X (RISC-V, USB PD)
-[![Build CH32X035](https://github.com/fastled/fbuild/actions/workflows/build-ch32x035.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32x035.yml)
-
-### Teensy
-[![Build Teensy 4.1](https://github.com/fastled/fbuild/actions/workflows/build-teensy41.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy41.yml)
-[![Build Teensy 4.0](https://github.com/fastled/fbuild/actions/workflows/build-teensy40.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy40.yml)
-[![Build Teensy 3.6](https://github.com/fastled/fbuild/actions/workflows/build-teensy36.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy36.yml)
-[![Build Teensy 3.5](https://github.com/fastled/fbuild/actions/workflows/build-teensy35.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy35.yml)
-[![Build Teensy 3.2](https://github.com/fastled/fbuild/actions/workflows/build-teensy32.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy32.yml)
-[![Build Teensy 3.1](https://github.com/fastled/fbuild/actions/workflows/build-teensy31.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy31.yml)
-[![Build Teensy 3.0](https://github.com/fastled/fbuild/actions/workflows/build-teensy30.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy30.yml)
-[![Build Teensy LC](https://github.com/fastled/fbuild/actions/workflows/build-teensylc.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensylc.yml)
-
-### STM32
-[![Build STM32F103C8](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103c8.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103c8.yml)
-[![Build STM32F103CB](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103cb.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103cb.yml)
-[![Build STM32F103TB](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103tb.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103tb.yml)
-[![Build STM32F411CE](https://github.com/fastled/fbuild/actions/workflows/build-stm32f411ce.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f411ce.yml)
-[![Build STM32H747XI](https://github.com/fastled/fbuild/actions/workflows/build-stm32h747xi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32h747xi.yml)
-[![Build Nucleo F429ZI](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f429zi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f429zi.yml)
-[![Build Nucleo F439ZI](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f439zi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f439zi.yml)
-[![Build Arduino Giga R1](https://github.com/fastled/fbuild/actions/workflows/build-giga-r1.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-giga-r1.yml)
-
-### SAM / SAMD
-[![Build Arduino Due](https://github.com/fastled/fbuild/actions/workflows/build-sam3x8e_due.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-sam3x8e_due.yml)
-[![Build SAMD21](https://github.com/fastled/fbuild/actions/workflows/build-samd21.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd21.yml)
-[![Build Arduino Zero](https://github.com/fastled/fbuild/actions/workflows/build-samd21_zero.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd21_zero.yml)
-[![Build SAMD51J](https://github.com/fastled/fbuild/actions/workflows/build-samd51j.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd51j.yml)
-[![Build SAMD51P](https://github.com/fastled/fbuild/actions/workflows/build-samd51p.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd51p.yml)
-
-### RP2040 / RP2350
-[![Build RP2040](https://github.com/fastled/fbuild/actions/workflows/build-rp2040.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rp2040.yml)
-[![Build RP2350](https://github.com/fastled/fbuild/actions/workflows/build-rp2350.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rp2350.yml)
-
-### Nordic NRF52
-[![Build nRF52840 DK](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml)
-
-### Apollo3
-[![Build Apollo3 RedBoard](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml)
-[![Build Apollo3 expLoRaBLE](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml)
-
-### Silicon Labs
-[![Build MGM240](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml)
-
-### NRF52
-[![Build Adafruit Feather NRF52840 Sense](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840-sense.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840-sense.yml)
-[![Build NRF52840 DK](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml)
-
-### Raspberry Pi Pico
-[![Build Raspberry Pi Pico](https://github.com/fastled/fbuild/actions/workflows/build-rpipico.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rpipico.yml)
-[![Build Raspberry Pi Pico 2](https://github.com/fastled/fbuild/actions/workflows/build-rpipico2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rpipico2.yml)
-
-### Silicon Labs
-[![Build SparkFun Thing Plus Matter](https://github.com/fastled/fbuild/actions/workflows/build-thingplusmatter.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-thingplusmatter.yml)
+Per-platform board build badges live in [`docs/BOARD_STATUS.md`](docs/BOARD_STATUS.md).
 
 # fbuild
 
-`fbuild` is a next-generation embedded development tool featuring a clean extensible data driven architecture. It provides fast incremental builds, URL-based package management, and soon to be comprehensive multi-platform support for Arduino and ESP32 development.
+`fbuild` is a next-generation embedded development tool featuring a clean, extensible, data-driven architecture. It provides fast incremental builds, URL-based package management, and comprehensive multi-platform support for Arduino and ESP32 development.
 
-**platformio.ini compatible**
+**`platformio.ini` compatible** — fbuild uses the same `platformio.ini` already used in your PlatformIO sketches.
 
-fbuild uses the same `platformio.ini` already used in platformio sketches.
+**Current status**: v2.0.6 — Rust rewrite. Full ESP32 / Teensy support with a working build system.
 
+## Docs index
 
+For a full FAQ-style map of every doc in this repo, see [`docs/INDEX.md`](docs/INDEX.md). Common entry points:
 
-**TODO: firmware.bin size comparisons between Arduino/PlatformIO vs fbuild**
+- **Why fbuild exists, key benefits, performance** → [`docs/WHY.md`](docs/WHY.md)
+- **Is my board supported?** → [`docs/BOARD_STATUS.md`](docs/BOARD_STATUS.md)
+- **Architecture / daemon / serial internals** → [`docs/architecture/`](docs/architecture/) (start at [`overview.md`](docs/architecture/overview.md))
+- **Crate dependency graph** → [`crates/CLAUDE.md`](crates/CLAUDE.md)
+- **Testing, troubleshooting, local setup** → [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
+- **Design decisions (ADRs)** → [`docs/DESIGN_DECISIONS.md`](docs/DESIGN_DECISIONS.md)
+- **Implementation roadmap** → [`docs/ROADMAP.md`](docs/ROADMAP.md)
 
-**TODO: Add integration with [velxio](https://github.com/davidmonterocrespo24/velxio)**
+## Installation
 
-**Design Goals**
+```bash
+# Install from PyPI
+pip install fbuild
 
-  * Replaces `platformio` in `FastLED` repo builders
-  * Correct and blazing parallel package management system
-    * locking is done through a daemon process
-    * packages are fingerprinted to their version and cached, download only once
-    * zccache for caching compiles
-  * Easily add features via AI
-    * This codebase is designed and implemented by AI, just fork it and ask ai to make your change Please send us a PR!
-  * Supports new build chains easily
-  * Supports wasm builds natively
-    
-**Current Status**: v2.0.6 - Rust rewrite. Full ESP32 / Teensy support with working build system
+# Or install from source
+git clone https://github.com/fastled/fbuild.git
+cd fbuild
+pip install -e .
+```
+
+## Quick Start
+
+### Build an Arduino Uno project
+
+1. **Create project structure**:
+   ```bash
+   mkdir my-project && cd my-project
+   mkdir src
+   ```
+
+2. **Create `platformio.ini`**:
+   ```ini
+   [env:uno]
+   platform = atmelavr
+   board = uno
+   framework = arduino
+   ```
+
+3. **Write your sketch** (`src/main.ino`):
+   ```cpp
+   void setup() {
+     pinMode(LED_BUILTIN, OUTPUT);
+   }
+
+   void loop() {
+     digitalWrite(LED_BUILTIN, HIGH);
+     delay(1000);
+     digitalWrite(LED_BUILTIN, LOW);
+     delay(1000);
+   }
+   ```
+
+4. **Build**:
+   ```bash
+   fbuild build
+   ```
+
+On first build, fbuild will download the AVR-GCC toolchain (~50MB, one-time), download the Arduino AVR core (~5MB, one-time), compile your sketch, and emit `firmware.hex` under `.fbuild/build/uno/`.
+
+**Build time**: ~19s first build, ~3s subsequent builds, <1s incremental.
 
 ## Examples
 
-**Quick start** - Build, deploy, and monitor in one command:
-
-```bash
-# install
-pip install fbuild
-```
+Build, deploy, and monitor in one command:
 
 ```bash
 # Default action: build + deploy
 fbuild tests/platform/esp32c6
-```
 
-```bash
 # Default action: build + deploy + monitor
 fbuild tests/platform/esp32c6 --monitor
 ```
 
-
-**Deploy commands:**
+**Deploy commands**:
 
 ```bash
 # Deploy with clean build
 fbuild deploy tests/platform/esp32c6 --clean
 
 # Deploy with monitoring and test patterns
-fbuild deploy tests/platform/esp32c6 --monitor="--timeout 60 --halt-on-error \"TEST FAILED\" --halt-on-success \"TEST PASSED\""
+fbuild deploy tests/platform/esp32c6 \
+  --monitor="--timeout 60 --halt-on-error \"TEST FAILED\" --halt-on-success \"TEST PASSED\""
 
 # Deploy to the default emulator backend
 fbuild deploy tests/platform/uno -e uno --to emu
@@ -179,7 +123,7 @@ fbuild deploy tests/platform/esp32s3 -e esp32s3 --to emu --monitor --timeout 10 
 fbuild deploy tests/platform/esp32s3 -e esp32s3 --to emu --emulator qemu --monitor --timeout 10
 ```
 
-**Test-emu command** -- build + run in emulator in one step:
+**`test-emu`** — build + run in emulator in one step (CI-friendly, exits with emulator exit code):
 
 ```bash
 # Auto-detect emulator backend from the board
@@ -192,10 +136,9 @@ fbuild test-emu tests/platform/esp32s3 -e esp32s3 --emulator qemu --timeout 10
 fbuild test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
 
 # Halt on first test result
-fbuild test-emu tests/platform/uno -e uno --halt-on-success "TEST PASSED" --halt-on-error "TEST FAILED"
+fbuild test-emu tests/platform/uno -e uno \
+  --halt-on-success "TEST PASSED" --halt-on-error "TEST FAILED"
 ```
-
-`test-emu` builds the firmware, selects the right emulator backend, and runs the firmware to completion (or until a halt/timeout pattern matches). The exit code reflects the emulator outcome.
 
 | Option | Description |
 |--------|-------------|
@@ -207,26 +150,25 @@ fbuild test-emu tests/platform/uno -e uno --halt-on-success "TEST PASSED" --halt
 | `--no-timestamp` | Disable timestamp prefix on output lines |
 | `-v, --verbose` | Show emulator command and build details |
 
-**Monitor command:**
+**Monitor command**:
 
 ```bash
 # Monitor serial output with pattern matching
 fbuild monitor --timeout 60 --halt-on-error "TEST FAILED" --halt-on-success "TEST PASSED"
 ```
 
-  * Serial monitoring requires pyserial to attach to the USB device
-  * Port auto-detection works similarly to PlatformIO
+Serial monitoring requires pyserial to attach to the USB device. Port auto-detection works similarly to PlatformIO.
 
-## Emulator Testing
+## Emulator testing
 
 fbuild can build and run firmware in emulators without physical hardware. Two entry points:
 
-- **`fbuild test-emu`** -- one-shot build + emulate + exit (CI-friendly)
-- **`fbuild deploy --to emu`** -- deploy flow with optional `--monitor`
+- **`fbuild test-emu`** — one-shot build + emulate + exit (CI-friendly)
+- **`fbuild deploy --to emu`** — deploy flow with optional `--monitor`
 
 Both auto-detect the emulator backend from the board, or accept `--emulator <backend>`.
 
-### Emulator Backends
+### Emulator backends
 
 | Backend | Platforms | MCUs | Requirements |
 |---------|-----------|------|--------------|
@@ -240,45 +182,9 @@ Auto-detection rules when `--emulator` is omitted:
 - Other AVR MCUs with `simavr` in `debug_tools` default to **simavr**
 - ESP32 / ESP32-S3 default to **qemu**
 
-### test-emu (recommended for CI)
-
-```bash
-# Auto-detect backend from the board
-fbuild test-emu tests/platform/uno -e uno
-
-# ESP32-S3 with QEMU
-fbuild test-emu tests/platform/esp32s3 -e esp32s3 --timeout 10
-
-# Explicit simavr for ATmega2560
-fbuild test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
-
-# Pattern matching: halt on first pass/fail
-fbuild test-emu tests/platform/uno -e uno \
-  --halt-on-success "TEST PASSED" \
-  --halt-on-error "TEST FAILED" \
-  --timeout 30
-```
-
-The exit code is the emulator process exit code (0 on pass, non-zero on fail/crash/timeout), so `test-emu` integrates directly into CI scripts.
-
-### deploy --to emu
-
-```bash
-fbuild deploy <project> --to emu
-fbuild deploy <project> --to emu --monitor
-fbuild deploy <project> --to emu --emulator qemu
-```
-
-Compatibility aliases:
-
-- `--qemu` remains accepted as a legacy alias
-- older `--target ...` emulator syntax remains accepted for compatibility
-
-### QEMU Configuration
+### QEMU notes
 
 ESP32-S3 QEMU runs from a normal ESP32-S3 Arduino environment. fbuild adds the required QEMU build flags automatically when deploying to `--to emu`.
-
-Example:
 
 ```ini
 [env:esp32s3]
@@ -291,104 +197,24 @@ board_upload.flash_mode = dio
 
 QEMU requires DIO flash mode. Boards configured with `qio` or `qout` will fail fast before building.
 
-### QEMU Requirements
+QEMU runtime is native-only. Supported hosts: Linux x86_64/arm64, macOS x86_64/arm64, Windows x86_64. On Windows, fbuild stages the required QEMU runtime DLLs for the managed install.
 
-- Native Espressif Xtensa QEMU runtime available on the host
-- Supported host platforms:
-  - Linux `x86_64` / `arm64`
-  - macOS `x86_64` / `arm64`
-  - Windows `x86_64`
-- On Windows, fbuild stages the required QEMU runtime DLLs for the managed install
+**Known limitations**:
 
-QEMU is native-only here. Unsupported hosts fail explicitly; Docker is not the fallback path.
-
-### Known Limitations
-
-1. **ESP32 QEMU**: Currently supports ESP32 and ESP32-S3 only. ESP32-C3/C6/S2 are not supported by upstream QEMU.
-
+1. **ESP32 QEMU** currently supports ESP32 and ESP32-S3 only. ESP32-C3/C6/S2 are not supported by upstream QEMU.
 2. **QEMU-specific firmware patching**: fbuild patches the generated ESP32-S3 app image for QEMU to bypass an ADC calibration constructor that hangs under emulation, then repairs the image checksum and hash.
-
 3. **Performance**: QEMU emulation is slower than real hardware. Use it for functional validation, not timing-sensitive behavior.
-
 4. **Peripheral coverage**: Not all peripherals are fully emulated. Real hardware is still required for production validation.
-
-## Key Features
-
-- **URL-based Package Management**: Direct URLs to toolchains and platforms - no hidden registries
-- **Library Management**: Download and compile Arduino libraries from GitHub URLs
-- **Fast Incremental Builds**: 0.76s rebuilds, 3s full builds (cached)
-- **LTO Support**: Link-Time Optimization for optimal code size
-- **Transparent Architecture**: Know exactly what's happening at every step
-- **Real Downloads, No Mocks**: All packages are real, validated, and checksummed
-- **Cross-platform Support**: Windows, macOS, and Linux
-- **Modern Python**: 100% type-safe, PEP 8 compliant, tested
-
-## Installation
-
-```bash
-# Install from PyPI (when published)
-pip install fbuild
-
-# Or install from source
-git clone https://github.com/yourusername/fbuild.git
-cd fbuild
-pip install -e .
-```
-
-## Quick Start
-
-### Building an Arduino Uno Project
-
-1. **Create project structure**:
-```bash
-mkdir my-project && cd my-project
-mkdir src
-```
-
-2. **Create platformio.ini**:
-```ini
-[env:uno]
-platform = atmelavr
-board = uno
-framework = arduino
-```
-
-3. **Write your sketch** (`src/main.ino`):
-```cpp
-void setup() {
-  pinMode(LED_BUILTIN, OUTPUT);
-}
-
-void loop() {
-  digitalWrite(LED_BUILTIN, HIGH);
-  delay(1000);
-  digitalWrite(LED_BUILTIN, LOW);
-  delay(1000);
-}
-```
-
-4. **Build**:
-```bash
-fbuild build
-```
-
-On first build, Fbuild will:
-- Download AVR-GCC toolchain (50MB, one-time)
-- Download Arduino AVR core (5MB, one-time)
-- Compile your sketch
-- Generate `firmware.hex` in `.fbuild/build/uno/`
-
-**Build time**: ~19s first build, ~3s subsequent builds, <1s incremental
 
 ## CLI Usage
 
-### Build Command
+### Build
 
 ```bash
 # Build with auto-detected environment
 fbuild build
 
-# Build specific environment
+# Build a specific environment
 fbuild build --environment uno
 fbuild build -e mega
 
@@ -398,11 +224,11 @@ fbuild build --clean
 # Verbose output (shows all compiler commands)
 fbuild build --verbose
 
-# Build in different directory
+# Build in a different directory
 fbuild build --project-dir /path/to/project
 ```
 
-### Output
+Typical output:
 
 ```
 Building environment: uno
@@ -426,9 +252,10 @@ Build time: 3.06s
 
 ## Configuration
 
-### platformio.ini Reference
+### `platformio.ini` summary
 
 **Minimal configuration**:
+
 ```ini
 [env:uno]
 platform = atmelavr
@@ -436,7 +263,8 @@ board = uno
 framework = arduino
 ```
 
-**Full configuration**:
+**Fuller configuration**:
+
 ```ini
 [platformio]
 default_envs = uno
@@ -445,8 +273,8 @@ default_envs = uno
 platform = atmelavr
 board = uno
 framework = arduino
-upload_port = COM3        # Future: for uploading
-monitor_speed = 9600      # Future: for serial monitor
+upload_port = COM3
+monitor_speed = 9600
 build_flags =
     -DDEBUG
     -DLED_PIN=13
@@ -455,9 +283,9 @@ lib_deps =
     https://github.com/adafruit/Adafruit_NeoPixel
 ```
 
-### Library Dependencies
+### Library dependencies
 
-Fbuild supports downloading and compiling Arduino libraries directly from GitHub URLs:
+fbuild supports downloading and compiling Arduino libraries directly from GitHub URLs:
 
 ```ini
 [env:uno]
@@ -468,734 +296,66 @@ lib_deps =
     https://github.com/FastLED/FastLED
 ```
 
-**Features**:
+Features:
+
 - Automatic GitHub URL optimization (converts repo URLs to zip downloads)
 - Automatic branch detection (main vs master)
 - Proper Arduino library structure handling
 - LTO (Link-Time Optimization) for optimal code size
 - Support for complex libraries with assembly optimizations
 
-**Example build with FastLED**:
-```
-✓ Build successful!
-Firmware: tests/platform/uno/.fbuild/build/uno/firmware.hex
-Size: 12KB (4318 bytes program, 3689 bytes RAM)
-Build time: 78.59 seconds
-```
+## Key features
 
+- **URL-based package management** — direct URLs to toolchains and platforms, no hidden registries
+- **Library management** — download and compile Arduino libraries from GitHub URLs
+- **Fast incremental builds** — 0.76s rebuilds, 3s full builds (cached)
+- **LTO support** — Link-Time Optimization for optimal code size
+- **Transparent architecture** — know exactly what's happening at every step
+- **Real downloads, no mocks** — all packages are real, validated, and checksummed
+- **Cross-platform** — Windows, macOS, and Linux
+- **`platformio.ini` compatible** — drop-in replacement for PlatformIO builds
 
-### Supported Platforms and Boards
+See [`docs/WHY.md`](docs/WHY.md) for the full rationale, benefits, and performance benchmarks.
 
-**Arduino AVR Platform** - Fully Supported ✓
-- **Arduino Uno** (atmega328p, 16MHz) - Fully tested ✓
-- **Arduino Leonardo** (atmega32u4, 16MHz) - Supported ✓
-- **ATmega8A** (atmega8a, 16MHz) - Supported ✓
-- **ATtiny85** - Supported ✓
-- **ATtiny88** - Supported ✓
-- **ATtiny4313** - Supported ✓
+## Supported platforms
 
-<details>
-<summary><strong>About the AVR Family</strong></summary>
+fbuild supports AVR, MegaAVR, Renesas RA, ESP8266, ESP32 (all variants incl. S2/S3/C2/C3/C5/C6/H2/P4), CH32V/CH32X RISC-V, Teensy (LC–4.1), STM32, Atmel SAM/SAMD, RP2040/RP2350, Nordic NRF52, Apollo3, Silicon Labs EFR32, and WASM via Emscripten.
 
-The Atmel AVR family is the 8-bit microcontroller architecture that launched the Arduino revolution. Originally designed by Atmel (now Microchip Technology) in 1996, these chips became the backbone of the maker movement when Arduino adopted the ATmega328P for the Arduino Uno in 2010. AVR microcontrollers are known for their simplicity, extensive community support, and massive library ecosystem. They remain the go-to choice for learning embedded development, simple I/O projects, and LED control.
+For the live per-platform CI badge matrix, per-board status, and family deep-dives, see [`docs/BOARD_STATUS.md`](docs/BOARD_STATUS.md).
 
-| Feature | ATmega328P (Uno) | ATmega32U4 (Leonardo) |
-|---|---|---|
-| Architecture | 8-bit AVR | 8-bit AVR |
-| Clock Speed | 16 MHz | 16 MHz |
-| Flash Memory | 32 KB | 32 KB |
-| SRAM | 2 KB | 2.5 KB |
-| EEPROM | 1 KB | 1 KB |
-| Digital I/O Pins | 14 | 20 |
-| Analog Inputs | 6 | 12 |
-| Native USB | No | Yes |
-| Operating Voltage | 5V | 5V |
-| Release Year | ~2008 (Uno: 2010) | ~2012 |
-| Typical Cost | ~$3–5 | ~$4–6 |
+## Project structure
 
-**Best for**: Beginner projects, LED control, basic sensor reading, learning embedded development, prototyping simple circuits.
+The repo is a Rust workspace. For the full crate dependency graph and per-crate responsibilities, see [`crates/CLAUDE.md`](crates/CLAUDE.md).
 
-</details>
-
-**ESP8266 Platform** - Supported ✓
-- **ESP8266** (esp8266) - Supported ✓
-
-<details>
-<summary><strong>About the ESP8266 Family</strong></summary>
-
-The ESP8266 was a game-changer when Espressif Systems released it in 2014. Originally marketed as a cheap WiFi-to-serial bridge (~$2), the community quickly discovered its full potential as a standalone WiFi-capable microcontroller. It single-handedly kicked off the affordable IoT revolution, making WiFi connectivity accessible for hobbyist and commercial projects alike. While largely superseded by the ESP32 family, the ESP8266 remains popular for simple WiFi applications due to its low cost and mature ecosystem.
-
-| Feature | ESP8266 |
-|---|---|
-| Architecture | 32-bit Tensilica Xtensa LX106 |
-| Clock Speed | 80 MHz (160 MHz boost) |
-| Flash Memory | 4 MB (typical) |
-| SRAM | 80 KB (user-accessible) |
-| WiFi | 802.11 b/g/n (2.4 GHz) |
-| Bluetooth | No |
-| GPIO Pins | 17 (limited usable) |
-| ADC | 1 (10-bit) |
-| Operating Voltage | 3.3V |
-| Release Year | 2014 |
-| Typical Cost | ~$1–3 |
-
-**Best for**: Simple IoT sensors, WiFi-connected projects, home automation nodes, weather stations, cost-sensitive WiFi applications.
-
-</details>
-
-**ESP32 Platform** - Supported ✓
-- **ESP32 Dev** (esp32dev) - Supported ✓
-- **ESP32-S2** - Supported ✓
-- **ESP32-S3** (esp32-s3-devkitc-1) - Supported ✓
-- **ESP32-C2** - Supported ✓ (v0.1.0+)
-- **ESP32-C3** (esp32-c3-devkitm-1) - Supported ✓
-- **ESP32-C5** - Supported ✓
-- **ESP32-C6** (esp32c6-devkit) - Supported ✓
-- **ESP32-H2** - Supported ✓
-- **ESP32-P4** - Supported ✓
-
-<details>
-<summary><strong>About the ESP32 Family</strong></summary>
-
-The ESP32 is Espressif Systems' flagship family of wireless SoCs and the dominant platform for IoT development. The original ESP32 launched in 2016 as the successor to the ESP8266, adding dual-core processing, Bluetooth, and significantly more memory. Since then, Espressif has expanded the family with specialized variants: the S-series for AI and USB, the C-series using RISC-V cores for cost optimization and WiFi 6, the H-series for Thread/Zigbee mesh networking, and the P-series for high-performance edge computing. Together they cover everything from $0.50 disposable sensors to multimedia edge devices.
-
-| Feature | ESP32 | ESP32-S2 | ESP32-S3 | ESP32-C2 | ESP32-C3 | ESP32-C5 | ESP32-C6 | ESP32-H2 | ESP32-P4 |
-|---|---|---|---|---|---|---|---|---|---|
-| Architecture | Xtensa LX6 | Xtensa LX7 | Xtensa LX7 | RISC-V | RISC-V | RISC-V | RISC-V | RISC-V | RISC-V |
-| Cores | 2 | 1 | 2 | 1 | 1 | 1 | 1 | 1 | 2 |
-| Clock (MHz) | 240 | 240 | 240 | 120 | 160 | 240 | 160 | 96 | 400 |
-| SRAM | 520 KB | 320 KB | 512 KB | 272 KB | 400 KB | 400 KB | 512 KB | 320 KB | 768 KB |
-| Flash (typical) | 4 MB | 4 MB | 8 MB | 4 MB | 4 MB | 4 MB | 4 MB | 4 MB | 16 MB |
-| WiFi | 2.4 GHz | 2.4 GHz | 2.4 GHz | 2.4 GHz | 2.4 GHz | 2.4+5 GHz (WiFi 6) | 2.4 GHz (WiFi 6) | No | No |
-| Bluetooth | BT 4.2 + BLE | No | BLE 5.0 | BLE 5.0 | BLE 5.0 | BLE 5.0 | BLE 5.0 | BLE 5.0 | No |
-| 802.15.4 (Thread/Zigbee) | No | No | No | No | No | Yes | Yes | Yes | No |
-| USB OTG | No | Yes | Yes | No | No | No | No | No | Yes |
-| AI Acceleration | No | No | Yes (vector) | No | No | No | No | No | Yes |
-| Release Year | 2016 | 2020 | 2021 | 2022 | 2021 | 2024 | 2023 | 2023 | 2024 |
-| Typical Cost | ~$2–4 | ~$2–3 | ~$3–5 | ~$0.50–1 | ~$1–2 | ~$2–3 | ~$2–3 | ~$2–3 | ~$5–8 |
-
-**Best for**:
-- **ESP32**: General IoT, WiFi+BT projects, audio, displays
-- **ESP32-S2/S3**: USB devices, camera/display applications, AI at the edge (S3)
-- **ESP32-C2/C3**: Cost-optimized IoT, simple WiFi/BLE sensors, high-volume products
-- **ESP32-C5/C6**: WiFi 6, smart home with Thread/Zigbee/Matter support
-- **ESP32-H2**: Thread/Zigbee mesh networking, Matter border routers, low-power sensors
-- **ESP32-P4**: High-performance edge computing, multimedia, display-intensive applications
-
-</details>
-
-**CH32V (RISC-V) Platform** - Supported ✓
-- **CH32V003** - Supported ✓
-
-<details>
-<summary><strong>About the CH32V Family</strong></summary>
-
-The CH32V series from WCH (Nanjing Qinheng Microelectronics) represents the new wave of ultra-low-cost RISC-V microcontrollers from China. The CH32V003, launched around 2022–2023, made headlines as a ~$0.10 microcontroller that could genuinely replace legacy 8-bit chips like the ATtiny in cost-sensitive designs. Running a 32-bit RISC-V core at 48 MHz with more memory than an ATtiny, the CH32V003 offers modern 32-bit capabilities at 8-bit prices. WCH's broader CH32V lineup spans from the tiny V003 up to the V307 with Ethernet and USB, positioning the family as a serious alternative for everything from disposable sensors to industrial control.
-
-| Feature | CH32V003 |
-|---|---|
-| Architecture | 32-bit RISC-V (RV32EC) |
-| Clock Speed | 48 MHz |
-| Flash Memory | 16 KB |
-| SRAM | 2 KB |
-| GPIO Pins | 18 |
-| ADC | 8 channels (10-bit) |
-| UART | 1 |
-| SPI | 1 |
-| I2C | 1 |
-| Timers | 2 |
-| Operating Voltage | 3.3V / 5V tolerant |
-| Package Options | SOP-8, SOP-16, QFN-20 |
-| Release Year | 2022–2023 |
-| Typical Cost | ~$0.10–0.20 |
-
-**Best for**: Ultra-low-cost applications, replacing ATtiny/PIC in production, high-volume consumer electronics, disposable/embedded sensors, cost-sensitive LED drivers.
-
-</details>
-
-**Teensy Platform** - Supported ✓
-- **Teensy 4.1** - Supported ✓
-- **Teensy 4.0** - Supported ✓
-- **Teensy 3.6** - Supported ✓
-- **Teensy 3.5** - Supported ✓
-- **Teensy 3.2** - Supported ✓
-- **Teensy 3.1** - Supported ✓
-- **Teensy 3.0** - Supported ✓
-- **Teensy LC** - Supported ✓
-
-<details>
-<summary><strong>About the Teensy Family</strong></summary>
-
-Teensy is a family of high-performance ARM-based development boards created by PJRC (Paul Stoffregen). Since 2011, Teensy boards have been the go-to choice for projects requiring serious processing power in a small form factor, particularly in audio, USB, and real-time applications. The Teensy 4.x series, powered by the NXP i.MX RT1062 Cortex-M7 at 600 MHz, was the fastest Arduino-compatible microcontroller board when it launched in 2019. Teensy is known for its exceptional audio library, mature USB stack (supporting MIDI, serial, HID, and more simultaneously), and robust real-time performance.
-
-| Feature | Teensy LC | Teensy 3.6 | Teensy 4.0 | Teensy 4.1 |
-|---|---|---|---|---|
-| Architecture | ARM Cortex-M0+ | ARM Cortex-M4F | ARM Cortex-M7 | ARM Cortex-M7 |
-| Clock Speed | 48 MHz | 180 MHz | 600 MHz | 600 MHz |
-| Flash Memory | 62 KB | 1 MB | 2 MB | 8 MB |
-| SRAM | 8 KB | 256 KB | 1 MB | 1 MB |
-| FPU | No | Single-precision | Double-precision | Double-precision |
-| USB | USB 2.0 | USB 2.0 High Speed | USB 2.0 High Speed | USB 2.0 High Speed |
-| Ethernet | No | No | No | Yes (10/100) |
-| SD Card | No | Built-in SDIO | No | Built-in SDIO |
-| Audio | I2S | I2S + DAC | I2S + S/PDIF | I2S + S/PDIF |
-| Digital I/O | 27 | 62 | 40 | 55 |
-| Analog Inputs | 13 | 25 | 14 | 18 |
-| Operating Voltage | 3.3V | 3.3V | 3.3V | 3.3V |
-| Release Year | 2015 | 2016 | 2019 | 2020 |
-| Typical Cost | ~$12 | ~$30 | ~$24 | ~$32 |
-
-**Best for**: Audio synthesis and processing, USB MIDI controllers, real-time data acquisition, LED installations requiring high frame rates, flight controllers, robotics, any project demanding maximum processing power with Arduino compatibility.
-
-</details>
-
-**WASM / WebAssembly Platform** - Supported ✓
-- Compiles Arduino/FastLED sketches to WebAssembly via Emscripten (`clang-tool-chain-emcc`)
-- Outputs `firmware.js` + `firmware.wasm`
-- Library dependencies from `lib_deps` compiled and linked automatically
-
-<details>
-<summary><strong>About the WASM Platform</strong></summary>
-
-WebAssembly (WASM) is not a physical microcontroller but a compilation target that allows Arduino/FastLED sketches to run in web browsers or server-side runtimes. fbuild uses Emscripten's Clang-based toolchain to cross-compile C/C++ Arduino code into portable `.wasm` binaries. This enables browser-based simulation, testing without hardware, and web-based LED visualizers. FastLED uses this extensively for its web-based examples and testing infrastructure.
-
-| Feature | WASM (Emscripten) |
-|---|---|
-| Architecture | Stack-based virtual machine |
-| Runtime | Browser (V8, SpiderMonkey, etc.) or Node.js |
-| Compiler | Clang via Emscripten |
-| Output | `firmware.js` + `firmware.wasm` |
-| Hardware Access | None (simulated) |
-| Debugging | Browser DevTools |
-| Performance | Near-native speed in browser |
-| Use Case | Simulation, testing, web demos |
-
-**Best for**: Browser-based LED simulators, testing without physical hardware, web demos, CI/CD firmware validation, interactive documentation.
-
-</details>
-
-**MegaAVR Platform** - Supported ✓
-- **ATtiny1604** - Supported ✓
-- **ATtiny1616** - Supported ✓
-- **Arduino Nano Every** (ATmega4809) - Supported ✓
-
-<details>
-<summary><strong>About the MegaAVR Family</strong></summary>
-
-The MegaAVR (also called AVR Dx / tinyAVR 1-series) is Microchip's modernized AVR architecture. These chips retain the familiar AVR instruction set but add improved peripherals, configurable custom logic (CCL), an event system for peripheral-to-peripheral communication without CPU involvement, and a more flexible clock system. The ATtiny1604/1616 replace older ATtiny chips with more flash, SRAM, and peripherals at similar price points. The ATmega4809 powers the Arduino Nano Every, providing a drop-in upgrade path from the classic Nano.
-
-| Feature | ATtiny1604 | ATtiny1616 | ATmega4809 (Nano Every) |
-|---|---|---|---|
-| Architecture | 8-bit AVR (tinyAVR 1-series) | 8-bit AVR (tinyAVR 1-series) | 8-bit MegaAVR 0-series |
-| Clock Speed | 20 MHz | 20 MHz | 20 MHz |
-| Flash Memory | 16 KB | 16 KB | 48 KB |
-| SRAM | 1 KB | 2 KB | 6 KB |
-| EEPROM | 256 B | 256 B | 256 B |
-| GPIO Pins | 12 | 18 | 33 |
-| ADC | 10-bit, 8 channels | 10-bit, 12 channels | 10-bit, 8 channels |
-| Event System | Yes | Yes | Yes |
-| CCL (Custom Logic) | Yes | Yes | Yes |
-| Operating Voltage | 1.8–5.5V | 1.8–5.5V | 1.8–5.5V |
-| Release Year | ~2018 | ~2018 | ~2019 |
-| Typical Cost | ~$0.50–1 | ~$0.60–1 | ~$3–5 (on Nano Every) |
-
-**Best for**: Modern replacements for classic ATtiny/ATmega projects, low-power sensing, cost-sensitive designs needing more peripherals than classic AVR.
-
-</details>
-
-**Renesas RA Platform** - Supported ✓
-- **Arduino UNO R4 WiFi** (RA4M1) - Supported ✓
-
-<details>
-<summary><strong>About the Renesas RA Family</strong></summary>
-
-The Arduino UNO R4 WiFi is Arduino's first board based on a Renesas RA4M1 (ARM Cortex-M4) processor, replacing the classic ATmega328P. Released in 2023, it represents Arduino's move into 32-bit territory for their flagship UNO form factor. The R4 WiFi adds an ESP32-S3 module for WiFi/BLE connectivity and includes a 12x8 LED matrix on-board. It maintains the classic UNO shield-compatible form factor while delivering significantly more processing power and memory.
-
-| Feature | UNO R4 WiFi |
-|---|---|
-| Architecture | ARM Cortex-M4 (Renesas RA4M1) |
-| Clock Speed | 48 MHz |
-| Flash Memory | 256 KB |
-| SRAM | 32 KB |
-| WiFi | 802.11 b/g/n (via ESP32-S3) |
-| Bluetooth | BLE 5.0 (via ESP32-S3) |
-| USB | USB-C (native USB) |
-| LED Matrix | 12x8 on-board |
-| Operating Voltage | 5V |
-| Release Year | 2023 |
-| Typical Cost | ~$28 |
-
-**Best for**: Upgrading classic UNO projects to 32-bit, WiFi-enabled Arduino projects, educational use with the on-board LED matrix.
-
-</details>
-
-**STM32 Platform** - Supported ✓
-- **STM32F103C8** (Blue Pill) - Supported ✓
-- **STM32F103CB** (Maple Mini) - Supported ✓
-- **STM32F103TB** (HY TinySTM103T) - Supported ✓
-- **STM32F411CE** (Black Pill) - Supported ✓
-- **STM32H747XI** (Arduino GIGA R1) - Supported ✓
-- **Nucleo F429ZI** - Supported ✓
-- **Nucleo F439ZI** - Supported ✓
-
-<details>
-<summary><strong>About the STM32 Family</strong></summary>
-
-STM32 is STMicroelectronics' extensive family of ARM Cortex-M microcontrollers, widely used in industrial, automotive, and consumer applications. The family spans from ultra-low-power Cortex-M0 to high-performance dual-core Cortex-M7+M4 devices. The "Blue Pill" (STM32F103C8) became the gateway drug for many makers transitioning from Arduino to 32-bit ARM, offering 72 MHz Cortex-M3 performance for under $2. The STM32H7 series represents the high end, with the dual-core H747 powering Arduino's GIGA R1 WiFi board.
-
-| Feature | STM32F103 (Blue Pill) | STM32F411CE (Black Pill) | STM32H747XI (GIGA R1) | Nucleo F429ZI |
-|---|---|---|---|---|
-| Architecture | Cortex-M3 | Cortex-M4F | Cortex-M7 + M4 | Cortex-M4F |
-| Clock Speed | 72 MHz | 100 MHz | 480 + 240 MHz | 180 MHz |
-| Flash Memory | 64–128 KB | 512 KB | 2 MB | 2 MB |
-| SRAM | 20 KB | 128 KB | 1 MB | 256 KB |
-| FPU | No | Single-precision | Double-precision | Single-precision |
-| USB | USB 2.0 FS | USB 2.0 FS | USB 2.0 HS | USB 2.0 FS/HS |
-| Ethernet | No | No | Yes | Yes |
-| Camera Interface | No | No | Yes (DCMI) | Yes (DCMI) |
-| Release Year | ~2007 | ~2019 | ~2022 | ~2014 |
-| Typical Cost | ~$1–2 | ~$3–5 | ~$60 (on GIGA R1) | ~$25 |
-
-**Best for**: Industrial control, motor driving, USB devices, high-performance embedded applications, prototyping with the Nucleo ecosystem.
-
-</details>
-
-**Atmel SAM / SAMD Platform** - Supported ✓
-- **Arduino Due** (SAM3X8E) - Supported ✓
-- **SAMD21** (Adafruit Feather M0) - Supported ✓
-- **SAMD21** (Arduino Zero) - Supported ✓
-- **SAMD51J** (Adafruit Feather M4) - Supported ✓
-- **SAMD51P** (Adafruit Grand Central M4) - Supported ✓
-
-<details>
-<summary><strong>About the SAM / SAMD Family</strong></summary>
-
-The Atmel SAM family (now Microchip) covers ARM-based microcontrollers used extensively in the Arduino ecosystem. The SAM3X8E powered the Arduino Due (the first official 32-bit Arduino). The SAMD21 (Cortex-M0+) is the foundation for Arduino Zero, MKR boards, and many Adafruit Feather boards. The SAMD51 (Cortex-M4F) brings significantly more performance with hardware floating point, making it popular for audio processing and complex sensor fusion.
-
-| Feature | SAM3X8E (Due) | SAMD21G18A (Zero/Feather M0) | SAMD51J19A (Feather M4) | SAMD51P20A (Grand Central) |
-|---|---|---|---|---|
-| Architecture | Cortex-M3 | Cortex-M0+ | Cortex-M4F | Cortex-M4F |
-| Clock Speed | 84 MHz | 48 MHz | 120 MHz | 120 MHz |
-| Flash Memory | 512 KB | 256 KB | 512 KB | 1 MB |
-| SRAM | 96 KB | 32 KB | 192 KB | 256 KB |
-| FPU | No | No | Single-precision | Single-precision |
-| USB | USB 2.0 HS | USB 2.0 FS | USB 2.0 FS | USB 2.0 FS |
-| DAC | 2x 12-bit | 1x 10-bit | 2x 12-bit | 2x 12-bit |
-| Release Year | 2012 (Due) | 2015 (Zero) | ~2018 | ~2019 |
-| Typical Cost | ~$10–15 | ~$5–20 | ~$15–25 | ~$35–40 |
-
-**Best for**: Audio processing (SAMD51), USB MIDI/HID devices, complex sensor projects, CircuitPython development, scientific instruments.
-
-</details>
-
-**RP2040 / RP2350 Platform** - Supported ✓
-- **RP2040** (Raspberry Pi Pico) - Supported ✓
-- **RP2350** (Raspberry Pi Pico 2) - Supported ✓
-
-<details>
-<summary><strong>About the RP2040 / RP2350 Family</strong></summary>
-
-The RP2040 is the Raspberry Pi Foundation's first microcontroller, released in 2021. It broke new ground with its unique PIO (Programmable I/O) state machines — dedicated hardware that can implement arbitrary digital protocols without CPU involvement. This makes it exceptionally good for driving LEDs, implementing custom serial protocols, and bit-banging at high speeds. The RP2350 (2024) doubles down with a faster dual-core Cortex-M33, adds hardware security features, and optionally includes RISC-V cores.
-
-| Feature | RP2040 (Pico) | RP2350 (Pico 2) |
-|---|---|---|
-| Architecture | Dual Cortex-M0+ | Dual Cortex-M33 (or RISC-V) |
-| Clock Speed | 133 MHz | 150 MHz |
-| Flash Memory | 2 MB (external) | 4 MB (external) |
-| SRAM | 264 KB | 520 KB |
-| PIO State Machines | 8 (2 blocks × 4) | 12 (3 blocks × 4) |
-| FPU | No | Single-precision |
-| USB | USB 1.1 | USB 1.1 |
-| Security | None | ARM TrustZone, secure boot |
-| ADC | 3x 12-bit | 4x 12-bit |
-| Release Year | 2021 | 2024 |
-| Typical Cost | ~$4 | ~$5 |
-
-**Best for**: LED driving (PIO is ideal for WS2812), custom digital protocols, USB devices, educational projects, cost-effective dual-core applications.
-
-</details>
-
-**Nordic NRF52 Platform** - Supported ✓
-- **nRF52840 DK** - Supported ✓
-
-<details>
-<summary><strong>About the Nordic NRF52 Family</strong></summary>
-
-The Nordic nRF52 series is the industry standard for Bluetooth Low Energy (BLE) development. The nRF52840 is the flagship, featuring a Cortex-M4F at 64 MHz with 1 MB flash, USB, and support for BLE 5.0, Thread, Zigbee, and 802.15.4. Nordic's SoftDevice BLE stack is considered one of the most reliable and power-efficient in the industry. The nRF52840 DK is the official development kit, while many third-party boards (Adafruit Feather, Seeed XIAO) use the same chip.
-
-| Feature | nRF52840 |
-|---|---|
-| Architecture | ARM Cortex-M4F |
-| Clock Speed | 64 MHz |
-| Flash Memory | 1 MB |
-| SRAM | 256 KB |
-| Bluetooth | BLE 5.0 (Long Range, 2Mbps) |
-| 802.15.4 | Yes (Thread, Zigbee) |
-| USB | USB 2.0 FS |
-| NFC | Yes (tag emulation) |
-| Operating Voltage | 1.7–5.5V |
-| Release Year | ~2018 |
-| Typical Cost | ~$5–10 (chip), ~$40 (DK) |
-
-**Best for**: BLE peripherals, wireless sensors, wearables, Thread/Zigbee mesh devices, USB+BLE combination devices.
-
-</details>
-
-**Apollo3 Platform** - Supported ✓
-- **SparkFun RedBoard Artemis ATP** - Supported ✓
-- **SparkFun Thing Plus expLoRaBLE** - Supported ✓
-
-<details>
-<summary><strong>About the Apollo3 Family</strong></summary>
-
-The Ambiq Apollo3 is an ultra-low-power ARM Cortex-M4F microcontroller designed for battery-powered and always-on applications. Ambiq's patented Subthreshold Power Optimized Technology (SPOT) enables the Apollo3 to run at under 6 µA/MHz — roughly 10x more power-efficient than typical Cortex-M4 chips. SparkFun's Artemis module packages the Apollo3 Blue with an antenna, flash, and support circuitry, making it accessible through Arduino-compatible boards.
-
-| Feature | Apollo3 Blue |
-|---|---|
-| Architecture | ARM Cortex-M4F |
-| Clock Speed | 48 MHz (96 MHz burst) |
-| Flash Memory | 1 MB |
-| SRAM | 384 KB |
-| BLE | BLE 5.0 |
-| Power Consumption | ~6 µA/MHz (active) |
-| ADC | 14-bit |
-| PDM Microphone Interface | Yes |
-| Operating Voltage | 1.8–3.6V |
-| Release Year | ~2019 |
-| Typical Cost | ~$15–25 (on SparkFun boards) |
-
-**Best for**: Ultra-low-power wearables, battery-powered BLE sensors, always-on voice detection, energy harvesting applications.
-
-</details>
-
-**Silicon Labs EFM32 Platform** - Supported ✓
-- **MGM240** (SparkFun Thing Plus Matter) - Supported ✓
-
-<details>
-<summary><strong>About the Silicon Labs EFM32 / EFR32 Family</strong></summary>
-
-The Silicon Labs EFR32MG24 (MGM240 module) is a Cortex-M33 SoC designed for Matter, Thread, and Zigbee smart home applications. It is one of the first chips purpose-built for the Matter smart home standard, with hardware acceleration for the cryptographic operations Matter requires. The SparkFun Thing Plus Matter board and Arduino Nano Matter both use the MGM240S module, making it easy to prototype Matter-compatible devices with Arduino.
-
-| Feature | EFR32MG24 (MGM240S) |
-|---|---|
-| Architecture | ARM Cortex-M33 |
-| Clock Speed | 78 MHz |
-| Flash Memory | 1536 KB |
-| SRAM | 256 KB |
-| 802.15.4 | Yes (Thread, Zigbee) |
-| Bluetooth | BLE 5.3 |
-| Security | ARM TrustZone, Secure Vault |
-| AI/ML Accelerator | Yes (MVP) |
-| Matter Support | Native |
-| Operating Voltage | 1.71–3.8V |
-| Release Year | ~2023 |
-| Typical Cost | ~$25–30 (on SparkFun board) |
-
-**Best for**: Matter smart home devices, Thread mesh networking, secure IoT endpoints, Zigbee coordinators.
-
-</details>
-
-**Planned Support**:
-- Arduino Mega
-## Performance
-
-**Benchmarks** (Arduino Uno Blink sketch):
-
-| Build Type | Time | Description |
-|------------|------|-------------|
-| First build | 19.25s | Includes toolchain download (50MB) |
-| Full build | 3.06s | All packages cached |
-| Incremental | 0.76s | No source changes |
-| Clean build | 2.58s | Rebuild from cache |
-
-**Firmware Size** (Blink):
-- Program: 1,058 bytes (3.3% of 32KB flash)
-- RAM: 9 bytes (0.4% of 2KB RAM)
-
-## Key Benefits
-
-### Transparency
-Direct URLs and hash-based caching mean you know exactly what you're downloading. No hidden package registries or opaque dependency resolution.
-
-### Reliability
-Real downloads with checksum verification ensure consistent, reproducible builds. No mocks in production code.
-
-### Speed
-Optimized incremental builds complete in under 1 second, with intelligent caching for full rebuilds in 2-5 seconds.
-
-### Code Quality
-100% type-safe (mypy), PEP 8 compliant, and comprehensive test coverage ensure a maintainable and reliable codebase.
-
-### Clear Error Messages
-Actionable error messages with suggestions help you quickly identify and fix issues without requiring forum searches.
-
-## Architecture
-
-See [docs/build-system.md](docs/build-system.md) for comprehensive architecture documentation.
-See [docs/architecture.dot](docs/architecture.dot) for a Graphviz diagram (render with `dot -Tpng`).
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────────────┐
-│                                      CLI LAYER                                          │
-│  ┌─────────────────────────────────────────────────────────────────────────────────┐    │
-│  │  cli.py                                                                         │    │
-│  │  ├── build command ──────┐                                                      │    │
-│  │  ├── deploy command ─────┼──► daemon/client.py ──► IPC (file-based) ──┐        │    │
-│  │  └── monitor command ────┘                                             │        │    │
-│  └────────────────────────────────────────────────────────────────────────│────────┘    │
-└───────────────────────────────────────────────────────────────────────────│─────────────┘
-                                                                            ▼
-┌─────────────────────────────────────────────────────────────────────────────────────────┐
-│                              DAEMON LAYER (Background Process)                          │
-│                                                                                         │
-│  ┌──────────────────────────────────────────────────────────────────────────────────┐  │
-│  │  daemon.py (Server)                                                               │  │
-│  │  ├── lock_manager.py (ResourceLockManager) ◄── Memory-based locks only!          │  │
-│  │  ├── status_manager.py                                                            │  │
-│  │  ├── process_tracker.py                                                           │  │
-│  │  └── device_manager.py ──► device_discovery.py                                    │  │
-│  │                         └── shared_serial.py                                      │  │
-│  └──────────────────────────────────────────────────────────────────────────────────┘  │
-│                            │                                                            │
-│                            ▼                                                            │
-│  ┌─────────────────────────────────────────────────────────────────────────────────┐   │
-│  │  Request Processors (daemon/processors/)                                        │   │
-│  │  ├── build_processor.py ────────────► BUILD LAYER                               │   │
-│  │  ├── deploy_processor.py ───────────► DEPLOY LAYER                              │   │
-│  │  ├── monitor_processor.py ──────────► monitor.py                                │   │
-│  │  └── install_deps_processor.py ─────► PACKAGES LAYER                            │   │
-│  └─────────────────────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────────────────┘
-                            │
-         ┌──────────────────┼──────────────────┐
-         ▼                  ▼                  ▼
-┌─────────────────┐ ┌─────────────────┐ ┌─────────────────────────────────────────────────┐
-│  CONFIG LAYER   │ │  PACKAGES LAYER │ │                  BUILD LAYER                    │
-│                 │ │                 │ │                                                 │
-│ ┌─────────────┐ │ │ ┌─────────────┐ │ │ ┌─────────────────────────────────────────────┐ │
-│ │ ini_parser  │ │ │ │   cache.py  │ │ │ │  Platform Orchestrators                     │ │
-│ │    .py      │ │ │ │      │      │ │ │ │  orchestrator.py (IBuildOrchestrator)       │ │
-│ │ (PlatformIO │ │ │ │      ▼      │ │ │ │       │                                     │ │
-│ │   Config)   │ │ │ │ downloader  │ │ │ │       ├── orchestrator_avr.py               │ │
-│ │      │      │ │ │ │    .py      │ │ │ │       ├── orchestrator_esp32.py             │ │
-│ │      ▼      │ │ │ └──────┬──────┘ │ │ │       ├── orchestrator_rp2040.py            │ │
-│ │board_config │ │ │        │        │ │ │       ├── orchestrator_stm32.py             │ │
-│ │    .py      │ │ │        ▼        │ │ │       └── orchestrator_teensy.py            │ │
-│ │      │      │ │ │ ┌─────────────┐ │ │ └─────────────────────────────────────────────┘ │
-│ │      ▼      │ │ │ │ Toolchains  │ │ │                      │                         │
-│ │board_loader │ │ │ │ toolchain   │ │ │                      ▼                         │
-│ │    .py      │ │ │ │   .py (AVR) │ │ │ ┌─────────────────────────────────────────────┐ │
-│ │      │      │ │ │ │ toolchain_  │ │ │ │  Compilation                                │ │
-│ │      ▼      │ │ │ │   esp32.py  │ │ │ │  source_scanner.py ──► compiler.py          │ │
-│ │ mcu_specs   │ │ │ │ toolchain_  │ │ │ │                              │              │ │
-│ │    .py      │ │ │ │   rp2040.py │ │ │ │  configurable_compiler.py    │              │ │
-│ └─────────────┘ │ │ │     ...     │ │ │ │         │                    │              │ │
-│                 │ │ └─────────────┘ │ │ │         ▼                    ▼              │ │
-│                 │ │        │        │ │ │  flag_builder.py ──► compilation_executor   │ │
-│                 │ │        ▼        │ │ └─────────────────────────────────────────────┘ │
-│                 │ │ ┌─────────────┐ │ │                      │                         │
-│                 │ │ │ Frameworks  │ │ │                      ▼                         │
-│                 │ │ │arduino_core │ │ │ ┌─────────────────────────────────────────────┐ │
-│                 │ │ │    .py      │ │ │ │  Linking                                    │ │
-│                 │ │ │ framework_  │ │ │ │  linker.py ──► archive_creator.py           │ │
-│                 │ │ │   esp32.py  │ │ │ │       │                                     │ │
-│                 │ │ │     ...     │ │ │ │       ▼                                     │ │
-│                 │ │ └─────────────┘ │ │ │  configurable_linker.py                     │ │
-│                 │ │        │        │ │ │       │                                     │ │
-│                 │ │        ▼        │ │ │       ▼                                     │ │
-│                 │ │ ┌─────────────┐ │ │ │  binary_generator.py ──► firmware.hex/.bin  │ │
-│                 │ │ │  Libraries  │ │ │ └─────────────────────────────────────────────┘ │
-│                 │ │ │ library_    │ │ │                                                 │
-│                 │ │ │  manager.py │ │ │  build_state.py (BuildStateTracker)             │
-│                 │ │ │      │      │ │ └─────────────────────────────────────────────────┘
-│                 │ │ │      ▼      │ │
-│                 │ │ │ library_    │ │
-│                 │ │ │ compiler.py │ │
-│                 │ │ │      │      │ │
-│                 │ │ │      ▼      │ │
-│                 │ │ │github_utils │ │
-│                 │ │ │platformio_  │ │
-│                 │ │ │ registry.py │ │
-│                 │ │ └─────────────┘ │
-└─────────────────┘ └─────────────────┘
-
-┌─────────────────────────────────────────────────────────────────────────────────────────┐
-│                                    DEPLOY LAYER                                         │
-│                                                                                         │
-│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐    │
-│  │  deployer.py    │  │ deployer_esp32  │  │   monitor.py    │  │  qemu_runner.py │    │
-│  │  (IDeployer)    │  │    .py          │  │ (Serial Monitor)│  │   (Emulator)    │    │
-│  │       │         │  │  (esptool)      │  │                 │  │                 │    │
-│  │       ▼         │  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘    │
-│  │   [avrdude]     │           │                    │                    │             │
-│  └────────┬────────┘           │                    │                    │             │
-│           └────────────────────┴────────────────────┴────────────────────┘             │
-│                                         │                                               │
-│                                         ▼                                               │
-│                          ┌──────────────────────────────┐                               │
-│                          │     External Dependencies    │                               │
-│                          │  esptool, avrdude, pyserial  │                               │
-│                          │         Docker (QEMU)        │                               │
-│                          └──────────────────────────────┘                               │
-└─────────────────────────────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────────────────────────────┐
-│                                    LEDGER LAYER                                         │
-│  ┌─────────────────────────────────┐  ┌─────────────────────────────────┐              │
-│  │  ledger/board_ledger.py         │  │  daemon/firmware_ledger.py      │              │
-│  │  (Board tracking)               │  │  (Firmware tracking)            │              │
-│  └─────────────────────────────────┘  └─────────────────────────────────┘              │
-└─────────────────────────────────────────────────────────────────────────────────────────┘
-```
-
-**Key Data Flows:**
-
-1. **Build Request**: CLI → Daemon Client → Daemon Server → Build Processor → Platform Orchestrator → Compiler → Linker → firmware.hex/.bin
-2. **Deploy Request**: CLI → Daemon Client → Daemon Server → Deploy Processor → Deployer (esptool/avrdude) → Device
-3. **Package Download**: Orchestrator → Cache → Downloader → fingerprint verification → extracted packages
-
-### Library System Architecture
-
-The library management system handles downloading, compiling, and linking Arduino libraries:
-
-1. **Library Downloading**
-   - Optimizes GitHub URLs to direct zip downloads
-   - Detects and uses appropriate branch (main/master)
-   - Extracts libraries with proper directory structure
-
-2. **Library Compilation**
-   - Compiles C/C++ library sources with LTO flags (`-flto -fno-fat-lto-objects`)
-   - Resolves include paths for Arduino library structure
-   - Generates LTO bytecode objects for optimal linking
-
-3. **Library Linking**
-   - Passes library object files directly to linker (no archiving)
-   - LTO-aware linking with `--allow-multiple-definition` for symbol resolution
-   - Proper handling of weak symbols and ISR handlers
-
-**Technical Solutions**:
-- **LTO Bytecode**: Generate only LTO bytecode to avoid AVR register limitations during compilation
-- **Direct Object Linking**: Pass object files directly to linker instead of archiving for better LTO integration
-- **Multiple Definition Handling**: Support libraries that define symbols in multiple files (e.g., FastLED ISR handlers)
-
-## Project Structure
+A typical user project on disk looks like:
 
 ```
 my-project/
 ├── platformio.ini       # Configuration file
 ├── src/
-│   ├── main.ino        # Your Arduino sketch
-│   └── helpers.cpp     # Additional C++ files
-└── .fbuild/               # Build artifacts (auto-generated)
+│   ├── main.ino         # Your Arduino sketch
+│   └── helpers.cpp      # Additional C++ files
+└── .fbuild/             # Build artifacts (auto-generated)
     ├── cache/
-    │   ├── packages/   # Downloaded toolchains
-    │   └── extracted/  # Arduino cores
+    │   ├── packages/    # Downloaded toolchains
+    │   └── extracted/   # Arduino cores
     └── build/
         └── uno/
-            ├── src/          # Compiled sketch objects
-            ├── core/         # Compiled Arduino core
-            └── firmware.hex  # Final output ← Upload this!
+            ├── src/           # Compiled sketch objects
+            ├── core/          # Compiled Arduino core
+            └── firmware.hex   # Final output ← upload this
 ```
 
-## Testing
+## Architecture
 
-Fbuild includes comprehensive integration tests:
-
-```bash
-# Run all tests
-pytest tests/
-
-# Run integration tests only
-pytest tests/integration/
-
-# Run with verbose output
-pytest -v tests/integration/
-
-# Test results: 11/11 passing
-```
-
-**Test Coverage**:
-- Full build success path
-- Incremental builds
-- Clean builds
-- Firmware size validation
-- HEX format validation
-- Error handling (missing config, syntax errors, etc.)
-
-## Troubleshooting
-
-### Build fails with "platformio.ini not found"
-
-Make sure you're in the project directory or use `-d`:
-```bash
-fbuild build -d /path/to/project
-```
-
-### Build fails with checksum mismatch
-
-Clear cache and rebuild:
-```bash
-rm -rf .fbuild/cache/
-fbuild build
-```
-
-### Compiler errors in sketch
-
-Check the error message for line numbers:
-```
-Error: src/main.ino:5:1: error: expected ';' before '}' token
-```
-
-Common issues:
-- Missing semicolon
-- Missing closing brace
-- Undefined function (missing #include or prototype)
-
-### Slow builds
-
-- First build with downloads: 15-30s (expected)
-- Cached builds: 2-5s (expected)
-- Incremental: <1s (expected)
-
-If slower, check:
-- Network speed (for downloads)
-- Disk speed (SSD recommended)
-- Use `--verbose` to see what's slow
-
-See [docs/build-system.md](docs/build-system.md) for more troubleshooting.
+Architecture docs are decentralized under [`docs/architecture/`](docs/architecture/). Start with [`overview.md`](docs/architecture/overview.md), then read the subsystem-specific docs listed in [`docs/CLAUDE.md`](docs/CLAUDE.md).
 
 ## Development
 
-To develop Fbuild, run `. ./activate.sh`
-
-### Windows
-
-This environment requires you to use `git-bash`.
-
-### Linting
-
-Run `./lint.sh` to find linting errors using `pylint`, `flake8` and `mypy`.
-
-# Why
-
-Both the Arduino CLI and PlatformIO build chains have lagged in their development. While PlatformIO represented a meaningful improvement over the original Arduino build system, it continues to exhibit significant architectural and reliability issues that have remained unresolved despite repeated community reports.
-
-One persistent problem is PlatformIO’s tendency to corrupt its own global installation state. In practice, this often requires users to manually delete `~/.platformio/packages` to restore functionality. This behavior is particularly harmful to new developers, as the failure mode is opaque and recovery is undocumented. In addition, PlatformIO’s package management is frequently slow and unreliable: large toolchains for modern targets (e.g., ESP, STM, Raspberry Pi-class boards) are regularly invalidated and re-downloaded in full, sometimes consuming multiple gigabytes of bandwidth. Even trivial changes to `platformio.ini`—including non-functional edits such as comments—can trigger a full revalidation and reinstall cycle, especially when using the VS Code extension with autosave enabled. This makes the development experience unpredictable and fragile.
-
-More critically, both Arduino CLI and PlatformIO fail to reliably enable essential compiler and linker features for embedded systems, most notably `--gc-sections` and link-time optimization (LTO). These features are fundamental for producing minimal binaries on memory-constrained devices, as they allow dead code elimination and cross–translation unit optimization. Their absence leads to substantial binary bloat. For FastLED, this limitation persisted for years and forced the project to rely on aggressive inlining strategies as a workaround—an approach that increases compile times and code complexity while still falling short of what proper LTO provides.
-
-Compounding these technical issues, conflicts between PlatformIO and Espressif resulted in incomplete or delayed support for newer ESP targets. Boards such as the ESP32-C2, C5, and C6 required external workaround repositories to function correctly with the IDF v5 toolchain, despite being officially supported by the vendor. This further increased maintenance burden and slowed development.
-
-Collectively, these issues cost the FastLED project months of developer time. PlatformIO serves as FastLED’s testing infrastructure, and repeated build failures, slow installs, and corrupted environments significantly reduced iteration speed. To enable concurrent builds and isolate failures, FastLED ultimately resorted to encapsulating the entire build chain inside Docker containers—solely to sandbox PlatformIO’s global state and avoid cross-contamination between builds.
-
-FastLED attempted to address these shortcomings through feature requests and pull requests to PlatformIO; all were declined. Meanwhile, emerging low-cost, high-capability platforms—such as CH-series RISC-V microcontrollers, which are cheaper and more powerful than legacy ATtiny-class devices—remain effectively inaccessible under these legacy build systems.
-
-Given this landscape, the cost to FastLED developers became untenable. It proved more efficient to rebuild the entire compile and deployment stack from first principles. The result is **fbuild**, the FastLED build system. With fbuild, builds are deterministic, fast, and scalable, and advanced compiler and linker features such as LTO can finally be enabled—both for modern targets and retroactively for legacy platforms where the tooling has supported them in theory for over a decade but failed to use them in practice.
-
+Testing, troubleshooting, linting, and local setup instructions live in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md). Project-wide rules for contributors and LLM agents are in [`CLAUDE.md`](CLAUDE.md).
 
 ## License
 
 In the spirit of Dan Garcia's permissively licensed software, `fbuild` is presented as free software.
 
 BSD 3-Clause License
-

--- a/docs/BOARD_STATUS.md
+++ b/docs/BOARD_STATUS.md
@@ -1,0 +1,516 @@
+# Board Status
+
+Live per-platform CI status and supported-board reference for fbuild.
+
+## Per-platform CI badges
+
+### AVR
+[![Build Arduino Uno](https://github.com/fastled/fbuild/actions/workflows/build-uno.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-uno.yml)
+[![Build Leonardo](https://github.com/fastled/fbuild/actions/workflows/build-leonardo.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-leonardo.yml)
+[![Build ATmega8A](https://github.com/fastled/fbuild/actions/workflows/build-atmega8a.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-atmega8a.yml)
+[![Build ATtiny85](https://github.com/fastled/fbuild/actions/workflows/build-attiny85.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny85.yml)
+[![Build ATtiny88](https://github.com/fastled/fbuild/actions/workflows/build-attiny88.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny88.yml)
+[![Build ATtiny4313](https://github.com/fastled/fbuild/actions/workflows/build-attiny4313.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny4313.yml)
+
+### MegaAVR
+[![Build ATtiny1604](https://github.com/fastled/fbuild/actions/workflows/build-attiny1604.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny1604.yml)
+[![Build ATtiny1616](https://github.com/fastled/fbuild/actions/workflows/build-attiny1616.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny1616.yml)
+[![Build Nano Every](https://github.com/fastled/fbuild/actions/workflows/build-nano_every.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nano_every.yml)
+
+### Renesas
+[![Build UNO R4 WiFi](https://github.com/fastled/fbuild/actions/workflows/build-uno_r4_wifi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-uno_r4_wifi.yml)
+
+### ESP8266
+[![Build ESP8266](https://github.com/fastled/fbuild/actions/workflows/build-esp8266.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp8266.yml)
+
+### ESP32
+[![Build ESP32 Dev](https://github.com/fastled/fbuild/actions/workflows/build-esp32dev.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32dev.yml)
+[![Build ESP32-C2](https://github.com/fastled/fbuild/actions/workflows/build-esp32c2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c2.yml)
+[![Build ESP32-C3](https://github.com/fastled/fbuild/actions/workflows/build-esp32c3.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c3.yml)
+[![Build ESP32-C5](https://github.com/fastled/fbuild/actions/workflows/build-esp32c5.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c5.yml)
+[![Build ESP32-C6](https://github.com/fastled/fbuild/actions/workflows/build-esp32c6.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c6.yml)
+[![Build ESP32-H2](https://github.com/fastled/fbuild/actions/workflows/build-esp32h2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32h2.yml)
+[![Build ESP32-P4](https://github.com/fastled/fbuild/actions/workflows/build-esp32p4.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32p4.yml)
+[![Build ESP32-S2](https://github.com/fastled/fbuild/actions/workflows/build-esp32s2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32s2.yml)
+[![Build ESP32-S3](https://github.com/fastled/fbuild/actions/workflows/build-esp32s3.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32s3.yml)
+
+### CH32V (RISC-V)
+[![Build CH32V003](https://github.com/fastled/fbuild/actions/workflows/build-ch32v003.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v003.yml)
+[![Build CH32V103](https://github.com/fastled/fbuild/actions/workflows/build-ch32v103.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v103.yml)
+[![Build CH32V203](https://github.com/fastled/fbuild/actions/workflows/build-ch32v203.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v203.yml)
+[![Build CH32V208](https://github.com/fastled/fbuild/actions/workflows/build-ch32v208.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v208.yml)
+[![Build CH32V303](https://github.com/fastled/fbuild/actions/workflows/build-ch32v303.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v303.yml)
+[![Build CH32V307](https://github.com/fastled/fbuild/actions/workflows/build-ch32v307.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v307.yml)
+
+### CH32X (RISC-V, USB PD)
+[![Build CH32X035](https://github.com/fastled/fbuild/actions/workflows/build-ch32x035.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32x035.yml)
+
+### Teensy
+[![Build Teensy 4.1](https://github.com/fastled/fbuild/actions/workflows/build-teensy41.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy41.yml)
+[![Build Teensy 4.0](https://github.com/fastled/fbuild/actions/workflows/build-teensy40.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy40.yml)
+[![Build Teensy 3.6](https://github.com/fastled/fbuild/actions/workflows/build-teensy36.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy36.yml)
+[![Build Teensy 3.5](https://github.com/fastled/fbuild/actions/workflows/build-teensy35.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy35.yml)
+[![Build Teensy 3.2](https://github.com/fastled/fbuild/actions/workflows/build-teensy32.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy32.yml)
+[![Build Teensy 3.1](https://github.com/fastled/fbuild/actions/workflows/build-teensy31.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy31.yml)
+[![Build Teensy 3.0](https://github.com/fastled/fbuild/actions/workflows/build-teensy30.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy30.yml)
+[![Build Teensy LC](https://github.com/fastled/fbuild/actions/workflows/build-teensylc.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensylc.yml)
+
+### STM32
+[![Build STM32F103C8](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103c8.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103c8.yml)
+[![Build STM32F103CB](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103cb.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103cb.yml)
+[![Build STM32F103TB](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103tb.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103tb.yml)
+[![Build STM32F411CE](https://github.com/fastled/fbuild/actions/workflows/build-stm32f411ce.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f411ce.yml)
+[![Build STM32H747XI](https://github.com/fastled/fbuild/actions/workflows/build-stm32h747xi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32h747xi.yml)
+[![Build Nucleo F429ZI](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f429zi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f429zi.yml)
+[![Build Nucleo F439ZI](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f439zi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f439zi.yml)
+[![Build Arduino Giga R1](https://github.com/fastled/fbuild/actions/workflows/build-giga-r1.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-giga-r1.yml)
+
+### SAM / SAMD
+[![Build Arduino Due](https://github.com/fastled/fbuild/actions/workflows/build-sam3x8e_due.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-sam3x8e_due.yml)
+[![Build SAMD21](https://github.com/fastled/fbuild/actions/workflows/build-samd21.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd21.yml)
+[![Build Arduino Zero](https://github.com/fastled/fbuild/actions/workflows/build-samd21_zero.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd21_zero.yml)
+[![Build SAMD51J](https://github.com/fastled/fbuild/actions/workflows/build-samd51j.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd51j.yml)
+[![Build SAMD51P](https://github.com/fastled/fbuild/actions/workflows/build-samd51p.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd51p.yml)
+
+### RP2040 / RP2350
+[![Build RP2040](https://github.com/fastled/fbuild/actions/workflows/build-rp2040.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rp2040.yml)
+[![Build RP2350](https://github.com/fastled/fbuild/actions/workflows/build-rp2350.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rp2350.yml)
+
+### Nordic NRF52
+[![Build nRF52840 DK](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml)
+
+### Apollo3
+[![Build Apollo3 RedBoard](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml)
+[![Build Apollo3 expLoRaBLE](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml)
+
+### Silicon Labs
+[![Build MGM240](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml)
+
+### NRF52
+[![Build Adafruit Feather NRF52840 Sense](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840-sense.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840-sense.yml)
+[![Build NRF52840 DK](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml)
+
+### Raspberry Pi Pico
+[![Build Raspberry Pi Pico](https://github.com/fastled/fbuild/actions/workflows/build-rpipico.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rpipico.yml)
+[![Build Raspberry Pi Pico 2](https://github.com/fastled/fbuild/actions/workflows/build-rpipico2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rpipico2.yml)
+
+### Silicon Labs
+[![Build SparkFun Thing Plus Matter](https://github.com/fastled/fbuild/actions/workflows/build-thingplusmatter.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-thingplusmatter.yml)
+
+## Supported platforms and boards
+
+**Arduino AVR Platform** - Fully Supported
+- **Arduino Uno** (atmega328p, 16MHz) - Fully tested
+- **Arduino Leonardo** (atmega32u4, 16MHz) - Supported
+- **ATmega8A** (atmega8a, 16MHz) - Supported
+- **ATtiny85** - Supported
+- **ATtiny88** - Supported
+- **ATtiny4313** - Supported
+
+<details>
+<summary><strong>About the AVR Family</strong></summary>
+
+The Atmel AVR family is the 8-bit microcontroller architecture that launched the Arduino revolution. Originally designed by Atmel (now Microchip Technology) in 1996, these chips became the backbone of the maker movement when Arduino adopted the ATmega328P for the Arduino Uno in 2010. AVR microcontrollers are known for their simplicity, extensive community support, and massive library ecosystem. They remain the go-to choice for learning embedded development, simple I/O projects, and LED control.
+
+| Feature | ATmega328P (Uno) | ATmega32U4 (Leonardo) |
+|---|---|---|
+| Architecture | 8-bit AVR | 8-bit AVR |
+| Clock Speed | 16 MHz | 16 MHz |
+| Flash Memory | 32 KB | 32 KB |
+| SRAM | 2 KB | 2.5 KB |
+| EEPROM | 1 KB | 1 KB |
+| Digital I/O Pins | 14 | 20 |
+| Analog Inputs | 6 | 12 |
+| Native USB | No | Yes |
+| Operating Voltage | 5V | 5V |
+| Release Year | ~2008 (Uno: 2010) | ~2012 |
+| Typical Cost | ~$3–5 | ~$4–6 |
+
+**Best for**: Beginner projects, LED control, basic sensor reading, learning embedded development, prototyping simple circuits.
+
+</details>
+
+**ESP8266 Platform** - Supported
+- **ESP8266** (esp8266) - Supported
+
+<details>
+<summary><strong>About the ESP8266 Family</strong></summary>
+
+The ESP8266 was a game-changer when Espressif Systems released it in 2014. Originally marketed as a cheap WiFi-to-serial bridge (~$2), the community quickly discovered its full potential as a standalone WiFi-capable microcontroller. It single-handedly kicked off the affordable IoT revolution, making WiFi connectivity accessible for hobbyist and commercial projects alike. While largely superseded by the ESP32 family, the ESP8266 remains popular for simple WiFi applications due to its low cost and mature ecosystem.
+
+| Feature | ESP8266 |
+|---|---|
+| Architecture | 32-bit Tensilica Xtensa LX106 |
+| Clock Speed | 80 MHz (160 MHz boost) |
+| Flash Memory | 4 MB (typical) |
+| SRAM | 80 KB (user-accessible) |
+| WiFi | 802.11 b/g/n (2.4 GHz) |
+| Bluetooth | No |
+| GPIO Pins | 17 (limited usable) |
+| ADC | 1 (10-bit) |
+| Operating Voltage | 3.3V |
+| Release Year | 2014 |
+| Typical Cost | ~$1–3 |
+
+**Best for**: Simple IoT sensors, WiFi-connected projects, home automation nodes, weather stations, cost-sensitive WiFi applications.
+
+</details>
+
+**ESP32 Platform** - Supported
+- **ESP32 Dev** (esp32dev) - Supported
+- **ESP32-S2** - Supported
+- **ESP32-S3** (esp32-s3-devkitc-1) - Supported
+- **ESP32-C2** - Supported (v0.1.0+)
+- **ESP32-C3** (esp32-c3-devkitm-1) - Supported
+- **ESP32-C5** - Supported
+- **ESP32-C6** (esp32c6-devkit) - Supported
+- **ESP32-H2** - Supported
+- **ESP32-P4** - Supported
+
+<details>
+<summary><strong>About the ESP32 Family</strong></summary>
+
+The ESP32 is Espressif Systems' flagship family of wireless SoCs and the dominant platform for IoT development. The original ESP32 launched in 2016 as the successor to the ESP8266, adding dual-core processing, Bluetooth, and significantly more memory. Since then, Espressif has expanded the family with specialized variants: the S-series for AI and USB, the C-series using RISC-V cores for cost optimization and WiFi 6, the H-series for Thread/Zigbee mesh networking, and the P-series for high-performance edge computing. Together they cover everything from $0.50 disposable sensors to multimedia edge devices.
+
+| Feature | ESP32 | ESP32-S2 | ESP32-S3 | ESP32-C2 | ESP32-C3 | ESP32-C5 | ESP32-C6 | ESP32-H2 | ESP32-P4 |
+|---|---|---|---|---|---|---|---|---|---|
+| Architecture | Xtensa LX6 | Xtensa LX7 | Xtensa LX7 | RISC-V | RISC-V | RISC-V | RISC-V | RISC-V | RISC-V |
+| Cores | 2 | 1 | 2 | 1 | 1 | 1 | 1 | 1 | 2 |
+| Clock (MHz) | 240 | 240 | 240 | 120 | 160 | 240 | 160 | 96 | 400 |
+| SRAM | 520 KB | 320 KB | 512 KB | 272 KB | 400 KB | 400 KB | 512 KB | 320 KB | 768 KB |
+| Flash (typical) | 4 MB | 4 MB | 8 MB | 4 MB | 4 MB | 4 MB | 4 MB | 4 MB | 16 MB |
+| WiFi | 2.4 GHz | 2.4 GHz | 2.4 GHz | 2.4 GHz | 2.4 GHz | 2.4+5 GHz (WiFi 6) | 2.4 GHz (WiFi 6) | No | No |
+| Bluetooth | BT 4.2 + BLE | No | BLE 5.0 | BLE 5.0 | BLE 5.0 | BLE 5.0 | BLE 5.0 | BLE 5.0 | No |
+| 802.15.4 (Thread/Zigbee) | No | No | No | No | No | Yes | Yes | Yes | No |
+| USB OTG | No | Yes | Yes | No | No | No | No | No | Yes |
+| AI Acceleration | No | No | Yes (vector) | No | No | No | No | No | Yes |
+| Release Year | 2016 | 2020 | 2021 | 2022 | 2021 | 2024 | 2023 | 2023 | 2024 |
+| Typical Cost | ~$2–4 | ~$2–3 | ~$3–5 | ~$0.50–1 | ~$1–2 | ~$2–3 | ~$2–3 | ~$2–3 | ~$5–8 |
+
+**Best for**:
+- **ESP32**: General IoT, WiFi+BT projects, audio, displays
+- **ESP32-S2/S3**: USB devices, camera/display applications, AI at the edge (S3)
+- **ESP32-C2/C3**: Cost-optimized IoT, simple WiFi/BLE sensors, high-volume products
+- **ESP32-C5/C6**: WiFi 6, smart home with Thread/Zigbee/Matter support
+- **ESP32-H2**: Thread/Zigbee mesh networking, Matter border routers, low-power sensors
+- **ESP32-P4**: High-performance edge computing, multimedia, display-intensive applications
+
+</details>
+
+**CH32V (RISC-V) Platform** - Supported
+- **CH32V003** - Supported
+
+<details>
+<summary><strong>About the CH32V Family</strong></summary>
+
+The CH32V series from WCH (Nanjing Qinheng Microelectronics) represents the new wave of ultra-low-cost RISC-V microcontrollers from China. The CH32V003, launched around 2022–2023, made headlines as a ~$0.10 microcontroller that could genuinely replace legacy 8-bit chips like the ATtiny in cost-sensitive designs. Running a 32-bit RISC-V core at 48 MHz with more memory than an ATtiny, the CH32V003 offers modern 32-bit capabilities at 8-bit prices. WCH's broader CH32V lineup spans from the tiny V003 up to the V307 with Ethernet and USB, positioning the family as a serious alternative for everything from disposable sensors to industrial control.
+
+| Feature | CH32V003 |
+|---|---|
+| Architecture | 32-bit RISC-V (RV32EC) |
+| Clock Speed | 48 MHz |
+| Flash Memory | 16 KB |
+| SRAM | 2 KB |
+| GPIO Pins | 18 |
+| ADC | 8 channels (10-bit) |
+| UART | 1 |
+| SPI | 1 |
+| I2C | 1 |
+| Timers | 2 |
+| Operating Voltage | 3.3V / 5V tolerant |
+| Package Options | SOP-8, SOP-16, QFN-20 |
+| Release Year | 2022–2023 |
+| Typical Cost | ~$0.10–0.20 |
+
+**Best for**: Ultra-low-cost applications, replacing ATtiny/PIC in production, high-volume consumer electronics, disposable/embedded sensors, cost-sensitive LED drivers.
+
+</details>
+
+**Teensy Platform** - Supported
+- **Teensy 4.1** - Supported
+- **Teensy 4.0** - Supported
+- **Teensy 3.6** - Supported
+- **Teensy 3.5** - Supported
+- **Teensy 3.2** - Supported
+- **Teensy 3.1** - Supported
+- **Teensy 3.0** - Supported
+- **Teensy LC** - Supported
+
+<details>
+<summary><strong>About the Teensy Family</strong></summary>
+
+Teensy is a family of high-performance ARM-based development boards created by PJRC (Paul Stoffregen). Since 2011, Teensy boards have been the go-to choice for projects requiring serious processing power in a small form factor, particularly in audio, USB, and real-time applications. The Teensy 4.x series, powered by the NXP i.MX RT1062 Cortex-M7 at 600 MHz, was the fastest Arduino-compatible microcontroller board when it launched in 2019. Teensy is known for its exceptional audio library, mature USB stack (supporting MIDI, serial, HID, and more simultaneously), and robust real-time performance.
+
+| Feature | Teensy LC | Teensy 3.6 | Teensy 4.0 | Teensy 4.1 |
+|---|---|---|---|---|
+| Architecture | ARM Cortex-M0+ | ARM Cortex-M4F | ARM Cortex-M7 | ARM Cortex-M7 |
+| Clock Speed | 48 MHz | 180 MHz | 600 MHz | 600 MHz |
+| Flash Memory | 62 KB | 1 MB | 2 MB | 8 MB |
+| SRAM | 8 KB | 256 KB | 1 MB | 1 MB |
+| FPU | No | Single-precision | Double-precision | Double-precision |
+| USB | USB 2.0 | USB 2.0 High Speed | USB 2.0 High Speed | USB 2.0 High Speed |
+| Ethernet | No | No | No | Yes (10/100) |
+| SD Card | No | Built-in SDIO | No | Built-in SDIO |
+| Audio | I2S | I2S + DAC | I2S + S/PDIF | I2S + S/PDIF |
+| Digital I/O | 27 | 62 | 40 | 55 |
+| Analog Inputs | 13 | 25 | 14 | 18 |
+| Operating Voltage | 3.3V | 3.3V | 3.3V | 3.3V |
+| Release Year | 2015 | 2016 | 2019 | 2020 |
+| Typical Cost | ~$12 | ~$30 | ~$24 | ~$32 |
+
+**Best for**: Audio synthesis and processing, USB MIDI controllers, real-time data acquisition, LED installations requiring high frame rates, flight controllers, robotics, any project demanding maximum processing power with Arduino compatibility.
+
+</details>
+
+**WASM / WebAssembly Platform** - Supported
+- Compiles Arduino/FastLED sketches to WebAssembly via Emscripten (`clang-tool-chain-emcc`)
+- Outputs `firmware.js` + `firmware.wasm`
+- Library dependencies from `lib_deps` compiled and linked automatically
+
+<details>
+<summary><strong>About the WASM Platform</strong></summary>
+
+WebAssembly (WASM) is not a physical microcontroller but a compilation target that allows Arduino/FastLED sketches to run in web browsers or server-side runtimes. fbuild uses Emscripten's Clang-based toolchain to cross-compile C/C++ Arduino code into portable `.wasm` binaries. This enables browser-based simulation, testing without hardware, and web-based LED visualizers. FastLED uses this extensively for its web-based examples and testing infrastructure.
+
+| Feature | WASM (Emscripten) |
+|---|---|
+| Architecture | Stack-based virtual machine |
+| Runtime | Browser (V8, SpiderMonkey, etc.) or Node.js |
+| Compiler | Clang via Emscripten |
+| Output | `firmware.js` + `firmware.wasm` |
+| Hardware Access | None (simulated) |
+| Debugging | Browser DevTools |
+| Performance | Near-native speed in browser |
+| Use Case | Simulation, testing, web demos |
+
+**Best for**: Browser-based LED simulators, testing without physical hardware, web demos, CI/CD firmware validation, interactive documentation.
+
+</details>
+
+**MegaAVR Platform** - Supported
+- **ATtiny1604** - Supported
+- **ATtiny1616** - Supported
+- **Arduino Nano Every** (ATmega4809) - Supported
+
+<details>
+<summary><strong>About the MegaAVR Family</strong></summary>
+
+The MegaAVR (also called AVR Dx / tinyAVR 1-series) is Microchip's modernized AVR architecture. These chips retain the familiar AVR instruction set but add improved peripherals, configurable custom logic (CCL), an event system for peripheral-to-peripheral communication without CPU involvement, and a more flexible clock system. The ATtiny1604/1616 replace older ATtiny chips with more flash, SRAM, and peripherals at similar price points. The ATmega4809 powers the Arduino Nano Every, providing a drop-in upgrade path from the classic Nano.
+
+| Feature | ATtiny1604 | ATtiny1616 | ATmega4809 (Nano Every) |
+|---|---|---|---|
+| Architecture | 8-bit AVR (tinyAVR 1-series) | 8-bit AVR (tinyAVR 1-series) | 8-bit MegaAVR 0-series |
+| Clock Speed | 20 MHz | 20 MHz | 20 MHz |
+| Flash Memory | 16 KB | 16 KB | 48 KB |
+| SRAM | 1 KB | 2 KB | 6 KB |
+| EEPROM | 256 B | 256 B | 256 B |
+| GPIO Pins | 12 | 18 | 33 |
+| ADC | 10-bit, 8 channels | 10-bit, 12 channels | 10-bit, 8 channels |
+| Event System | Yes | Yes | Yes |
+| CCL (Custom Logic) | Yes | Yes | Yes |
+| Operating Voltage | 1.8–5.5V | 1.8–5.5V | 1.8–5.5V |
+| Release Year | ~2018 | ~2018 | ~2019 |
+| Typical Cost | ~$0.50–1 | ~$0.60–1 | ~$3–5 (on Nano Every) |
+
+**Best for**: Modern replacements for classic ATtiny/ATmega projects, low-power sensing, cost-sensitive designs needing more peripherals than classic AVR.
+
+</details>
+
+**Renesas RA Platform** - Supported
+- **Arduino UNO R4 WiFi** (RA4M1) - Supported
+
+<details>
+<summary><strong>About the Renesas RA Family</strong></summary>
+
+The Arduino UNO R4 WiFi is Arduino's first board based on a Renesas RA4M1 (ARM Cortex-M4) processor, replacing the classic ATmega328P. Released in 2023, it represents Arduino's move into 32-bit territory for their flagship UNO form factor. The R4 WiFi adds an ESP32-S3 module for WiFi/BLE connectivity and includes a 12x8 LED matrix on-board. It maintains the classic UNO shield-compatible form factor while delivering significantly more processing power and memory.
+
+| Feature | UNO R4 WiFi |
+|---|---|
+| Architecture | ARM Cortex-M4 (Renesas RA4M1) |
+| Clock Speed | 48 MHz |
+| Flash Memory | 256 KB |
+| SRAM | 32 KB |
+| WiFi | 802.11 b/g/n (via ESP32-S3) |
+| Bluetooth | BLE 5.0 (via ESP32-S3) |
+| USB | USB-C (native USB) |
+| LED Matrix | 12x8 on-board |
+| Operating Voltage | 5V |
+| Release Year | 2023 |
+| Typical Cost | ~$28 |
+
+**Best for**: Upgrading classic UNO projects to 32-bit, WiFi-enabled Arduino projects, educational use with the on-board LED matrix.
+
+</details>
+
+**STM32 Platform** - Supported
+- **STM32F103C8** (Blue Pill) - Supported
+- **STM32F103CB** (Maple Mini) - Supported
+- **STM32F103TB** (HY TinySTM103T) - Supported
+- **STM32F411CE** (Black Pill) - Supported
+- **STM32H747XI** (Arduino GIGA R1) - Supported
+- **Nucleo F429ZI** - Supported
+- **Nucleo F439ZI** - Supported
+
+<details>
+<summary><strong>About the STM32 Family</strong></summary>
+
+STM32 is STMicroelectronics' extensive family of ARM Cortex-M microcontrollers, widely used in industrial, automotive, and consumer applications. The family spans from ultra-low-power Cortex-M0 to high-performance dual-core Cortex-M7+M4 devices. The "Blue Pill" (STM32F103C8) became the gateway drug for many makers transitioning from Arduino to 32-bit ARM, offering 72 MHz Cortex-M3 performance for under $2. The STM32H7 series represents the high end, with the dual-core H747 powering Arduino's GIGA R1 WiFi board.
+
+| Feature | STM32F103 (Blue Pill) | STM32F411CE (Black Pill) | STM32H747XI (GIGA R1) | Nucleo F429ZI |
+|---|---|---|---|---|
+| Architecture | Cortex-M3 | Cortex-M4F | Cortex-M7 + M4 | Cortex-M4F |
+| Clock Speed | 72 MHz | 100 MHz | 480 + 240 MHz | 180 MHz |
+| Flash Memory | 64–128 KB | 512 KB | 2 MB | 2 MB |
+| SRAM | 20 KB | 128 KB | 1 MB | 256 KB |
+| FPU | No | Single-precision | Double-precision | Single-precision |
+| USB | USB 2.0 FS | USB 2.0 FS | USB 2.0 HS | USB 2.0 FS/HS |
+| Ethernet | No | No | Yes | Yes |
+| Camera Interface | No | No | Yes (DCMI) | Yes (DCMI) |
+| Release Year | ~2007 | ~2019 | ~2022 | ~2014 |
+| Typical Cost | ~$1–2 | ~$3–5 | ~$60 (on GIGA R1) | ~$25 |
+
+**Best for**: Industrial control, motor driving, USB devices, high-performance embedded applications, prototyping with the Nucleo ecosystem.
+
+</details>
+
+**Atmel SAM / SAMD Platform** - Supported
+- **Arduino Due** (SAM3X8E) - Supported
+- **SAMD21** (Adafruit Feather M0) - Supported
+- **SAMD21** (Arduino Zero) - Supported
+- **SAMD51J** (Adafruit Feather M4) - Supported
+- **SAMD51P** (Adafruit Grand Central M4) - Supported
+
+<details>
+<summary><strong>About the SAM / SAMD Family</strong></summary>
+
+The Atmel SAM family (now Microchip) covers ARM-based microcontrollers used extensively in the Arduino ecosystem. The SAM3X8E powered the Arduino Due (the first official 32-bit Arduino). The SAMD21 (Cortex-M0+) is the foundation for Arduino Zero, MKR boards, and many Adafruit Feather boards. The SAMD51 (Cortex-M4F) brings significantly more performance with hardware floating point, making it popular for audio processing and complex sensor fusion.
+
+| Feature | SAM3X8E (Due) | SAMD21G18A (Zero/Feather M0) | SAMD51J19A (Feather M4) | SAMD51P20A (Grand Central) |
+|---|---|---|---|---|
+| Architecture | Cortex-M3 | Cortex-M0+ | Cortex-M4F | Cortex-M4F |
+| Clock Speed | 84 MHz | 48 MHz | 120 MHz | 120 MHz |
+| Flash Memory | 512 KB | 256 KB | 512 KB | 1 MB |
+| SRAM | 96 KB | 32 KB | 192 KB | 256 KB |
+| FPU | No | No | Single-precision | Single-precision |
+| USB | USB 2.0 HS | USB 2.0 FS | USB 2.0 FS | USB 2.0 FS |
+| DAC | 2x 12-bit | 1x 10-bit | 2x 12-bit | 2x 12-bit |
+| Release Year | 2012 (Due) | 2015 (Zero) | ~2018 | ~2019 |
+| Typical Cost | ~$10–15 | ~$5–20 | ~$15–25 | ~$35–40 |
+
+**Best for**: Audio processing (SAMD51), USB MIDI/HID devices, complex sensor projects, CircuitPython development, scientific instruments.
+
+</details>
+
+**RP2040 / RP2350 Platform** - Supported
+- **RP2040** (Raspberry Pi Pico) - Supported
+- **RP2350** (Raspberry Pi Pico 2) - Supported
+
+<details>
+<summary><strong>About the RP2040 / RP2350 Family</strong></summary>
+
+The RP2040 is the Raspberry Pi Foundation's first microcontroller, released in 2021. It broke new ground with its unique PIO (Programmable I/O) state machines — dedicated hardware that can implement arbitrary digital protocols without CPU involvement. This makes it exceptionally good for driving LEDs, implementing custom serial protocols, and bit-banging at high speeds. The RP2350 (2024) doubles down with a faster dual-core Cortex-M33, adds hardware security features, and optionally includes RISC-V cores.
+
+| Feature | RP2040 (Pico) | RP2350 (Pico 2) |
+|---|---|---|
+| Architecture | Dual Cortex-M0+ | Dual Cortex-M33 (or RISC-V) |
+| Clock Speed | 133 MHz | 150 MHz |
+| Flash Memory | 2 MB (external) | 4 MB (external) |
+| SRAM | 264 KB | 520 KB |
+| PIO State Machines | 8 (2 blocks × 4) | 12 (3 blocks × 4) |
+| FPU | No | Single-precision |
+| USB | USB 1.1 | USB 1.1 |
+| Security | None | ARM TrustZone, secure boot |
+| ADC | 3x 12-bit | 4x 12-bit |
+| Release Year | 2021 | 2024 |
+| Typical Cost | ~$4 | ~$5 |
+
+**Best for**: LED driving (PIO is ideal for WS2812), custom digital protocols, USB devices, educational projects, cost-effective dual-core applications.
+
+</details>
+
+**Nordic NRF52 Platform** - Supported
+- **nRF52840 DK** - Supported
+
+<details>
+<summary><strong>About the Nordic NRF52 Family</strong></summary>
+
+The Nordic nRF52 series is the industry standard for Bluetooth Low Energy (BLE) development. The nRF52840 is the flagship, featuring a Cortex-M4F at 64 MHz with 1 MB flash, USB, and support for BLE 5.0, Thread, Zigbee, and 802.15.4. Nordic's SoftDevice BLE stack is considered one of the most reliable and power-efficient in the industry. The nRF52840 DK is the official development kit, while many third-party boards (Adafruit Feather, Seeed XIAO) use the same chip.
+
+| Feature | nRF52840 |
+|---|---|
+| Architecture | ARM Cortex-M4F |
+| Clock Speed | 64 MHz |
+| Flash Memory | 1 MB |
+| SRAM | 256 KB |
+| Bluetooth | BLE 5.0 (Long Range, 2Mbps) |
+| 802.15.4 | Yes (Thread, Zigbee) |
+| USB | USB 2.0 FS |
+| NFC | Yes (tag emulation) |
+| Operating Voltage | 1.7–5.5V |
+| Release Year | ~2018 |
+| Typical Cost | ~$5–10 (chip), ~$40 (DK) |
+
+**Best for**: BLE peripherals, wireless sensors, wearables, Thread/Zigbee mesh devices, USB+BLE combination devices.
+
+</details>
+
+**Apollo3 Platform** - Supported
+- **SparkFun RedBoard Artemis ATP** - Supported
+- **SparkFun Thing Plus expLoRaBLE** - Supported
+
+<details>
+<summary><strong>About the Apollo3 Family</strong></summary>
+
+The Ambiq Apollo3 is an ultra-low-power ARM Cortex-M4F microcontroller designed for battery-powered and always-on applications. Ambiq's patented Subthreshold Power Optimized Technology (SPOT) enables the Apollo3 to run at under 6 µA/MHz — roughly 10x more power-efficient than typical Cortex-M4 chips. SparkFun's Artemis module packages the Apollo3 Blue with an antenna, flash, and support circuitry, making it accessible through Arduino-compatible boards.
+
+| Feature | Apollo3 Blue |
+|---|---|
+| Architecture | ARM Cortex-M4F |
+| Clock Speed | 48 MHz (96 MHz burst) |
+| Flash Memory | 1 MB |
+| SRAM | 384 KB |
+| BLE | BLE 5.0 |
+| Power Consumption | ~6 µA/MHz (active) |
+| ADC | 14-bit |
+| PDM Microphone Interface | Yes |
+| Operating Voltage | 1.8–3.6V |
+| Release Year | ~2019 |
+| Typical Cost | ~$15–25 (on SparkFun boards) |
+
+**Best for**: Ultra-low-power wearables, battery-powered BLE sensors, always-on voice detection, energy harvesting applications.
+
+</details>
+
+**Silicon Labs EFM32 Platform** - Supported
+- **MGM240** (SparkFun Thing Plus Matter) - Supported
+
+<details>
+<summary><strong>About the Silicon Labs EFM32 / EFR32 Family</strong></summary>
+
+The Silicon Labs EFR32MG24 (MGM240 module) is a Cortex-M33 SoC designed for Matter, Thread, and Zigbee smart home applications. It is one of the first chips purpose-built for the Matter smart home standard, with hardware acceleration for the cryptographic operations Matter requires. The SparkFun Thing Plus Matter board and Arduino Nano Matter both use the MGM240S module, making it easy to prototype Matter-compatible devices with Arduino.
+
+| Feature | EFR32MG24 (MGM240S) |
+|---|---|
+| Architecture | ARM Cortex-M33 |
+| Clock Speed | 78 MHz |
+| Flash Memory | 1536 KB |
+| SRAM | 256 KB |
+| 802.15.4 | Yes (Thread, Zigbee) |
+| Bluetooth | BLE 5.3 |
+| Security | ARM TrustZone, Secure Vault |
+| AI/ML Accelerator | Yes (MVP) |
+| Matter Support | Native |
+| Operating Voltage | 1.71–3.8V |
+| Release Year | ~2023 |
+| Typical Cost | ~$25–30 (on SparkFun board) |
+
+**Best for**: Matter smart home devices, Thread mesh networking, secure IoT endpoints, Zigbee coordinators.
+
+</details>
+
+**Planned Support**:
+- Arduino Mega
+
+## Adding a new board
+
+For the workflow to add or fix a board definition, see the [`/board-support`](../.claude/skills/board-support/SKILL.md) skill and the scripts under `ci/` (`board_sources.py`, `validate_boards.py`).

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Architecture docs are split by subsystem. Read only what's relevant to your current work.
 
+For a full FAQ-style index of every doc in this repo (human + LLM entry point), see [INDEX.md](INDEX.md).
+
 ## Which doc to read
 
 | Working on crate | Read these |
@@ -20,8 +22,13 @@ Architecture docs are split by subsystem. Read only what's relevant to your curr
 
 ## Other docs
 
+- **[INDEX.md](INDEX.md)** - FAQ-style index across all docs
+- **[WHY.md](WHY.md)** - Why fbuild exists, key benefits, performance
+- **[BOARD_STATUS.md](BOARD_STATUS.md)** - Per-platform CI badges and supported boards
+- **[DEVELOPMENT.md](DEVELOPMENT.md)** - Testing, troubleshooting, local setup
 - **[DESIGN_DECISIONS.md](DESIGN_DECISIONS.md)** - ADR-style decisions with rationale
 - **[ROADMAP.md](ROADMAP.md)** - Implementation phases
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - Index of all architecture documents
+- **[../crates/CLAUDE.md](../crates/CLAUDE.md)** - Crate dependency graph and boundaries
 - **[../PLAN_QEMU_ESP32S3.md](../PLAN_QEMU_ESP32S3.md)** - QEMU ESP32-S3 emulation plan
 - Emulator CLI: `fbuild test-emu` (build + emulate) and `fbuild deploy --to emu [--emulator <kind>]`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,130 @@
+# Development
+
+This document covers the developer workflow: testing, troubleshooting, and local setup. For architecture, see [architecture/overview.md](architecture/overview.md). For why the project exists, see [WHY.md](WHY.md).
+
+## Testing
+
+fbuild includes comprehensive integration tests. The Rust workspace uses `cargo test` via the `uv run` / `soldr` trampolines enforced by repo hooks.
+
+```bash
+# Run unit tests only
+uv run test
+
+# Run unit + stress + integration tests
+uv run test --full
+
+# Run a specific test in a specific crate
+uv run test -p <crate> -- <test_name>
+```
+
+For the legacy Python test suite (used only for CI parity checks against the Python fbuild reference):
+
+```bash
+# Run all tests
+pytest tests/
+
+# Run integration tests only
+pytest tests/integration/
+
+# Run with verbose output
+pytest -v tests/integration/
+```
+
+**Test Coverage**:
+- Full build success path
+- Incremental builds
+- Clean builds
+- Firmware size validation
+- HEX format validation
+- Error handling (missing config, syntax errors, etc.)
+
+## Troubleshooting
+
+### Build fails with "platformio.ini not found"
+
+Make sure you're in the project directory or use `-d`:
+```bash
+fbuild build -d /path/to/project
+```
+
+### Build fails with checksum mismatch
+
+Clear cache and rebuild:
+```bash
+rm -rf .fbuild/cache/
+fbuild build
+```
+
+### Compiler errors in sketch
+
+Check the error message for line numbers:
+```
+Error: src/main.ino:5:1: error: expected ';' before '}' token
+```
+
+Common issues:
+- Missing semicolon
+- Missing closing brace
+- Undefined function (missing #include or prototype)
+
+### Slow builds
+
+- First build with downloads: 15-30s (expected)
+- Cached builds: 2-5s (expected)
+- Incremental: <1s (expected)
+
+If slower, check:
+- Network speed (for downloads)
+- Disk speed (SSD recommended)
+- Use `--verbose` to see what's slow
+
+See [architecture/overview.md](architecture/overview.md) for additional architecture-level troubleshooting.
+
+## Development setup
+
+To develop fbuild, run `. ./activate.sh`
+
+### Windows
+
+This environment requires you to use `git-bash`.
+
+### Toolchain
+
+- MSRV: 1.75 | Edition: 2021
+- Toolchain: 1.94.1 pinned in `rust-toolchain.toml` (clippy + rustfmt)
+- CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)
+
+### Linting
+
+Use the `uv run` trampolines (bare `cargo` / `rustc` are blocked by hook):
+
+```bash
+uv run cargo check --workspace --all-targets
+uv run cargo clippy --workspace --all-targets -- -D warnings
+uv run cargo fmt --all
+```
+
+The legacy Python linters (`./lint.sh` with `pylint`, `flake8`, `mypy`) remain for any Python utility code under `ci/`.
+
+### Distribution
+
+Native binaries are built via GitHub Actions and downloaded locally for packaging. PyPI is the distribution channel — no Python in the runtime hot path.
+
+```bash
+# Build all platforms (triggers GH Actions, waits, downloads to dist/)
+uv run python ci/build_dist.py --ref main
+
+# Publish to PyPI
+./publish
+```
+
+### Hooks (enforced automatically)
+
+See the root [CLAUDE.md](../CLAUDE.md) for the full list of PreToolUse / PostToolUse / Stop hooks under `ci/hooks/`.
+
+## See also
+
+- [../CLAUDE.md](../CLAUDE.md) — project rules and essential commands
+- [../crates/CLAUDE.md](../crates/CLAUDE.md) — crate dependency graph and boundaries
+- [architecture/overview.md](architecture/overview.md) — system architecture
+- [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md) — ADR-style decisions

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,38 @@
+# Documentation Index
+
+A grep-friendly FAQ that maps common questions to the file that answers them. Both humans and LLM agents should use this table as the entry point into the fbuild docs.
+
+| Question                                                  | File                                                       |
+|-----------------------------------------------------------|------------------------------------------------------------|
+| How do I install fbuild?                                  | [../README.md](../README.md#installation)                  |
+| How do I run my first build / deploy / monitor?           | [../README.md](../README.md#quick-start)                   |
+| What does `platformio.ini` need to contain?               | [../README.md](../README.md#configuration)                 |
+| Why does fbuild exist?                                    | [WHY.md](WHY.md)                                           |
+| What are fbuild's key benefits and performance numbers?   | [WHY.md](WHY.md#key-benefits)                              |
+| Is my board supported?                                    | [BOARD_STATUS.md](BOARD_STATUS.md)                         |
+| How do I add a new board?                                  | [BOARD_STATUS.md](BOARD_STATUS.md#adding-a-new-board)      |
+| What's the crate dependency graph?                        | [../crates/CLAUDE.md](../crates/CLAUDE.md)                 |
+| How does fbuild's architecture fit together?              | [architecture/overview.md](architecture/overview.md)       |
+| How does the daemon work?                                 | [architecture/runtime.md](architecture/runtime.md)         |
+| How does the serial / monitor subsystem work?             | [architecture/serial.md](architecture/serial.md)           |
+| How do the PyO3 Python bindings work?                     | [architecture/pyo3-bindings.md](architecture/pyo3-bindings.md) |
+| How does deploy preemption work?                          | [architecture/deploy-preemption.md](architecture/deploy-preemption.md) |
+| What are the cross-platform portability constraints?      | [architecture/portability.md](architecture/portability.md) |
+| Why did we choose X over Y?                               | [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md)                 |
+| What's on the implementation roadmap?                     | [ROADMAP.md](ROADMAP.md)                                   |
+| How do I run tests / lint / fmt?                          | [DEVELOPMENT.md](DEVELOPMENT.md#testing)                   |
+| Why is my build failing?                                  | [DEVELOPMENT.md](DEVELOPMENT.md#troubleshooting)           |
+| How do I use the emulator (QEMU / avr8js / simavr)?       | [../README.md](../README.md#emulator-testing)              |
+| What architecture docs should I read for a given crate?   | [CLAUDE.md](CLAUDE.md)                                     |
+
+## Conventions
+
+- The top-level `README.md` is the install + Quick Start entry point for humans.
+- `CLAUDE.md` at the repo root is the LLM-entry file; `docs/CLAUDE.md` is the LLM map into architecture docs.
+- Architecture docs live under `docs/architecture/`, one file per subsystem.
+- ADR-style decisions go in `docs/DESIGN_DECISIONS.md`.
+- Per-directory `README.md` files are enforced by a pre-commit hook — every directory with files needs one.
+
+## Keeping this index current
+
+When a new doc is added under `docs/`, add a row to the table above. Prefer one FAQ-style question per row so readers can grep for the question they have.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,12 @@ Architecture and design documentation for the fbuild project.
 
 ## Contents
 
+- **`INDEX.md`** -- FAQ-style index mapping questions to files (start here)
 - **`ARCHITECTURE.md`** -- Index of all architecture documents
 - **`CLAUDE.md`** -- Guide mapping crates to relevant architecture docs
+- **`WHY.md`** -- Why fbuild exists, key benefits, performance benchmarks
+- **`BOARD_STATUS.md`** -- Per-platform CI badges and supported boards
+- **`DEVELOPMENT.md`** -- Testing, troubleshooting, local development setup
 - **`DESIGN_DECISIONS.md`** -- ADR-style decisions with rationale
 - **`ROADMAP.md`** -- Implementation phases for the Rust port
 - **`architecture/`** -- Subsystem-specific architecture documents

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -1,0 +1,67 @@
+# Why fbuild?
+
+## Key Benefits
+
+### Transparency
+Direct URLs and hash-based caching mean you know exactly what you're downloading. No hidden package registries or opaque dependency resolution.
+
+### Reliability
+Real downloads with checksum verification ensure consistent, reproducible builds. No mocks in production code.
+
+### Speed
+Optimized incremental builds complete in under 1 second, with intelligent caching for full rebuilds in 2-5 seconds.
+
+### Code Quality
+100% type-safe (mypy), PEP 8 compliant, and comprehensive test coverage ensure a maintainable and reliable codebase.
+
+### Clear Error Messages
+Actionable error messages with suggestions help you quickly identify and fix issues without requiring forum searches.
+
+## Performance
+
+**Benchmarks** (Arduino Uno Blink sketch):
+
+| Build Type | Time | Description |
+|------------|------|-------------|
+| First build | 19.25s | Includes toolchain download (50MB) |
+| Full build | 3.06s | All packages cached |
+| Incremental | 0.76s | No source changes |
+| Clean build | 2.58s | Rebuild from cache |
+
+**Firmware Size** (Blink):
+- Program: 1,058 bytes (3.3% of 32KB flash)
+- RAM: 9 bytes (0.4% of 2KB RAM)
+
+## Why fbuild exists
+
+Both the Arduino CLI and PlatformIO build chains have lagged in their development. While PlatformIO represented a meaningful improvement over the original Arduino build system, it continues to exhibit significant architectural and reliability issues that have remained unresolved despite repeated community reports.
+
+One persistent problem is PlatformIO's tendency to corrupt its own global installation state. In practice, this often requires users to manually delete `~/.platformio/packages` to restore functionality. This behavior is particularly harmful to new developers, as the failure mode is opaque and recovery is undocumented. In addition, PlatformIO's package management is frequently slow and unreliable: large toolchains for modern targets (e.g., ESP, STM, Raspberry Pi-class boards) are regularly invalidated and re-downloaded in full, sometimes consuming multiple gigabytes of bandwidth. Even trivial changes to `platformio.ini`—including non-functional edits such as comments—can trigger a full revalidation and reinstall cycle, especially when using the VS Code extension with autosave enabled. This makes the development experience unpredictable and fragile.
+
+More critically, both Arduino CLI and PlatformIO fail to reliably enable essential compiler and linker features for embedded systems, most notably `--gc-sections` and link-time optimization (LTO). These features are fundamental for producing minimal binaries on memory-constrained devices, as they allow dead code elimination and cross–translation unit optimization. Their absence leads to substantial binary bloat. For FastLED, this limitation persisted for years and forced the project to rely on aggressive inlining strategies as a workaround—an approach that increases compile times and code complexity while still falling short of what proper LTO provides.
+
+Compounding these technical issues, conflicts between PlatformIO and Espressif resulted in incomplete or delayed support for newer ESP targets. Boards such as the ESP32-C2, C5, and C6 required external workaround repositories to function correctly with the IDF v5 toolchain, despite being officially supported by the vendor. This further increased maintenance burden and slowed development.
+
+Collectively, these issues cost the FastLED project months of developer time. PlatformIO serves as FastLED's testing infrastructure, and repeated build failures, slow installs, and corrupted environments significantly reduced iteration speed. To enable concurrent builds and isolate failures, FastLED ultimately resorted to encapsulating the entire build chain inside Docker containers—solely to sandbox PlatformIO's global state and avoid cross-contamination between builds.
+
+FastLED attempted to address these shortcomings through feature requests and pull requests to PlatformIO; all were declined. Meanwhile, emerging low-cost, high-capability platforms—such as CH-series RISC-V microcontrollers, which are cheaper and more powerful than legacy ATtiny-class devices—remain effectively inaccessible under these legacy build systems.
+
+Given this landscape, the cost to FastLED developers became untenable. It proved more efficient to rebuild the entire compile and deployment stack from first principles. The result is **fbuild**, the FastLED build system. With fbuild, builds are deterministic, fast, and scalable, and advanced compiler and linker features such as LTO can finally be enabled—both for modern targets and retroactively for legacy platforms where the tooling has supported them in theory for over a decade but failed to use them in practice.
+
+## Design Goals
+
+- Replaces `platformio` in `FastLED` repo builders
+- Correct and blazing parallel package management system
+  - locking is done through a daemon process
+  - packages are fingerprinted to their version and cached, download only once
+  - zccache for caching compiles
+- Easily add features via AI
+  - This codebase is designed and implemented by AI; fork it and ask AI to make your change. Please send us a PR!
+- Supports new build chains easily
+- Supports wasm builds natively
+
+## See also
+
+- [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md) — ADR-style decisions with rationale
+- [architecture/overview.md](architecture/overview.md) — system architecture
+- [ROADMAP.md](ROADMAP.md) — implementation phases


### PR DESCRIPTION
## Summary

Closes #81. Splits the 1201-line top-level `README.md` into a lean entry point (361 lines) that leads with install + Quick Start, and moves the long-form content into decentralized docs under `docs/`.

- **`docs/BOARD_STATUS.md`** — per-platform CI badges + family deep-dives (formerly lines 19–109 + the per-family `<details>` blocks)
- **`docs/WHY.md`** — `## Key Benefits`, `## Performance`, `# Why`, and design goals
- **`docs/DEVELOPMENT.md`** — `## Testing`, `## Troubleshooting`, `## Development`
- **`docs/INDEX.md`** — new FAQ-style table (~20 rows) mapping questions to files; cross-referenced from `docs/CLAUDE.md` so the LLM path and human path converge
- **Project Structure** section now links to the canonical `crates/CLAUDE.md`
- **Architecture** ASCII is replaced with a link to `docs/architecture/` (no duplication)

No content was lost — every section removed from the README lives under `docs/` and is reachable from `docs/INDEX.md`.

### Intentionally skipped from the issue
- `docs-maintainer` skill / `/docs` agent (nice-to-have, deferred)
- `lychee` markdown-link checker in CI (deferred)

## Test plan

- [x] `uv run cargo check --workspace --all-targets` — clean
- [x] README is under 400 lines (361)
- [x] Every section removed from README is reachable from `docs/INDEX.md`
- [x] `docs/CLAUDE.md` cross-references `docs/INDEX.md`
- [ ] CI green on PR

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README with improved installation and quick-start guidance, including platform-specific examples.
  * Added new documentation index for easier navigation across all project docs.
  * Consolidated CI build status badges and supported platform information into dedicated reference page.
  * Added developer workflow guide covering testing, setup, and troubleshooting.
  * New FAQ-style documentation entry point for common questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->