### PR TITLE
fix(python): remove stale _native extension from repo (#75)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,16 @@ __pycache__/
 dist/
 build/
 
+# PyO3 native extension — built locally from crates/fbuild-python via
+# `uv run cargo build --release -p fbuild-python --features extension-module`,
+# then copied into python/fbuild/. Never commit these binaries: they go stale
+# relative to crates/fbuild-python/src/lib.rs and break Python tests with
+# ModuleNotFoundError / AttributeError. CI rebuilds them on every publish.
+python/fbuild/_native.pyd
+python/fbuild/_native.abi3.so
+python/fbuild/_native.so
+python/fbuild/_native.dylib
+
 # VSCode extension build artifacts
 vscode-fbuild/out/
 vscode-fbuild/node_modules/

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -118,6 +118,24 @@ uv run python ci/build_dist.py --ref main
 ./publish
 ```
 
+### Python / PyO3 extension
+
+The `fbuild` Python package wraps a Rust PyO3 extension built from `crates/fbuild-python`. The compiled binary (`python/fbuild/_native.{pyd,abi3.so,so,dylib}`) is **not** checked into the repo — it must be rebuilt whenever `crates/fbuild-python/src/lib.rs` changes, otherwise tests that import `fbuild._native` fail with `ModuleNotFoundError` or `AttributeError`.
+
+```bash
+# Build the extension and copy it into the Python package
+uv run cargo build --release -p fbuild-python --features extension-module
+
+# Windows
+cp target/release/_native.dll python/fbuild/_native.pyd
+# Linux
+cp target/release/lib_native.so python/fbuild/_native.abi3.so
+# macOS
+cp target/release/lib_native.dylib python/fbuild/_native.abi3.so
+```
+
+See [`../python/README.md`](../python/README.md) for more detail. PyPI wheels are assembled by `ci/publish.py` using native binaries built in GitHub Actions — this local step only affects in-tree Python tests and scripts.
+
 ### Hooks (enforced automatically)
 
 See the root [CLAUDE.md](../CLAUDE.md) for the full list of PreToolUse / PostToolUse / Stop hooks under `ci/hooks/`.

--- a/python/README.md
+++ b/python/README.md
@@ -6,4 +6,27 @@ Thin Python wrapper modules that re-export classes from the Rust `_native` exten
 
 - **`fbuild/`** -- Top-level package re-exporting `Daemon`, `DaemonConnection`, `connect_daemon`, and `__version__`
 - **`fbuild/api/`** -- Public serial-monitoring API re-exporting `SerialMonitor`
-- **`fbuild/_native.pyd`** -- Compiled Rust PyO3 extension (platform-specific binary)
+- **`fbuild/_native.{pyd,abi3.so,so,dylib}`** -- Compiled Rust PyO3 extension (platform-specific binary, gitignored — see below)
+
+## Building the native extension locally
+
+The `_native` extension is **not** checked into the repo — it would go stale relative to `crates/fbuild-python/src/lib.rs`. Build it locally before running any Python test or script that imports `fbuild._native`:
+
+```bash
+# 1. Compile the PyO3 extension
+uv run cargo build --release -p fbuild-python --features extension-module
+
+# 2. Copy into python/fbuild/ (platform-specific extension name).
+#    Rustup may place output under target/<triple>/release/ on some hosts —
+#    adjust the source path if target/release/ does not contain the artifact.
+#
+#    Windows:
+cp target/release/_native.dll python/fbuild/_native.pyd \
+  || cp target/x86_64-pc-windows-msvc/release/_native.dll python/fbuild/_native.pyd
+#    Linux:
+cp target/release/lib_native.so python/fbuild/_native.abi3.so
+#    macOS:
+cp target/release/lib_native.dylib python/fbuild/_native.abi3.so
+```
+
+Rebuild whenever `crates/fbuild-python/src/lib.rs` (or any crate it depends on) changes. Published PyPI wheels are assembled by `ci/publish.py` using native binaries built in GitHub Actions, so this local step only affects in-tree Python tests.

--- a/python/fbuild/README.md
+++ b/python/fbuild/README.md
@@ -5,5 +5,5 @@ Top-level Python package that re-exports Rust PyO3 classes, providing a drop-in 
 ## Modules
 
 - **`__init__.py`** -- Re-exports `Daemon`, `DaemonConnection`, `connect_daemon`, and `__version__` from `_native`
-- **`_native.pyd`** -- Compiled Rust extension built by the `fbuild-python` crate (not edited directly)
+- **`_native.{pyd,abi3.so,so,dylib}`** -- Compiled Rust extension built by the `fbuild-python` crate (not checked into the repo — build locally; see [../README.md](../README.md))
 - **`api/`** -- Sub-package exposing `SerialMonitor` for serial port monitoring


### PR DESCRIPTION
## Summary

- Removes `python/fbuild/_native.pyd`, a checked-in PyO3 extension that went stale against `crates/fbuild-python/src/lib.rs` and caused `AttributeError: SerialMonitor.reset_device` when running Python tests that import `fbuild._native`.
- Adds `python/fbuild/_native.{pyd,abi3.so,so,dylib}` to `.gitignore` so a freshly-built artifact cannot be accidentally re-committed.
- Documents the local build step in the top-level README (under Development) and in `python/README.md` / `python/fbuild/README.md`:
  ```bash
  uv run cargo build --release -p fbuild-python --features extension-module
  # then copy target/release/_native.{dll,so,dylib} -> python/fbuild/_native.{pyd,abi3.so}
  ```

Published PyPI wheels are unaffected — `ci/publish.py` already pulls fresh per-platform extensions from the `build.yml` GitHub Actions run. The committed binary was only ever used for local in-tree Python tests.

Fixes #75.

## Test plan

- [x] `uv run cargo build --release -p fbuild-python --features extension-module` succeeds
- [x] After copying the fresh artifact to `python/fbuild/_native.pyd`, `from fbuild._native import SerialMonitor` exposes `reset_device` (previously missing on the stale binary)
- [x] `git check-ignore python/fbuild/_native.pyd` matches the new `.gitignore` entry
- [ ] CI: `build.yml` still produces `_native.pyd` / `_native.abi3.so` artifacts (workflow unchanged)
- [ ] CI: `./publish` wheel assembly still finds the extensions (publish.py unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added local build instructions for the Python native extension with platform-specific guidance (Windows, Linux, macOS)
  * Clarified that compiled extensions are not version-controlled and must be rebuilt locally when source changes occur

* **Chores**
  * Added patterns to .gitignore for platform-specific native extension artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->