### PR TITLE
docs(board-status): collapse CI badge matrix behind <details>

### DIFF
--- a/docs/BOARD_STATUS.md
+++ b/docs/BOARD_STATUS.md
@@ -4,6 +4,9 @@ Live per-platform CI status and supported-board reference for fbuild.
 
 ## Per-platform CI badges
 
+<details>
+<summary>Expand CI badge matrix</summary>
+
 ### AVR
 [![Build Arduino Uno](https://github.com/fastled/fbuild/actions/workflows/build-uno.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-uno.yml)
 [![Build Leonardo](https://github.com/fastled/fbuild/actions/workflows/build-leonardo.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-leonardo.yml)
@@ -96,6 +99,8 @@ Live per-platform CI status and supported-board reference for fbuild.
 
 ### Silicon Labs
 [![Build SparkFun Thing Plus Matter](https://github.com/fastled/fbuild/actions/workflows/build-thingplusmatter.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-thingplusmatter.yml)
+
+</details>
 
 ## Supported platforms and boards
 


### PR DESCRIPTION
## Summary
- Wrap the per-platform CI badge matrix in `docs/BOARD_STATUS.md` inside a `<details><summary>Expand CI badge matrix</summary>` block so it is hidden by default.
- Keeps the page short when readers are scrolling to the supported-platforms reference further down.

Closes #93.

## Test plan
- [ ] Render `docs/BOARD_STATUS.md` on github.com and confirm the badge matrix is collapsed by default and expands/collapses correctly.
- [ ] Confirm inner `###` family headings still render inside the `<details>` group (blank line after `<summary>` preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * CI badge matrix is now collapsible, hidden by default behind an expandable control for improved readability of the board status documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->