### PR TITLE
fix(test): relax dev_mode_port assertion to match get_daemon_port contract

### DIFF
--- a/crates/fbuild-paths/src/lib.rs
+++ b/crates/fbuild-paths/src/lib.rs
@@ -227,7 +227,7 @@ mod tests {
         // Note: can't set env vars in parallel tests safely,
         // so just test the function exists and returns a valid port
         let port = get_daemon_port();
-        assert!(port == 8765 || port == 8865);
+        assert!(port > 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #88.

`crates/fbuild-paths/src/lib.rs:230` asserted `port == 8765 || port == 8865`, but `get_daemon_port()` honors `FBUILD_DAEMON_PORT` env var and port-file entries — it can legitimately return any u16. Test was flaky whenever a stale port file existed (e.g. `~/.fbuild/prod/daemon/daemon.port` holding `18900`).

Relaxed to `assert!(port > 0)` to match the function's public contract. The in-source comment already stated the intent was "returns a valid port" — the strict assertion contradicted that.

## Test plan
- [x] `uv run cargo test -p fbuild-paths --lib dev_mode_port`
- [x] `uv run cargo test -p fbuild-paths` (9 passing)
- [x] `uv run cargo clippy --workspace --all-targets -- -D warnings`
- [x] `uv run cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)