### PR TITLE
feat(ci): reusable FastLED/fbuild/setup composite action (closes #101)

### DIFF
--- a/.github/actions/setup/README.md
+++ b/.github/actions/setup/README.md
@@ -1,0 +1,95 @@
+# `FastLED/fbuild/setup` — composite GitHub Action
+
+One-line fbuild setup for consumer CI pipelines. Installs fbuild, wires `actions/cache@v4` with sensible defaults, and exports `FBUILD_CACHE_DIR` so subsequent steps Just Work.
+
+For the underlying cache design (what's cached, why, and how to tune the key for your project) see [`../../docs/CI_CACHING.md`](../../../docs/CI_CACHING.md).
+
+## Minimal usage
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: FastLED/fbuild/.github/actions/setup@main
+        with:
+          cache-key-extra: ${{ hashFiles('platformio.ini') }}
+      - run: fbuild build examples/Blink -e esp32dev
+```
+
+## Full matrix example
+
+```yaml
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        board: [uno, esp32dev, esp32s3, teensy41]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: FastLED/fbuild/.github/actions/setup@main
+        id: fbuild
+        with:
+          cache-key-extra: ${{ matrix.board }}-${{ hashFiles('platformio.ini') }}
+
+      - run: fbuild build examples/Blink -e ${{ matrix.board }}
+
+      - name: Second build should be a near-no-op (smoke test cache warmth)
+        shell: bash
+        run: |
+          start=$SECONDS
+          fbuild build examples/Blink -e ${{ matrix.board }}
+          elapsed=$((SECONDS - start))
+          echo "second-build elapsed: ${elapsed}s"
+          test "$elapsed" -lt 15 || {
+            echo "::error::cache restore did not produce a warm build (took ${elapsed}s)"
+            exit 1
+          }
+```
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `fbuild-version` | `latest` | PyPI version spec. Pin to an exact version (`2.1.16`) for reproducible CI. |
+| `python-version` | `3.12` | Python used to install fbuild. Must be ≥ 3.9. |
+| `cache` | `true` | Set to `false` to install fbuild without wiring `actions/cache`. |
+| `cache-key-extra` | `""` | String baked into the cache key. Use `hashFiles(...)` over your graph inputs so edits invalidate stale artifacts. |
+| `cache-version` | `v1` | Manual cache bump. Increment when you want to force-invalidate across your matrix. |
+| `cache-dir` | `$RUNNER_TEMP/fbuild-cache` | Override if you need a different cache root. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `cache-hit` | `true` if the cache was restored from a previous run, `false` on miss. |
+| `cache-dir` | Resolved cache directory path. Useful for diagnostic steps. |
+
+## What this action does
+
+1. Sets up Python.
+2. Resolves a stable cache directory under `$RUNNER_TEMP` (survives across steps of the same job; not a surprise `$HOME` path).
+3. Exports `FBUILD_CACHE_DIR` via `$GITHUB_ENV` so every later step inherits it.
+4. Installs fbuild from PyPI at the requested version.
+5. Restores (and on job-end, saves) the cache via `actions/cache@v4`.
+
+It does **not** cache `~/.fbuild/*/daemon/` — that's ephemeral runtime state and restoring it across runs causes broken daemon discovery on the next client call. The action sidesteps the whole `~/.fbuild/` tree by redirecting fbuild's cache to `$RUNNER_TEMP/fbuild-cache` via `FBUILD_CACHE_DIR`.
+
+## Version pinning
+
+For reproducible CI, reference a release tag rather than `@main`:
+
+```yaml
+- uses: FastLED/fbuild/.github/actions/setup@v1
+```
+
+At time of writing there is no `v1` tag — use `@main` and pin `fbuild-version` to an explicit PyPI version if reproducibility matters.
+
+## Related
+
+- [`docs/CI_CACHING.md`](../../../docs/CI_CACHING.md) — detailed design of the underlying cache, plus raw `actions/cache@v4` snippets for consumers who prefer to avoid the action dependency.
+- [#101](https://github.com/FastLED/fbuild/issues/101) — the issue that tracked creation of this action.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,90 @@
+name: "Set up fbuild"
+description: "Install fbuild and configure its cache for save/restore across CI runs."
+author: "FastLED"
+branding:
+  icon: "zap"
+  color: "yellow"
+
+inputs:
+  fbuild-version:
+    description: "fbuild version to install from PyPI. 'latest' pulls the newest release."
+    required: false
+    default: "latest"
+  python-version:
+    description: "Python version used to install fbuild. Must be >= 3.9."
+    required: false
+    default: "3.12"
+  cache:
+    description: "Whether to save/restore the fbuild cache via actions/cache. Set to 'false' to skip caching (install only)."
+    required: false
+    default: "true"
+  cache-key-extra:
+    description: "Extra string baked into the cache key. Typically hashFiles('platformio.ini', ...) so graph-input changes invalidate stale artifacts."
+    required: false
+    default: ""
+  cache-version:
+    description: "Manual bump to force-invalidate the cache without changing any inputs. Increment this string (or bump in a workflow env) when cache needs busting."
+    required: false
+    default: "v1"
+  cache-dir:
+    description: "Override the cache directory. Default: $RUNNER_TEMP/fbuild-cache (runner-stable, survives across steps of the same job)."
+    required: false
+    default: ""
+
+outputs:
+  cache-hit:
+    description: "true if the fbuild cache was restored from a previous run, false on miss."
+    value: ${{ steps.fbuild-cache.outputs.cache-hit }}
+  cache-dir:
+    description: "Resolved cache directory path (useful for diagnostic steps)."
+    value: ${{ steps.resolve-paths.outputs.cache-dir }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Resolve cache directory and fbuild install target
+      id: resolve-paths
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [ -n "${{ inputs.cache-dir }}" ]; then
+          CACHE_DIR="${{ inputs.cache-dir }}"
+        else
+          CACHE_DIR="${RUNNER_TEMP}/fbuild-cache"
+        fi
+        mkdir -p "$CACHE_DIR"
+
+        # Exported for every subsequent step in the user's job.
+        echo "FBUILD_CACHE_DIR=$CACHE_DIR" >> "$GITHUB_ENV"
+        echo "cache-dir=$CACHE_DIR" >> "$GITHUB_OUTPUT"
+
+        if [ "${{ inputs.fbuild-version }}" = "latest" ]; then
+          echo "pip-spec=fbuild" >> "$GITHUB_OUTPUT"
+        else
+          echo "pip-spec=fbuild==${{ inputs.fbuild-version }}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install fbuild
+      shell: bash
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade pip
+        python -m pip install '${{ steps.resolve-paths.outputs.pip-spec }}'
+        fbuild --version || echo "fbuild --version not yet supported on this release" >&2
+
+    - name: Restore fbuild cache
+      if: ${{ inputs.cache == 'true' }}
+      id: fbuild-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.resolve-paths.outputs.cache-dir }}
+        key: fbuild-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-key-extra }}
+        restore-keys: |
+          fbuild-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-
+          fbuild-${{ inputs.cache-version }}-${{ runner.os }}-

--- a/docs/CI_CACHING.md
+++ b/docs/CI_CACHING.md
@@ -8,7 +8,20 @@ For the *local* developer experience see [DEVELOPMENT.md](DEVELOPMENT.md). For *
 
 ---
 
-## TL;DR — drop-in GitHub Actions snippet
+## TL;DR — use the composite action
+
+Most consumers should use the [`FastLED/fbuild/.github/actions/setup`](../.github/actions/setup/README.md) composite action — it handles fbuild install, cache restore/save, and env-var wiring in one line:
+
+```yaml
+- uses: FastLED/fbuild/.github/actions/setup@main
+  with:
+    cache-key-extra: ${{ hashFiles('platformio.ini') }}
+- run: fbuild build examples/Blink -e esp32dev
+```
+
+The action sidesteps the whole `~/.fbuild/*/daemon/` "don't cache ephemeral state" pitfall by redirecting fbuild's cache to `$RUNNER_TEMP/fbuild-cache` via `FBUILD_CACHE_DIR`. See the [action's README](../.github/actions/setup/README.md) for inputs/outputs and a full matrix example.
+
+### Raw snippet (if you don't want the action dependency)
 
 ```yaml
 - name: Restore fbuild cache


### PR DESCRIPTION
## Summary

Ships a composite GitHub Action that lets consumer CI pipelines wire fbuild + cache in one step:

\`\`\`yaml
- uses: FastLED/fbuild/.github/actions/setup@main
  with:
    cache-key-extra: \${{ hashFiles('platformio.ini') }}
- run: fbuild build examples/Blink -e esp32dev
\`\`\`

## What it does

1. \`actions/setup-python\` with a pinnable Python version (default 3.12).
2. Resolves \`FBUILD_CACHE_DIR\` to \`\$RUNNER_TEMP/fbuild-cache\` and exports via \`\$GITHUB_ENV\` so every later step inherits it.
3. \`pip install fbuild\` (pinnable via \`fbuild-version\` input).
4. \`actions/cache@v4\` restore/save keyed on OS/arch + cache-version + cache-key-extra + restore-key fallback.

Redirecting to \`\$RUNNER_TEMP\` sidesteps the \`~/.fbuild/*/daemon/\` gotcha from the cache doc — ephemeral daemon state never ends up inside the cached tree.

## Outputs

- \`cache-hit\` — bool, so consumers can assert warm-build behavior in a smoke step.
- \`cache-dir\` — resolved path for diagnostics.

## Doc update

\`docs/CI_CACHING.md\` TL;DR now recommends the action first; the raw \`actions/cache\` snippet is preserved below for consumers who prefer zero action dependencies.

## Follow-up

FastLED repo will switch its workflows to use this action in a companion PR (tracked in #101's \"Follow-up\" section).

## Test plan

- [x] YAML validates (GitHub schema).
- [x] README documents inputs, outputs, and a full matrix example with smoke-test cache assertion.
- [ ] End-to-end verification happens implicitly when FastLED's workflows adopt it — flagged in #101.