### PR TITLE
perf(cli): strip Windows handle inheritance + fast daemon health probe (partial #91)

### DIFF
--- a/crates/fbuild-cli/src/daemon_client.rs
+++ b/crates/fbuild-cli/src/daemon_client.rs
@@ -380,9 +380,17 @@ pub struct DaemonClient {
 
 impl DaemonClient {
     pub fn new() -> Self {
+        // 100ms connect_timeout fails fast when the daemon is not running
+        // (ECONNREFUSED returns instantly on Windows and Linux but reqwest
+        // would otherwise wait for the full request timeout before surfacing
+        // the error).
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_millis(100))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         Self {
             base_url: fbuild_paths::get_daemon_url(),
-            client: reqwest::Client::new(),
+            client,
         }
     }
 
@@ -889,6 +897,16 @@ async fn spawn_daemon_process() -> fbuild_core::Result<()> {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::from(log_file));
 
+    // On Windows, any inheritable handle in our process — including the shell's
+    // stderr pipe — flows into the daemon grandchild via bInheritHandles=TRUE
+    // in CreateProcess. The daemon holds that pipe open for SELF_EVICTION_TIMEOUT
+    // (120s), blocking the shell from unblocking even after the CLI exits. Strip
+    // HANDLE_FLAG_INHERIT from our std handles before spawn so Rust's plumbing
+    // only passes through the explicit Stdio handles it configured above.
+    // See issue #91.
+    #[cfg(windows)]
+    strip_std_handle_inheritance();
+
     cmd.spawn().map_err(|e| {
         fbuild_core::FbuildError::DaemonError(format!(
             "failed to spawn daemon (is fbuild-daemon in PATH?): {}",
@@ -897,6 +915,39 @@ async fn spawn_daemon_process() -> fbuild_core::Result<()> {
     })?;
 
     Ok(())
+}
+
+/// Clear `HANDLE_FLAG_INHERIT` on the CLI's STD_INPUT/OUTPUT/ERROR handles.
+///
+/// Called immediately before spawning the daemon so the parent shell's pipes
+/// (attached to our stderr via `|`, `2>&1`, etc.) are not inherited by the
+/// long-lived daemon grandchild.
+#[cfg(windows)]
+fn strip_std_handle_inheritance() {
+    use std::ffi::c_void;
+
+    const HANDLE_FLAG_INHERIT: u32 = 0x1;
+    const STD_INPUT_HANDLE: u32 = -10i32 as u32;
+    const STD_OUTPUT_HANDLE: u32 = -11i32 as u32;
+    const STD_ERROR_HANDLE: u32 = -12i32 as u32;
+    const INVALID_HANDLE_VALUE: isize = -1;
+
+    unsafe extern "system" {
+        fn GetStdHandle(nStdHandle: u32) -> *mut c_void;
+        fn SetHandleInformation(hObject: *mut c_void, dwMask: u32, dwFlags: u32) -> i32;
+    }
+
+    for std_id in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+        // SAFETY: GetStdHandle / SetHandleInformation are documented safe for
+        // concurrent use on owned std handles. We only clear a flag on handles
+        // the OS already owns on our behalf; we do not close them.
+        unsafe {
+            let h = GetStdHandle(std_id);
+            if !h.is_null() && (h as isize) != INVALID_HANDLE_VALUE {
+                SetHandleInformation(h, HANDLE_FLAG_INHERIT, 0);
+            }
+        }
+    }
 }
 
 /// Display compact daemon status line before every command (matches Python behavior).


### PR DESCRIPTION
## Summary

Two targeted warm-path fixes identified in the #91 profiling report. Both live in `crates/fbuild-cli/src/daemon_client.rs`.

### F1 — Strip `HANDLE_FLAG_INHERIT` from CLI stdio before spawning daemon

`spawn_daemon_process` on Windows previously let the daemon grandchild inherit every inheritable handle in the CLI — including the parent shell's stderr pipe (attached via `|`, `2>&1`, or PowerShell's default pipeline). The daemon holds that pipe open for `SELF_EVICTION_TIMEOUT` = 120 s, so the shell stays blocked until that timer fires even after the CLI's `main()` has returned.

Reproducibly visible as a ~125 s stall in PowerShell; adding `2>$null` (PS) or `2>/dev/null` (bash) eliminates the stall and drops total to ~4 s. Exact match to the 120 s eviction timeout was the smoking gun in #91's profiling.

Fix: call `SetHandleInformation(GetStdHandle(STD_*_HANDLE), HANDLE_FLAG_INHERIT, 0)` on the CLI's std handles immediately before `cmd.spawn()`. Rust's `Command` still duplicates the explicit `Stdio` handles it configured (null/null/log_file) as inheritable for the daemon, so stderr-to-log-file redirection is preserved; only the shell-owned pipe is stripped. Uses a tiny `extern "system"` FFI block — no new crate dependencies.

### F2 — 100ms `connect_timeout` on `DaemonClient`

When the daemon is not running, TCP connect refusal returns instantly (<1 ms, verified with `Test-NetConnection`). reqwest's per-request `.timeout(2s)` would nevertheless wait the full 2 s before surfacing `ECONNREFUSED`. `DaemonClient::new()` is called from two sites (`display_daemon_stats_compact` + `ensure_daemon_running`), so the cold path eats 4 s before any work starts.

Fix: build the shared client with `ClientBuilder::connect_timeout(Duration::from_millis(100))`.

## Measured

| Scenario | Before | After |
|---|---:|---:|
| `fbuild daemon status` (daemon not running, bash) | 4.0 s | 0.28 s |
| `fbuild build ...` warm in PowerShell w/ attached stderr | ~125 s | *expected ~2 s — live verification pending; needs hands-on PowerShell session* |

## Test plan

- [x] `uv run cargo build -p fbuild-cli --release` clean.
- [x] `uv run cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `uv run cargo test -p fbuild-cli` — 9/9 pass.
- [x] F2 empirically verified: cold `daemon status` 4.0 s → 0.28 s.
- [ ] F1 empirically verified in PowerShell with the 125 s reproducer (needs a non-busy daemon; please verify on merge).

## Scope

- Defers F3 (`display_daemon_stats_compact` dedupe) and F4 (`SELF_EVICTION_TIMEOUT` 120 s → 30 s) from the #91 report; both are independent cleanups best filed as follow-ups after this lands.

## Related

- Partial #91 (warm-pass 30 s stall investigation — the root causes F1/F2 address are described in the comment thread and `tasks/issue-91-report.md`).