### PR TITLE
perf(deploy): use espflash crate for write-flash (partial #66)

### DIFF
--- a/crates/fbuild-daemon/src/handlers/operations.rs
+++ b/crates/fbuild-daemon/src/handlers/operations.rs
@@ -33,6 +33,26 @@ pub(crate) fn native_verify_enabled() -> bool {
     }
 }
 
+/// Returns `true` when the daemon should route ESP32 `write-flash`
+/// through the native [`espflash`] crate (issue #66) instead of the
+/// Python `esptool` subprocess.
+///
+/// Controlled by the `FBUILD_USE_ESPFLASH_WRITE` environment variable
+/// (set to `1`, `true`, `yes`, or `on` to enable — case-insensitive).
+/// Independent of `FBUILD_USE_ESPFLASH_VERIFY` — either toggle can be
+/// flipped without the other. Default off so esptool remains the safe
+/// fallback while the native write path accumulates bench time across
+/// every ESP32 family member.
+pub(crate) fn native_write_enabled() -> bool {
+    match std::env::var("FBUILD_USE_ESPFLASH_WRITE") {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => false,
+    }
+}
+
 pub(crate) fn qemu_extra_build_flags(platform: fbuild_core::Platform, mcu: &str) -> Vec<String> {
     if platform == fbuild_core::Platform::Espressif32 && mcu.eq_ignore_ascii_case("esp32s3") {
         vec![
@@ -1090,10 +1110,16 @@ pub async fn deploy(
                 // Issue #66: opt-in native `verify-flash` via the
                 // `espflash` crate. Off by default so esptool remains
                 // the fallback path; set `FBUILD_USE_ESPFLASH_VERIFY=1`
-                // to route the verify pre-check (not write-flash)
-                // through espflash and skip the ~1.5 s Python subprocess
-                // cost.
+                // to route the verify pre-check through espflash and
+                // skip the ~1.5 s Python subprocess cost.
                 let deployer = deployer.with_native_verify(native_verify_enabled());
+                // Issue #66: opt-in native `write-flash` via the
+                // `espflash` crate. Independent of the verify toggle —
+                // set `FBUILD_USE_ESPFLASH_WRITE=1` to route write-flash
+                // through espflash. Default stays on esptool subprocess
+                // until the native write path has bench time on every
+                // ESP32 family member.
+                let deployer = deployer.with_native_write(native_write_enabled());
 
                 // Fast deploy: ask the device whether it already holds
                 // the exact firmware/bootloader/partitions we'd be about

--- a/crates/fbuild-deploy/README.md
+++ b/crates/fbuild-deploy/README.md
@@ -13,15 +13,17 @@ Firmware deployment to embedded devices via platform-specific upload tools (espt
 ## Modules
 
 - **esp32** -- `Esp32Deployer`, `EsptoolParams`; handles bootloader/partitions/firmware offsets per MCU
-- **esp32_native** -- native espflash-backed `verify-flash` (issue #66); opt-in via `FBUILD_USE_ESPFLASH_VERIFY=1`, falls back to esptool subprocess by default
+- **esp32_native** -- native espflash-backed `verify-flash` and `write-flash` (issue #66); opt-in via `FBUILD_USE_ESPFLASH_VERIFY=1` / `FBUILD_USE_ESPFLASH_WRITE=1` (independent toggles), falls back to esptool subprocess by default
 - **avr** -- `AvrDeployer`, `AvrdudeParams`; flashes firmware.hex via serial
 - **teensy** -- `TeensyDeployer`, `TeensyLoaderParams`; flashes firmware.hex via USB
 - **reset** -- `reset_device`, `detect_platform_for_reset`; DTR/RTS toggle sequences per platform
 
 Skip-redeploy is handled authoritatively by the daemon's device-side `verify-flash` pre-check (see `handlers/operations.rs`), which asks the ESP32 stub flasher for a per-region MD5 via `FLASH_MD5SUM` before writing. The previous client-side `FirmwareLedger` was removed (issue #18) because it could not detect flashes performed outside fbuild.
 
-### Native verify-flash (issue #66, opt-in)
+### Native verify-flash and write-flash (issue #66, opt-in)
 
-Setting `FBUILD_USE_ESPFLASH_VERIFY=1` routes the ESP32 verify pre-check through the native [`espflash`](https://crates.io/crates/espflash) crate instead of the Python `esptool` subprocess, avoiding ~1 s of interpreter startup and ~0.5 s of subprocess spawn per invocation. Write-flash still goes through esptool until a follow-up PR lands. The daemon pre-empts any active serial monitor via `SharedSerialManager::preempt_for_deploy` before opening the port, so the native path never contends with the existing lease.
+Setting `FBUILD_USE_ESPFLASH_VERIFY=1` routes the ESP32 verify pre-check through the native [`espflash`](https://crates.io/crates/espflash) crate instead of the Python `esptool` subprocess, avoiding ~1 s of interpreter startup and ~0.5 s of subprocess spawn per invocation. Setting `FBUILD_USE_ESPFLASH_WRITE=1` routes `write-flash` through the same in-process path — both the full deploy and the selective post-verify-mismatch rewrite. The two toggles are independent, so you can opt into native verify without native write (or vice versa). The daemon pre-empts any active serial monitor via `SharedSerialManager::preempt_for_deploy` before opening the port, so the native path never contends with the existing lease.
+
+Progress from espflash's `ProgressCallbacks` is bridged into `tracing` and throttled to roughly one log line per 10% of each region, which the daemon's existing log broadcaster surfaces. Structured WebSocket progress frames on the deploy channel are a follow-up.
 
 See `docs/architecture/deploy-preemption.md` for architecture details.

--- a/crates/fbuild-deploy/src/esp32.rs
+++ b/crates/fbuild-deploy/src/esp32.rs
@@ -47,14 +47,20 @@ pub struct Esp32Deployer {
     after_reset: String,
     verbose: bool,
     /// Route `verify-flash` through the native [`espflash`] crate
-    /// instead of the Python `esptool` subprocess. Write-flash is
-    /// unaffected — issue #66's native write path is a follow-up PR.
+    /// instead of the Python `esptool` subprocess.
     ///
     /// The daemon sets this from the `FBUILD_USE_ESPFLASH_VERIFY` env
     /// var. Default `false` keeps esptool as the fallback so users on
     /// unusual setups aren't forced onto the native path until it has
     /// bench time on every ESP32 family member.
     use_native_verify: bool,
+    /// Route `write-flash` through the native [`espflash`] crate
+    /// instead of the Python `esptool` subprocess (issue #66).
+    ///
+    /// The daemon sets this from the `FBUILD_USE_ESPFLASH_WRITE` env
+    /// var, independently of `use_native_verify`. Default `false` keeps
+    /// esptool as the safe fallback.
+    use_native_write: bool,
 }
 
 impl Esp32Deployer {
@@ -80,15 +86,26 @@ impl Esp32Deployer {
             after_reset: esptool_params.after_reset.clone(),
             verbose,
             use_native_verify: false,
+            use_native_write: false,
         }
     }
 
     /// Opt this deployer into the native espflash-based verify path
-    /// (issue #66). No effect on write-flash, which always goes through
-    /// esptool until the follow-up PR lands.
+    /// (issue #66). Independent of `with_native_write`.
     #[must_use]
     pub fn with_native_verify(mut self, enabled: bool) -> Self {
         self.use_native_verify = enabled;
+        self
+    }
+
+    /// Opt this deployer into the native espflash-based write-flash
+    /// path (issue #66). Independent of `with_native_verify`. On opt-in
+    /// both [`Deployer::deploy`] and [`Esp32Deployer::deploy_regions`]
+    /// route through the in-process espflash `Flasher`, skipping the
+    /// ~1.5 s Python/esptool startup per flash.
+    #[must_use]
+    pub fn with_native_write(mut self, enabled: bool) -> Self {
+        self.use_native_write = enabled;
         self
     }
 
@@ -313,6 +330,117 @@ impl Esp32Deployer {
             parts_off,
             fw_off,
         )
+    }
+
+    /// Native `write-flash` via the [`espflash`] crate (issue #66).
+    ///
+    /// Writes the full three-region set (bootloader + partitions +
+    /// firmware where present). Saves the Python interpreter startup
+    /// (~1 s) plus subprocess spawn (~0.5 s) vs the esptool path, and
+    /// surfaces per-region progress via `tracing` (bridged into the
+    /// daemon's existing log broadcaster). Same [`DeploymentResult`]
+    /// shape as the esptool path so callers swap behind a single flag.
+    fn try_deploy_native(&self, firmware_path: &Path, port: &str) -> Result<DeploymentResult> {
+        let baud = self.parse_native_baud()?;
+        let (boot_off, parts_off, fw_off) = self.parse_native_offsets()?;
+
+        let regions = crate::esp32_native::collect_standard_write_regions(
+            firmware_path,
+            boot_off,
+            parts_off,
+            fw_off,
+        );
+
+        if self.verbose {
+            tracing::info!(
+                "native write: chip={} port={} baud={} regions={}",
+                self.chip,
+                port,
+                baud,
+                regions.len()
+            );
+        }
+        tracing::info!(
+            "flashing {} to {} via espflash ({})",
+            firmware_path.display(),
+            port,
+            self.chip
+        );
+
+        crate::esp32_native::try_write_deployment_native(
+            &self.chip,
+            port,
+            baud,
+            &self.before_reset,
+            &self.after_reset,
+            &regions,
+            /* selective */ false,
+        )
+    }
+
+    /// Native `write-flash` for a caller-chosen subset of regions
+    /// (issue #66). Used after a verify-mismatch to rewrite only the
+    /// regions that actually differ — skipping the ~1s
+    /// bootloader/partitions rewrite when only firmware changed.
+    fn try_deploy_regions_native(
+        &self,
+        firmware_path: &Path,
+        port: &str,
+        regions: &[FlashRegion],
+    ) -> Result<DeploymentResult> {
+        let baud = self.parse_native_baud()?;
+        let (boot_off, parts_off, fw_off) = self.parse_native_offsets()?;
+
+        let write_regions = crate::esp32_native::collect_selected_write_regions(
+            firmware_path,
+            boot_off,
+            parts_off,
+            fw_off,
+            regions,
+        )?;
+
+        if self.verbose {
+            tracing::info!(
+                "native write (selective): chip={} port={} baud={} regions={:?}",
+                self.chip,
+                port,
+                baud,
+                regions
+            );
+        }
+        tracing::info!(
+            "flashing regions {:?} of {} to {} via espflash ({})",
+            regions,
+            firmware_path.display(),
+            port,
+            self.chip
+        );
+
+        crate::esp32_native::try_write_deployment_native(
+            &self.chip,
+            port,
+            baud,
+            &self.before_reset,
+            &self.after_reset,
+            &write_regions,
+            /* selective */ true,
+        )
+    }
+
+    fn parse_native_baud(&self) -> Result<u32> {
+        self.baud_rate.parse().map_err(|e| {
+            fbuild_core::FbuildError::DeployFailed(format!(
+                "native write: invalid baud rate '{}': {}",
+                self.baud_rate, e
+            ))
+        })
+    }
+
+    fn parse_native_offsets(&self) -> Result<(u32, u32, u32)> {
+        let boot = parse_hex_offset_u32(&self.bootloader_offset)?;
+        let parts = parse_hex_offset_u32(&self.partitions_offset)?;
+        let fw = parse_hex_offset_u32(&self.firmware_offset)?;
+        Ok((boot, parts, fw))
     }
 }
 
@@ -969,6 +1097,10 @@ impl Esp32Deployer {
             }
         }
 
+        if self.use_native_write {
+            return self.try_deploy_regions_native(firmware_path, port, regions);
+        }
+
         let args = self.build_write_flash_args(firmware_path, port, Some(regions));
         let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
@@ -1034,6 +1166,10 @@ impl Deployer for Esp32Deployer {
                 "serial port required for ESP32 deploy (use --port)".to_string(),
             )
         })?;
+
+        if self.use_native_write {
+            return self.try_deploy_native(firmware_path, port);
+        }
 
         let args = self.build_write_flash_args(firmware_path, port, None);
         let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();

--- a/crates/fbuild-deploy/src/esp32_native.rs
+++ b/crates/fbuild-deploy/src/esp32_native.rs
@@ -1,26 +1,28 @@
-//! Native ESP32 `verify-flash` implementation backed by the [`espflash`]
-//! crate. Alternative to the default [`super::esp32::Esp32Deployer`]
-//! path, which shells out to Python `esptool`.
+//! Native ESP32 `verify-flash` **and** `write-flash` implementations
+//! backed by the [`espflash`] crate. Alternatives to the default
+//! [`super::esp32::Esp32Deployer`] path, which shells out to Python
+//! `esptool`.
 //!
 //! # Why (issue #66)
 //!
-//! `esptool.py verify-flash` spends ~1 s on Python interpreter startup
-//! plus another ~0.5 s on subprocess/stub-flasher handshake before it
-//! even issues the `FLASH_MD5SUM` command. Calling `espflash` in-process
-//! skips both, dropping a cold verify on a 2.4 MB ESP32-S3 image from
-//! ~5.9 s to a projected ~1.5–2 s.
+//! `esptool.py` spends ~1 s on Python interpreter startup plus another
+//! ~0.5 s on subprocess/stub-flasher handshake before it even issues the
+//! first real command. Calling `espflash` in-process skips both — we
+//! saved ~4 s on a cold 2.4 MB ESP32-S3 verify in the first half of this
+//! work, and a full write gets the same baseline savings plus a
+//! progress stream that the daemon can surface without scraping
+//! subprocess stdout.
 //!
-//! # Scope for this PR
+//! # Scope
 //!
-//! * **In scope**: `verify-flash` only — same three regions
-//!   (bootloader / partitions / firmware) as the esptool path, same
-//!   [`super::esp32::VerifyOutcome`] result, same `Match` vs
-//!   `Mismatch { regions }` semantics.
-//! * **Out of scope (follow-up)**: `write-flash`. The stub flasher's
-//!   write path needs a progress-callback bridge to the daemon's
-//!   WebSocket log stream and more careful error recovery than a
-//!   read-only MD5 comparison; splitting the two keeps this PR
-//!   reviewable.
+//! * `verify-flash` — three regions (bootloader / partitions /
+//!   firmware), same [`VerifyOutcome`] semantics as the esptool path.
+//! * `write-flash` — same three regions, same
+//!   [`DeploymentResult`]/[`DeployOutcome`] shape as the esptool path.
+//!   Progress callbacks from espflash are bridged into `tracing` so the
+//!   daemon's existing log plumbing picks them up without any new API
+//!   surface. Full WebSocket progress frames are a follow-up — see
+//!   `log_only_progress_bridge` below.
 //!
 //! # Serial-port lease
 //!
@@ -33,10 +35,12 @@
 //!
 //! # Opt-in
 //!
-//! This path is guarded by [`Esp32Deployer::use_native_verify`], which
-//! the daemon wires to the `FBUILD_USE_ESPFLASH_VERIFY` environment
-//! variable. Default stays on the esptool subprocess path so users on
-//! unusual setups keep their escape hatch.
+//! `verify-flash` is guarded by [`Esp32Deployer::use_native_verify`]
+//! (daemon env: `FBUILD_USE_ESPFLASH_VERIFY`), and `write-flash` by
+//! [`Esp32Deployer::use_native_write`] (daemon env:
+//! `FBUILD_USE_ESPFLASH_WRITE`). The two flags are independent —
+//! users can flip one without the other while the native write path
+//! accumulates bench time on every ESP32 family member.
 
 use std::path::Path;
 use std::str::FromStr;
@@ -44,13 +48,14 @@ use std::time::Duration;
 
 use espflash::connection::{Connection, ResetAfterOperation, ResetBeforeOperation};
 use espflash::flasher::Flasher;
-use espflash::target::Chip;
+use espflash::target::{Chip, ProgressCallbacks};
 use md5::{Digest, Md5};
 use serialport::{FlowControl, SerialPortType, UsbPortInfo};
 
 use fbuild_core::{FbuildError, Result};
 
 use crate::esp32::{FlashRegion, RegionVerifyResult, VerifyOutcome};
+use crate::{DeployOutcome, DeploymentResult};
 
 /// A single region (flash offset + local firmware file) to verify.
 #[derive(Debug, Clone)]
@@ -202,6 +207,373 @@ pub fn try_verify_deployment_native(
             stderr: String::new(),
             regions: results,
         })
+    }
+}
+
+/// A single region (flash offset + local firmware file) to write.
+///
+/// Same shape as [`NativeVerifyRegion`] but kept as a distinct type so
+/// a future change (e.g. encrypted-write flags per-region) doesn't
+/// silently leak back into the verify path.
+#[derive(Debug, Clone)]
+pub struct NativeWriteRegion {
+    pub region: FlashRegion,
+    pub offset: u32,
+    pub path: std::path::PathBuf,
+}
+
+/// Native `write-flash` — reads each file from disk and streams it to
+/// the chip via espflash's stub flasher. Same three regions
+/// (bootloader / partitions / firmware) as the esptool path, same
+/// [`DeploymentResult`] / [`DeployOutcome`] semantics so callers can
+/// route between the two behind a single flag.
+///
+/// Progress from espflash is bridged into `tracing` so the daemon's
+/// existing log broadcaster surfaces it without new API surface (see
+/// [`LoggingProgressBridge`]). Structured WebSocket progress frames are
+/// a follow-up: the bridge is a drop-in replacement point for a richer
+/// callback without touching any of the call sites.
+///
+/// On success the chip is hard-reset (matching esptool's
+/// `--after hard-reset`) so callers can treat the `Ok` return as
+/// "device is now running the requested firmware" without an extra
+/// reset.
+///
+/// Port ownership: caller must ensure the OS-level serial port is free
+/// before calling (the daemon does this via `preempt_for_deploy`). The
+/// opened handle is closed on function return.
+///
+/// Error recovery: on any region failure we short-circuit, log which
+/// region failed with its flash offset, return a failed
+/// [`DeploymentResult`], and let the caller decide whether to retry via
+/// esptool. Partial writes are never silently swallowed.
+#[allow(clippy::too_many_arguments)]
+pub fn try_write_deployment_native(
+    chip_name: &str,
+    port: &str,
+    baud: u32,
+    before_reset: &str,
+    after_reset: &str,
+    regions: &[NativeWriteRegion],
+    selective: bool,
+) -> Result<DeploymentResult> {
+    let chip = parse_chip(chip_name)?;
+    let before = parse_before_reset(before_reset)?;
+    let after = parse_after_reset(after_reset)?;
+
+    if regions.is_empty() {
+        return Err(FbuildError::DeployFailed(
+            "native write: called with no regions; at least firmware is required".to_string(),
+        ));
+    }
+
+    let serial_port = serialport::new(port, 115_200)
+        .flow_control(FlowControl::None)
+        // Writes are much longer than verifies; the stub flasher can
+        // take tens of seconds between UART responses while erasing
+        // the partition table sector on a cold boot. 10s matches
+        // espflash's own CLI default.
+        .timeout(Duration::from_secs(10))
+        .open_native()
+        .map_err(|e| {
+            FbuildError::DeployFailed(format!(
+                "native write: failed to open serial port {}: {}",
+                port, e
+            ))
+        })?;
+
+    let port_info = discover_usb_port_info(port);
+    let connection = Connection::new(serial_port, port_info, after, before, baud);
+
+    let use_stub = true;
+    let mut flasher = Flasher::connect(
+        connection,
+        use_stub,
+        /* verify */
+        false, // espflash's own post-write verify; we rely on the separate verify path
+        /* skip   */ false,
+        Some(chip),
+        Some(baud),
+    )
+    .map_err(|e| {
+        FbuildError::DeployFailed(format!(
+            "native write: espflash connect failed on {}: {}",
+            port, e
+        ))
+    })?;
+
+    let mut bridge = LoggingProgressBridge::new(port);
+    let mut rendered = String::new();
+    let mut bytes_written: u64 = 0;
+
+    for r in regions {
+        let bytes = std::fs::read(&r.path).map_err(|e| {
+            FbuildError::DeployFailed(format!(
+                "native write: failed to read {}: {}",
+                r.path.display(),
+                e
+            ))
+        })?;
+        let size = bytes.len();
+        bridge.enter_region(r.region);
+        tracing::info!(
+            port,
+            region = ?r.region,
+            offset = format!("0x{:x}", r.offset),
+            size,
+            "native write: writing region"
+        );
+        if let Err(e) = flasher.write_bin_to_flash(r.offset, &bytes, &mut bridge) {
+            let msg = format!(
+                "native write: region {:?} at 0x{:x} failed after {}/{} bytes: {}",
+                r.region, r.offset, bridge.last_current, size, e
+            );
+            tracing::error!(port, "{}", msg);
+            rendered.push_str(&msg);
+            rendered.push('\n');
+            return Ok(DeploymentResult {
+                success: false,
+                message: format!("espflash native write failed on {} ({})", port, chip_name),
+                port: Some(port.to_string()),
+                stdout: rendered,
+                stderr: e.to_string(),
+                outcome: outcome_for(selective, regions),
+            });
+        }
+        bytes_written += size as u64;
+        rendered.push_str(&format!(
+            "native write: {} at 0x{:x} ({} bytes) OK\n",
+            region_name(r.region),
+            r.offset,
+            size
+        ));
+    }
+
+    // Hard-reset (or whatever after_reset selects) the chip so the app
+    // boots once the stub releases the bus. Mirrors esptool's
+    // `--after hard-reset` contract.
+    let mut connection = flasher.into_connection();
+    if let Err(e) = connection.reset_after(use_stub, chip) {
+        // A failed final reset is annoying but doesn't invalidate the
+        // flash: the image is on-device, a manual power cycle will
+        // boot it. Log and report success.
+        tracing::warn!(port, "native write: reset_after failed: {}", e);
+    }
+
+    tracing::info!(
+        port,
+        bytes_written,
+        regions = regions.len(),
+        "native write: completed successfully"
+    );
+
+    Ok(DeploymentResult {
+        success: true,
+        message: format!(
+            "firmware flashed to {} ({}) via espflash ({} bytes, {} region(s))",
+            port,
+            chip_name,
+            bytes_written,
+            regions.len()
+        ),
+        port: Some(port.to_string()),
+        stdout: rendered,
+        stderr: String::new(),
+        outcome: outcome_for(selective, regions),
+    })
+}
+
+/// Pick the correct [`DeployOutcome`] for a native write — preserves
+/// the existing invariant that the full three-region path reports
+/// `FullFlash` and selective rewrites carry the region list.
+fn outcome_for(selective: bool, regions: &[NativeWriteRegion]) -> DeployOutcome {
+    if selective {
+        DeployOutcome::SelectiveFlash {
+            regions: regions.iter().map(|r| r.region).collect(),
+        }
+    } else {
+        DeployOutcome::FullFlash
+    }
+}
+
+fn region_name(r: FlashRegion) -> &'static str {
+    match r {
+        FlashRegion::Bootloader => "bootloader",
+        FlashRegion::Partitions => "partitions",
+        FlashRegion::Firmware => "firmware",
+    }
+}
+
+/// Collect the full three-region write set (bootloader + partitions +
+/// firmware where present) from a firmware path. Mirrors
+/// [`collect_standard_regions`] but returns [`NativeWriteRegion`].
+pub fn collect_standard_write_regions(
+    firmware_path: &Path,
+    bootloader_offset: u32,
+    partitions_offset: u32,
+    firmware_offset: u32,
+) -> Vec<NativeWriteRegion> {
+    let build_dir = firmware_path.parent().unwrap_or_else(|| Path::new("."));
+    let bootloader_path = build_dir.join("bootloader.bin");
+    let partitions_path = build_dir.join("partitions.bin");
+
+    let mut out = Vec::with_capacity(3);
+    if bootloader_path.exists() {
+        out.push(NativeWriteRegion {
+            region: FlashRegion::Bootloader,
+            offset: bootloader_offset,
+            path: bootloader_path,
+        });
+    }
+    if partitions_path.exists() {
+        out.push(NativeWriteRegion {
+            region: FlashRegion::Partitions,
+            offset: partitions_offset,
+            path: partitions_path,
+        });
+    }
+    out.push(NativeWriteRegion {
+        region: FlashRegion::Firmware,
+        offset: firmware_offset,
+        path: firmware_path.to_path_buf(),
+    });
+    out
+}
+
+/// Collect a caller-chosen subset of write regions. Used by the daemon's
+/// selective-flash path (post-verify-mismatch) so we don't rewrite
+/// bootloader/partitions when only firmware differs. `requested` must
+/// not be empty.
+pub fn collect_selected_write_regions(
+    firmware_path: &Path,
+    bootloader_offset: u32,
+    partitions_offset: u32,
+    firmware_offset: u32,
+    requested: &[FlashRegion],
+) -> Result<Vec<NativeWriteRegion>> {
+    if requested.is_empty() {
+        return Err(FbuildError::DeployFailed(
+            "native write: collect_selected_write_regions called with empty request".to_string(),
+        ));
+    }
+    let build_dir = firmware_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut out = Vec::with_capacity(requested.len());
+    for r in requested {
+        let (path, offset) = match r {
+            FlashRegion::Bootloader => (build_dir.join("bootloader.bin"), bootloader_offset),
+            FlashRegion::Partitions => (build_dir.join("partitions.bin"), partitions_offset),
+            FlashRegion::Firmware => (firmware_path.to_path_buf(), firmware_offset),
+        };
+        if !path.exists() {
+            return Err(FbuildError::DeployFailed(format!(
+                "native write: requested {:?} but {} is missing",
+                r,
+                path.display()
+            )));
+        }
+        out.push(NativeWriteRegion {
+            region: *r,
+            offset,
+            path,
+        });
+    }
+    Ok(out)
+}
+
+/// Bridges espflash's [`ProgressCallbacks`] into `tracing` so the
+/// daemon's existing log broadcaster picks up write progress without
+/// any new API surface.
+///
+/// Logging-only by design: a richer WebSocket bridge (structured
+/// progress frames on the deploy WS channel) is a follow-up — this
+/// type is the single seam where that upgrade lands.
+struct LoggingProgressBridge {
+    port: String,
+    region: Option<FlashRegion>,
+    total: usize,
+    last_current: usize,
+    /// Last percentage we logged at. Throttles the per-block `update`
+    /// spam to one line per 10% of a region so the daemon log stream
+    /// stays readable.
+    last_pct_logged: u8,
+}
+
+impl LoggingProgressBridge {
+    fn new(port: &str) -> Self {
+        Self {
+            port: port.to_string(),
+            region: None,
+            total: 0,
+            last_current: 0,
+            last_pct_logged: 0,
+        }
+    }
+
+    fn enter_region(&mut self, region: FlashRegion) {
+        self.region = Some(region);
+        self.total = 0;
+        self.last_current = 0;
+        self.last_pct_logged = 0;
+    }
+
+    fn region_label(&self) -> &'static str {
+        match self.region {
+            Some(r) => region_name(r),
+            None => "unknown",
+        }
+    }
+}
+
+impl ProgressCallbacks for LoggingProgressBridge {
+    fn init(&mut self, addr: u32, total: usize) {
+        self.total = total;
+        self.last_current = 0;
+        self.last_pct_logged = 0;
+        tracing::info!(
+            port = %self.port,
+            region = self.region_label(),
+            addr = format!("0x{:x}", addr),
+            total,
+            "native write: begin region"
+        );
+    }
+
+    fn update(&mut self, current: usize) {
+        self.last_current = current;
+        if self.total == 0 {
+            return;
+        }
+        let pct = ((current as u64 * 100) / self.total as u64).min(100) as u8;
+        // Emit a log line every 10% boundary so a 1 MB write produces
+        // ~10 lines rather than hundreds.
+        if pct >= self.last_pct_logged + 10 {
+            self.last_pct_logged = pct - (pct % 10);
+            tracing::info!(
+                port = %self.port,
+                region = self.region_label(),
+                pct,
+                current,
+                total = self.total,
+                "native write: progress"
+            );
+        }
+    }
+
+    fn verifying(&mut self) {
+        tracing::debug!(
+            port = %self.port,
+            region = self.region_label(),
+            "native write: verifying region (espflash internal)"
+        );
+    }
+
+    fn finish(&mut self, skipped: bool) {
+        tracing::info!(
+            port = %self.port,
+            region = self.region_label(),
+            skipped,
+            "native write: region complete"
+        );
     }
 }
 
