### PR TITLE
fix(test): relax dev_mode_port assertion to match function contract (closes #88)

### DIFF
--- a/crates/fbuild-paths/src/lib.rs
+++ b/crates/fbuild-paths/src/lib.rs
@@ -224,10 +224,12 @@ mod tests {
 
     #[test]
     fn dev_mode_port() {
-        // Note: can't set env vars in parallel tests safely,
-        // so just test the function exists and returns a valid port
+        // Note: can't set env vars in parallel tests safely, and the
+        // function's own priority chain (env var > current-mode port file >
+        // other-mode port file > mode-default) legitimately returns any
+        // u16 > 0. Assert only the contract the function actually promises.
         let port = get_daemon_port();
-        assert!(port == 8765 || port == 8865);
+        assert!(port > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`get_daemon_port()` documents a four-priority chain (env var → current-mode port file → other-mode port file → mode-default). The test asserted only outcome (4), so any legitimately present port file on disk (e.g., from a past daemon run that wrote `18900` before crashing) breaks the test. Relax the assertion to `port > 0` — the actual contract the function promises.

Encountered during the session that produced #91; observed with a real `18900` port file that triggered `assertion failed: port == 8765 || port == 8865`.

## Test plan

- [x] `uv run cargo test -p fbuild-paths --lib dev_mode_port` — passes.
- [x] Passes equally with a stale port file on disk or none.