### PR TITLE
feat(ci): reusable setup composite action with fbuild-hash pinning (closes #101)

### DIFF
--- a/.github/actions/setup/README.md
+++ b/.github/actions/setup/README.md
@@ -68,6 +68,7 @@ jobs:
 |---|---|
 | `cache-hit` | `true` if the cache was restored from a previous run, `false` on miss. |
 | `cache-dir` | Resolved cache directory path. Useful for diagnostic steps. |
+| `fbuild-hash` | sha256 prefix (16 hex chars) of the installed fbuild wheel's `RECORD` file. Baked into the cache key so any fbuild change — including a re-released wheel at the same version — invalidates stale cache artifacts. |
 
 ## What this action does
 
@@ -75,7 +76,18 @@ jobs:
 2. Resolves a stable cache directory under `$RUNNER_TEMP` (survives across steps of the same job; not a surprise `$HOME` path).
 3. Exports `FBUILD_CACHE_DIR` via `$GITHUB_ENV` so every later step inherits it.
 4. Installs fbuild from PyPI at the requested version.
-5. Restores (and on job-end, saves) the cache via `actions/cache@v4`.
+5. **Computes the installed fbuild's content hash** (sha256 of its dist-info `RECORD`) and bakes it into the cache key. This guarantees the cache is tied to the exact fbuild you're running, not just the PyPI version string — so `latest` is safe and a re-released wheel won't poison the cache.
+6. Restores (and on job-end, saves) the cache via `actions/cache@v4`.
+
+### Why hash-pinning matters
+
+The fbuild cache stores toolchains, frameworks, and build outputs whose internal layout is tied to fbuild's own fingerprint format, response-file generation, and path embedding. If fbuild itself changes without the cache key changing, the restored cache can encode stale paths or obsolete fingerprints — silent cache poisoning.
+
+Baking the wheel's `RECORD` hash into the key means:
+
+- `fbuild-version: latest` is reproducible-by-construction: a new release produces a new hash, which rolls the cache.
+- A re-uploaded wheel (same version, different contents) invalidates correctly.
+- Per-platform wheel differences (manylinux vs. macOS vs. Windows) produce different hashes and do not cross-pollute caches.
 
 It does **not** cache `~/.fbuild/*/daemon/` — that's ephemeral runtime state and restoring it across runs causes broken daemon discovery on the next client call. The action sidesteps the whole `~/.fbuild/` tree by redirecting fbuild's cache to `$RUNNER_TEMP/fbuild-cache` via `FBUILD_CACHE_DIR`.
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,6 +38,9 @@ outputs:
   cache-dir:
     description: "Resolved cache directory path (useful for diagnostic steps)."
     value: ${{ steps.resolve-paths.outputs.cache-dir }}
+  fbuild-hash:
+    description: "sha256 prefix of the installed fbuild wheel's RECORD file. Baked into the cache key so an fbuild upgrade invalidates stale artifacts."
+    value: ${{ steps.fbuild-hash.outputs.fbuild-hash }}
 
 runs:
   using: "composite"
@@ -78,13 +81,41 @@ runs:
         python -m pip install '${{ steps.resolve-paths.outputs.pip-spec }}'
         fbuild --version || echo "fbuild --version not yet supported on this release" >&2
 
+    - name: Resolve fbuild content hash
+      id: fbuild-hash
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Cache correctness depends on the EXACT installed fbuild, not just the
+        # PyPI version string. Hash the wheel's dist-info RECORD file — it
+        # contains sha256s of every installed file, so any change to fbuild
+        # (re-released wheel, local build, different platform tag) produces a
+        # different digest. See docs/CI_CACHING.md "Cache-key strategy".
+        FBUILD_HASH=$(python - <<'PY'
+        import hashlib
+        import importlib.metadata as md
+        import sys
+        try:
+            dist = md.distribution("fbuild")
+        except md.PackageNotFoundError:
+            sys.exit("fbuild is not installed; cannot resolve content hash")
+        record = dist.read_text("RECORD")
+        if not record:
+            # Fallback: hash version + metadata so we at least discriminate by release.
+            record = f"{dist.version}\n{dist.read_text('METADATA') or ''}"
+        print(hashlib.sha256(record.encode("utf-8")).hexdigest()[:16])
+        PY
+        )
+        echo "fbuild-hash=${FBUILD_HASH}" >> "$GITHUB_OUTPUT"
+        echo "Resolved fbuild content hash: ${FBUILD_HASH}"
+
     - name: Restore fbuild cache
       if: ${{ inputs.cache == 'true' }}
       id: fbuild-cache
       uses: actions/cache@v4
       with:
         path: ${{ steps.resolve-paths.outputs.cache-dir }}
-        key: fbuild-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-key-extra }}
+        key: fbuild-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.fbuild-hash.outputs.fbuild-hash }}-${{ inputs.cache-key-extra }}
         restore-keys: |
