### PR TITLE
fix(daemon): set SO_LINGER 0 on accepted sockets to avoid CLOSE_WAIT leaks (partial #32)

### DIFF
--- a/crates/fbuild-daemon/src/main.rs
+++ b/crates/fbuild-daemon/src/main.rs
@@ -407,6 +407,17 @@ fn is_pid_alive(pid: u32) -> bool {
 ///   so it's safe there but not on Windows). See ISSUES.md "Issue B5a".
 /// * **Unix** — sets `SO_REUSEADDR`, which only permits `TIME_WAIT`
 ///   recovery on this OS family.
+/// * **All platforms** — sets `SO_LINGER = 0` on the listening socket so
+///   that accepted client sockets inherit a zero linger and force an
+///   immediate `RST` on close instead of going through the
+///   `FIN / CLOSE_WAIT / TIME_WAIT` dance. After a hard-kill of the
+///   daemon, this prevents the kernel from leaking dangling `CLOSE_WAIT`
+///   state on client sockets that outlives the daemon itself and would
+///   otherwise block a fresh instance from re-binding the port. SO_LINGER
+///   is inherited from the listener by `accept(2)` on Linux, macOS, and
+///   Windows (AFD.sys), so setting it once on the listener covers every
+///   subsequently accepted connection without needing to hook axum 0.7's
+///   internal accept loop. See FastLED/fbuild#32.
 ///
 /// Bind is retried up to 3 times with 500 ms backoff to handle the brief
 /// window where a hard-killed previous instance still has kernel TCP
@@ -441,6 +452,13 @@ fn bind_listener_with_retry(addr: &str) -> tokio::net::TcpListener {
             if let Err(e) = sock.set_reuse_address(true) {
                 tracing::warn!("failed to set SO_REUSEADDR: {}", e);
             }
+        }
+
+        // Force RST on close for accepted client sockets — inherited via
+        // `accept(2)` on Linux/macOS/Windows. See doc comment above and
+        // FastLED/fbuild#32.
+        if let Err(e) = sock.set_linger(Some(std::time::Duration::ZERO)) {
+            tracing::warn!("failed to set SO_LINGER=0 on listener: {}", e);
         }
 
         if let Err(e) = sock.set_nonblocking(true) {


### PR DESCRIPTION
## Summary

- Set `SO_LINGER=0` on the daemon's listening socket before `listen(2)` so accepted client sockets inherit a zero linger and force an immediate `RST` on close instead of going through `FIN / CLOSE_WAIT / TIME_WAIT`.
- After a hard-kill of the daemon, this prevents the kernel from leaking dangling `CLOSE_WAIT` state on client sockets that outlives the daemon itself and would otherwise block a fresh instance from re-binding the port.
- Minimal (18-line) change inside the existing `bind_listener_with_retry` path.

## Why listener-inheritance (and not a custom accept loop)

`axum::serve` in axum 0.7 owns the accept loop inside its `IntoFuture` impl and hands each accepted `TcpStream` straight to `hyper-util` with no per-connection hook. Replacing that loop means reimplementing graceful shutdown + `serve_connection_with_upgrades` plumbing.

`SO_LINGER` is inherited by `accept(2)` from the listening socket on all three target platforms (Linux `sock_copy`, macOS/BSD `sonewconn`, Windows AFD.sys). Setting it once on the listener covers every accepted connection and keeps the change surgical. Axum 0.8's `Listener` trait would allow a cleaner per-connection hook; we can revisit when we upgrade.

## Test plan

- [x] `uv run cargo test -p fbuild-daemon --test port_recovery -- --ignored` passes (hard-kills a daemon holding an open TCP connection, then asserts a second daemon re-binds the port cleanly).
- [x] `uv run cargo check --workspace --all-targets` clean.
- [x] `uv run cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `uv run cargo fmt --all -- --check` clean.

## Remaining on #32

- [ ] Process containment via the `running-process` crate (Windows Job Object kill-on-close + POSIX process group / Linux parent-death). Still open; intentionally deferred to a separate PR since it touches every subprocess spawn site.
- [x] SO_LINGER 0 on accepted sockets (this PR)
- [x] `SetConsoleCtrlHandler` for Windows CTRL_CLOSE / LOGOFF / SHUTDOWN (already merged in PR #61)

Closes: no (partial progress only). Tracking stays on #32 until process containment lands.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)