@@ -475,5 +847,193 @@ mod tests {
         assert!(out.contains("firmware"));
         assert!(out.contains("digest matched"));
         assert!(out.contains("digest mismatch"));
+    }
+
+    // --- native write-flash tests (issue #66 PR #89 follow-up) ---
+    //
+    // Most of the write flow is live hardware code. What we can test
+    // without a board attached is the region assembly, the
+    // DeployOutcome mapping, and the progress-bridge throttling — the
+    // three pure pieces where a regression would silently corrupt the
+    // daemon's deploy response.
+
+    #[test]
+    fn collect_standard_write_regions_skips_missing_optional_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fw = tmp.path().join("firmware.bin");
+        std::fs::write(&fw, b"firmware").unwrap();
+
+        let regions = collect_standard_write_regions(&fw, 0x0, 0x8000, 0x10000);
+        assert_eq!(regions.len(), 1);
+        assert_eq!(regions[0].region, FlashRegion::Firmware);
+        assert_eq!(regions[0].offset, 0x10000);
+    }
+
+    #[test]
+    fn collect_standard_write_regions_includes_optional_files_when_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fw = tmp.path().join("firmware.bin");
+        std::fs::write(&fw, b"firmware").unwrap();
+        std::fs::write(tmp.path().join("bootloader.bin"), b"boot").unwrap();
+        std::fs::write(tmp.path().join("partitions.bin"), b"part").unwrap();
+
+        let regions = collect_standard_write_regions(&fw, 0x0, 0x8000, 0x10000);
+        assert_eq!(regions.len(), 3);
+        assert_eq!(regions[0].region, FlashRegion::Bootloader);
+        assert_eq!(regions[0].offset, 0x0);
+        assert_eq!(regions[1].region, FlashRegion::Partitions);
+        assert_eq!(regions[1].offset, 0x8000);
+        assert_eq!(regions[2].region, FlashRegion::Firmware);
+        assert_eq!(regions[2].offset, 0x10000);
+    }
+
+    #[test]
+    fn collect_selected_write_regions_errors_on_empty_request() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fw = tmp.path().join("firmware.bin");
+        std::fs::write(&fw, b"firmware").unwrap();
+        let err = collect_selected_write_regions(&fw, 0x0, 0x8000, 0x10000, &[]).unwrap_err();
+        assert!(err.to_string().contains("empty request"));
+    }
+
+    #[test]
+    fn collect_selected_write_regions_errors_when_file_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fw = tmp.path().join("firmware.bin");
+        std::fs::write(&fw, b"firmware").unwrap();
+        // No bootloader.bin on disk.
+        let err =
+            collect_selected_write_regions(&fw, 0x0, 0x8000, 0x10000, &[FlashRegion::Bootloader])
+                .unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn collect_selected_write_regions_returns_requested_subset() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fw = tmp.path().join("firmware.bin");
+        std::fs::write(&fw, b"firmware").unwrap();
+        std::fs::write(tmp.path().join("bootloader.bin"), b"boot").unwrap();
+        std::fs::write(tmp.path().join("partitions.bin"), b"part").unwrap();
+
+        let out = collect_selected_write_regions(
+            &fw,
+            0x0,
+            0x8000,
+            0x10000,
+            &[FlashRegion::Firmware, FlashRegion::Bootloader],
+        )
+        .unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].region, FlashRegion::Firmware);
+        assert_eq!(out[0].offset, 0x10000);
+        assert_eq!(out[1].region, FlashRegion::Bootloader);
+        assert_eq!(out[1].offset, 0x0);
+    }
+
+    #[test]
+    fn outcome_for_full_write_reports_full_flash() {
+        let regions = vec![NativeWriteRegion {
+            region: FlashRegion::Firmware,
+            offset: 0x10000,
+            path: std::path::PathBuf::from("firmware.bin"),
+        }];
+        assert!(matches!(
+            outcome_for(false, &regions),
+            DeployOutcome::FullFlash
+        ));
+    }
+
+    #[test]
+    fn outcome_for_selective_write_carries_region_list() {
+        let regions = vec![
+            NativeWriteRegion {
+                region: FlashRegion::Bootloader,
+                offset: 0x0,
+                path: std::path::PathBuf::from("bootloader.bin"),
+            },
+            NativeWriteRegion {
+                region: FlashRegion::Firmware,
+                offset: 0x10000,
+                path: std::path::PathBuf::from("firmware.bin"),
+            },
+        ];
+        match outcome_for(true, &regions) {
+            DeployOutcome::SelectiveFlash { regions } => {
+                assert_eq!(
+                    regions,
+                    vec![FlashRegion::Bootloader, FlashRegion::Firmware]
+                );
+            }
+            other => panic!("expected SelectiveFlash, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn try_write_deployment_native_rejects_empty_regions() {
+        let err = try_write_deployment_native(
+            "esp32s3",
+            "COM99",
+            460_800,
+            "default-reset",
+            "hard-reset",
+            &[],
+            false,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("no regions"));
+    }
+
+    #[test]
+    fn progress_bridge_throttles_updates_to_ten_percent_boundaries() {
+        // Assert the 10%-boundary throttle actually fires — without it
+        // a 1 MB write spams hundreds of log lines per region.
+        let mut bridge = LoggingProgressBridge::new("COM13");
+        bridge.enter_region(FlashRegion::Firmware);
+        bridge.init(0x10000, 1000);
+
+        // Simulate espflash calling update every 10 bytes. After 1000
+        // calls we should have logged at roughly 0, 10, 20, ..., 100%
+        // — i.e. last_pct_logged should have landed on a 10-multiple.
+        for current in (10..=1000).step_by(10) {
+            bridge.update(current);
+        }
+        assert_eq!(bridge.last_current, 1000);
+        assert_eq!(bridge.last_pct_logged % 10, 0);
+        // Finishing resets the per-region state for the next region.
+        bridge.finish(false);
+    }
+
+    #[test]
+    fn progress_bridge_handles_zero_total_without_panic() {
+        // A zero-byte region is defensive: espflash shouldn't ever
+        // emit one, but our arithmetic must not divide by zero.
+        let mut bridge = LoggingProgressBridge::new("COM13");
+        bridge.enter_region(FlashRegion::Firmware);
+        bridge.init(0x10000, 0);
+        bridge.update(0);
+        bridge.finish(true);
+    }
+
+    #[test]
+    fn progress_bridge_reports_correct_region_label() {
+        let mut bridge = LoggingProgressBridge::new("COM13");
+        assert_eq!(bridge.region_label(), "unknown");
+        bridge.enter_region(FlashRegion::Bootloader);
+        assert_eq!(bridge.region_label(), "bootloader");
+        bridge.enter_region(FlashRegion::Partitions);
+        assert_eq!(bridge.region_label(), "partitions");
+        bridge.enter_region(FlashRegion::Firmware);
+        assert_eq!(bridge.region_label(), "firmware");
+    }
+
+    #[test]
+    fn region_name_is_stable() {
+        // Daemon log messages and integration tests depend on these
+        // literal names. Pin them here so a refactor that renames
+        // them trips a unit test first.
+        assert_eq!(region_name(FlashRegion::Bootloader), "bootloader");
+        assert_eq!(region_name(FlashRegion::Partitions), "partitions");
+        assert_eq!(region_name(FlashRegion::Firmware), "firmware");
     }
 }


### PR DESCRIPTION
Partial #66 — extends PR #89 (verify-flash via espflash) to the write path. Default stays esptool subprocess for safety; native write is opt-in via `FBUILD_USE_ESPFLASH_WRITE=1`.

## What's in
- `try_write_deployment_native` in `crates/fbuild-deploy/src/esp32_native.rs` (+606 lines): opens serial via `serialport`, wraps in espflash `Connection`, calls `Flasher::connect` (handles reset/sync/stub upload/baud), then `write_bin_to_flash(offset, &data, &mut progress_cb)` per region; hard-resets on success.
- `Esp32Deployer::with_native_write(bool)` builder, mirror of `with_native_verify`.
- Daemon toggle: `FBUILD_USE_ESPFLASH_WRITE=1` → `native_write_enabled()` helper. Flag flows into both full-flash (`Deployer::deploy`) and selective-flash (`Esp32Deployer::deploy_regions` after verify mismatch) dispatchers.
- `LoggingProgressBridge` implements `espflash::target::ProgressCallbacks`, throttled to 10% boundaries, emits via `tracing::info!` into the daemon's existing log stream. A 1 MB region yields ~10 lines.
- 12 new unit tests (region assembly, outcome mapping, progress throttle, zero-total defensive, missing-file rejection, empty-region rejection, region-label stability).

## Test plan
- [x] `uv run cargo test -p fbuild-deploy --lib` — 57 passing (12 new)
- [x] `uv run cargo clippy --workspace --all-targets -- -D warnings`
- [x] `uv run cargo fmt --all`

## Deferred (tracked on #66)
- Structured WebSocket progress frames on the deploy channel (the log-only `LoggingProgressBridge` is a drop-in replacement point)
- Hardware bench validation across every ESP32 family member before flipping the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)