+          fbuild-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.fbuild-hash.outputs.fbuild-hash }}-
           fbuild-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-
-          fbuild-${{ inputs.cache-version }}-${{ runner.os }}-

--- a/docs/CI_CACHING.md
+++ b/docs/CI_CACHING.md
@@ -23,19 +23,35 @@ The action sidesteps the whole `~/.fbuild/*/daemon/` "don't cache ephemeral stat
 
 ### Raw snippet (if you don't want the action dependency)
 
+If you skip the composite action, you MUST still bake the fbuild content hash into the cache key — see [Cache-key strategy](#cache-key-strategy) below for why. Minimal version:
+
 ```yaml
+- name: Resolve fbuild content hash
+  id: fbuild-hash
+  shell: bash
+  run: |
+    FBUILD_HASH=$(python - <<'PY'
+    import hashlib, importlib.metadata as md
+    dist = md.distribution("fbuild")
+    record = dist.read_text("RECORD") or f"{dist.version}\n{dist.read_text('METADATA') or ''}"
+    print(hashlib.sha256(record.encode('utf-8')).hexdigest()[:16])
+    PY
+    )
+    echo "hash=$FBUILD_HASH" >> "$GITHUB_OUTPUT"
+
 - name: Restore fbuild cache
   uses: actions/cache@v4
   with:
     path: |
       ~/.fbuild/prod/cache
-    key: fbuild-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('platformio.ini', '**/boards.txt', 'rust-toolchain.toml') }}-${{ hashFiles('.fbuild-cache-version') }}
+    key: fbuild-${{ runner.os }}-${{ runner.arch }}-${{ steps.fbuild-hash.outputs.hash }}-${{ hashFiles('platformio.ini', '**/boards.txt', 'rust-toolchain.toml') }}-${{ hashFiles('.fbuild-cache-version') }}
     restore-keys: |
-      fbuild-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('platformio.ini', '**/boards.txt', 'rust-toolchain.toml') }}-
+      fbuild-${{ runner.os }}-${{ runner.arch }}-${{ steps.fbuild-hash.outputs.hash }}-${{ hashFiles('platformio.ini', '**/boards.txt', 'rust-toolchain.toml') }}-
+      fbuild-${{ runner.os }}-${{ runner.arch }}-${{ steps.fbuild-hash.outputs.hash }}-
       fbuild-${{ runner.os }}-${{ runner.arch }}-
 ```
 
-Adjust `hashFiles(...)` inputs to whatever files actually change the build graph in your project. `.fbuild-cache-version` is a sentinel you bump when you want to force a cache bust (or cache an fbuild version identifier file — see [Cache-key strategy](#cache-key-strategy) below).
+Adjust `hashFiles(...)` inputs to whatever files actually change the build graph in your project. `.fbuild-cache-version` is a sentinel you bump when you want to force a cache bust.
 
 **Do not cache** `~/.fbuild/*/daemon/` — it's runtime state (port file, PID file, log), and restoring it across runs will make the next client try to connect to a dead daemon.
 
@@ -60,9 +76,34 @@ See `crates/fbuild-paths/src/lib.rs` for the authoritative path list.
 The goal is to maximize hit rate without producing wrong output. In priority order, the key should discriminate on:
 
 1. **Runner OS + arch** — `${{ runner.os }}-${{ runner.arch }}`. Toolchains are platform-pinned; sharing across OSes corrupts builds.
-2. **fbuild version** — if you use the fbuild PyPI wheel, cache-key `fbuild --version` output. Internal fingerprints and cache-index formats are stable within a minor version but may change on major bumps.
+2. **fbuild content hash** — **required**, not optional. Key on a content hash of the installed fbuild (e.g., sha256 of the wheel's dist-info `RECORD` file), not just the PyPI version string. A version string does not discriminate against re-released wheels, dev builds, or local installs; cached artifacts can encode fbuild-internal layout (response-file format, path embedding, fingerprint scheme) that changes silently across those. The composite `setup` action computes this hash for you and exports it via the `fbuild-hash` output — consumers who roll their own `actions/cache@v4` should do the equivalent.
 3. **Graph inputs** — `platformio.ini`, per-board JSONs, `rust-toolchain.toml`, any `lib_deps`-defining file. A change to these invalidates the warm-build fingerprint anyway, so it's cheap to bake them into the key to avoid carrying obsolete artifacts.
 4. **Manual bump** — a `.fbuild-cache-version` sentinel in the repo lets you force-invalidate with a one-line commit when the runtime has rotted for reasons GH Actions can't see.
+
+### Computing the fbuild content hash (if you're not using the composite action)
+
+```yaml
+- name: Resolve fbuild content hash
+  id: fbuild-hash
+  shell: bash
+  run: |
+    FBUILD_HASH=$(python - <<'PY'
+    import hashlib, importlib.metadata as md
+    dist = md.distribution("fbuild")
+    record = dist.read_text("RECORD") or f"{dist.version}\n{dist.read_text('METADATA') or ''}"
+    print(hashlib.sha256(record.encode('utf-8')).hexdigest()[:16])
+    PY
+    )
+    echo "hash=$FBUILD_HASH" >> "$GITHUB_OUTPUT"
+
+- uses: actions/cache@v4
+  with:
+    path: ~/.fbuild/prod/cache
+    key: fbuild-${{ runner.os }}-${{ runner.arch }}-${{ steps.fbuild-hash.outputs.hash }}-${{ hashFiles('platformio.ini') }}
+    restore-keys: |
+      fbuild-${{ runner.os }}-${{ runner.arch }}-${{ steps.fbuild-hash.outputs.hash }}-
+      fbuild-${{ runner.os }}-${{ runner.arch }}-
+```
 
 ### Restore-key fallback chain
 


### PR DESCRIPTION
## Summary

- Adds `FastLED/fbuild/.github/actions/setup` composite action for one-line fbuild CI setup (install + cache + env wiring).
- Pins cache keys to the **exact installed fbuild content hash** (sha256 of the wheel's dist-info `RECORD`), not just the PyPI version string — protects against silent cache poisoning from re-released wheels or non-registry installs.
- Updates `docs/CI_CACHING.md` to promote fbuild-hash from optional to required, with a raw-snippet example for consumers who don't want the action dependency.

## Why hash-pinning matters

The fbuild cache stores toolchains, frameworks, and build outputs whose layout is tied to fbuild's fingerprint format, response-file generation, and embedded paths. A version string does not discriminate against re-released wheels, dev builds, or different platform tags — any of which can poison a restored cache. Hashing the installed `RECORD` covers all of those cases and makes `fbuild-version: latest` safe-by-construction.

## Test plan

- [ ] CI matrix runs against the action on `ubuntu-latest`, `macos-latest`, `windows-latest`
- [ ] Second build in the same job hits cache (see smoke test in `.github/actions/setup/README.md`)
- [ ] Upgrading fbuild between two runs forces a cache miss (hash changes)
- [ ] Consumers can read the `fbuild-hash` output for their own diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GitHub composite action for setting up fbuild with automatic caching, environment variable configuration, and cache invalidation based on fbuild content.

* **Documentation**
  * Added documentation for the new fbuild setup action with usage examples and cache behavior details.
  * Updated CI caching guide to recommend the composite action for streamlined setup.

* **Chores**
  * Added follow-up tasks for enhancing fbuild cache pinning strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->