### PR TITLE
perf(daemon): session-trusted verify-skip for ESP32 warm redeploys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serialport",
+ "sha2",
  "socket2",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/fbuild-daemon/Cargo.toml
+++ b/crates/fbuild-daemon/Cargo.toml
@@ -23,6 +23,7 @@ fbuild-serial = { path = "../fbuild-serial" }
 fbuild-build = { path = "../fbuild-build" }
 fbuild-deploy = { path = "../fbuild-deploy" }
 tokio = { workspace = true }
+sha2 = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
 serde = { workspace = true }

--- a/crates/fbuild-daemon/src/context.rs
+++ b/crates/fbuild-daemon/src/context.rs
@@ -53,7 +53,20 @@ impl BroadcastHub {
 /// next `fbuild` invocation in an interactive workflow, without leaving
 /// the daemon holding shell-inherited resources (see #91) for two minutes
 /// after a one-shot command returns.
-pub const SELF_EVICTION_TIMEOUT: Duration = Duration::from_secs(30);
+///
+/// Overridable at runtime via `FBUILD_SELF_EVICTION_SECS` (useful for
+/// benchmarks that need the daemon to stay alive across multiple CLI
+/// invocations without re-paying daemon spawn cost).
+pub fn self_eviction_timeout() -> Duration {
+    std::env::var("FBUILD_SELF_EVICTION_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(SELF_EVICTION_TIMEOUT_DEFAULT)
+}
+
+pub const SELF_EVICTION_TIMEOUT_DEFAULT: Duration = Duration::from_secs(30);
+pub const SELF_EVICTION_TIMEOUT: Duration = SELF_EVICTION_TIMEOUT_DEFAULT;
 
 /// Fallback idle timeout: daemon shuts down after 12 hours regardless.
 pub const IDLE_TIMEOUT: Duration = Duration::from_secs(43200);

--- a/crates/fbuild-daemon/src/device_manager.rs
+++ b/crates/fbuild-daemon/src/device_manager.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 /// Type of device lease.
@@ -27,6 +27,22 @@ pub struct DeviceLease {
     pub acquired_at: f64,
 }
 
+/// In-memory record of the firmware image the daemon *last observed*
+/// on a given port (either written by us, or confirmed by
+/// `verify-flash` MD5 match). Used by the session-trusted verify-skip
+/// path — see [`DeviceManager::trusted_firmware_hash`].
+#[derive(Debug, Clone, Copy)]
+pub struct TrustedFirmwareHash {
+    /// SHA-256 of the (offset, size, bytes) tuples for all flashed
+    /// regions. Stable across rebuilds that produce identical output.
+    pub hash: [u8; 32],
+    /// Instant when this hash was recorded. Compared against
+    /// [`DeviceState::last_disconnect_at`] to invalidate trust on any
+    /// device disconnect — if the user unplugged the board, something
+    /// else may have flashed it before it came back.
+    pub set_at: Instant,
+}
+
 /// Per-device tracked state.
 #[derive(Debug, Clone)]
 pub struct DeviceState {
@@ -39,6 +55,15 @@ pub struct DeviceState {
     pub monitor_leases: HashMap<String, DeviceLease>,
     pub last_seen_at: f64,
     pub is_connected: bool,
+    /// Firmware image last seen on this device, or `None` if the
+    /// daemon has not deployed/verified since startup. Cleared on
+    /// disconnect through [`DeviceState::last_disconnect_at`].
+    pub trusted_firmware: Option<TrustedFirmwareHash>,
+    /// `Instant` of the most recent `true → false` transition on
+    /// `is_connected`. Used to invalidate `trusted_firmware` if a
+    /// disconnect happened after the trust was set. Populated at
+    /// runtime, never serialized.
+    pub last_disconnect_at: Option<Instant>,
 }
 
 impl DeviceState {
@@ -90,8 +115,15 @@ impl DeviceManager {
         let mut devices = self.devices.lock().unwrap();
         let now = Self::now_unix();
 
-        // Mark all devices as disconnected first
-        for state in devices.values_mut() {
+        // Mark all devices as disconnected first. Track the previous
+        // `is_connected` state so we can stamp `last_disconnect_at`
+        // on the `true → false` edge *after* the re-enumeration pass
+        // below re-flips surviving devices. The stamp lets
+        // `trusted_firmware_hash` invalidate any trust that predates
+        // a physical disconnect — see `TrustedFirmwareHash::set_at`.
+        let mut was_connected: HashMap<String, bool> = HashMap::with_capacity(devices.len());
+        for (key, state) in devices.iter_mut() {
+            was_connected.insert(key.clone(), state.is_connected);
             state.is_connected = false;
         }
 
@@ -129,6 +161,8 @@ impl DeviceManager {
                 monitor_leases: HashMap::new(),
                 last_seen_at: now,
                 is_connected: true,
+                trusted_firmware: None,
+                last_disconnect_at: None,
             });
 
             entry.is_connected = true;
@@ -137,6 +171,21 @@ impl DeviceManager {
             entry.device_id = device_id;
             entry.vid = vid;
             entry.pid = pid;
+        }
+
+        // Stamp `last_disconnect_at` for every device that went from
+        // `true → false` on this refresh (i.e. it was connected
+        // before, but absent from this enumeration). Devices that
+        // came back on this pass stay with `is_connected = true` and
+        // don't get a fresh stamp.
+        for (key, prev) in was_connected {
+            if prev {
+                if let Some(state) = devices.get_mut(&key) {
+                    if !state.is_connected {
+                        state.last_disconnect_at = Some(Instant::now());
+                    }
+                }
+            }
         }
     }
 
@@ -316,6 +365,60 @@ impl DeviceManager {
         Ok((lease, preempted_client_id))
     }
 
+    /// Return the currently-trusted firmware hash for `port`, if any.
+    ///
+    /// Trust is valid only if:
+    ///  1. [`DeviceState::trusted_firmware`] is `Some`, AND
+    ///  2. The port is currently connected, AND
+    ///  3. No disconnect has been observed since the hash was recorded
+    ///     (i.e. [`DeviceState::last_disconnect_at`] is either `None`
+    ///     or older than `trusted_firmware.set_at`).
+    ///
+    /// Returns `None` in every other case, so the deploy handler falls
+    /// back to the regular `verify-flash` path on any doubt.
+    pub fn trusted_firmware_hash(&self, port: &str) -> Option<[u8; 32]> {
+        let devices = self.devices.lock().unwrap();
+        let state = devices.get(port)?;
+        if !state.is_connected {
+            return None;
+        }
+        let trusted = state.trusted_firmware.as_ref()?;
+        if let Some(disc) = state.last_disconnect_at {
+            if disc > trusted.set_at {
+                return None;
+            }
+        }
+        Some(trusted.hash)
+    }
+
+    /// Record a newly-observed firmware hash for `port`, stamped
+    /// with `Instant::now()`. Called after a successful write-flash
+    /// *or* a successful verify-flash match — in both cases the
+    /// daemon knows exactly what the device holds right now.
+    ///
+    /// Silently no-ops if the port isn't in the enumeration cache
+    /// yet: the hash will be recorded on the next deploy once
+    /// `refresh_devices` has picked the port up.
+    pub fn set_trusted_firmware_hash(&self, port: &str, hash: [u8; 32]) {
+        let mut devices = self.devices.lock().unwrap();
+        if let Some(state) = devices.get_mut(port) {
+            state.trusted_firmware = Some(TrustedFirmwareHash {
+                hash,
+                set_at: Instant::now(),
+            });
+        }
+    }
+
+    /// Drop any recorded trust for `port`. Called when a deploy
+    /// fails part-way through — partial writes mean we can't say
+    /// what's on the chip anymore.
+    pub fn clear_trusted_firmware_hash(&self, port: &str) {
+        let mut devices = self.devices.lock().unwrap();
+        if let Some(state) = devices.get_mut(port) {
+            state.trusted_firmware = None;
+        }
+    }
+
     /// Remove stale disconnected devices that have no leases.
     pub fn cleanup_stale_devices(&self) -> usize {
         let mut devices = self.devices.lock().unwrap();
@@ -354,6 +457,8 @@ mod tests {
                     monitor_leases: HashMap::new(),
                     last_seen_at: DeviceManager::now_unix(),
                     is_connected: true,
+                    trusted_firmware: None,
+                    last_disconnect_at: None,
                 },
             );
         }
@@ -481,6 +586,73 @@ mod tests {
         }
         assert_eq!(mgr.cleanup_stale_devices(), 1);
         assert!(mgr.get_all_devices().is_empty());
+    }
+
+    #[test]
+    fn trusted_hash_round_trip() {
+        let mgr = make_manager_with_device("COM3");
+        assert_eq!(mgr.trusted_firmware_hash("COM3"), None);
+        let h = [7u8; 32];
+        mgr.set_trusted_firmware_hash("COM3", h);
+        assert_eq!(mgr.trusted_firmware_hash("COM3"), Some(h));
+    }
+
+    #[test]
+    fn trusted_hash_cleared_on_demand() {
+        let mgr = make_manager_with_device("COM3");
+        mgr.set_trusted_firmware_hash("COM3", [1u8; 32]);
+        mgr.clear_trusted_firmware_hash("COM3");
+        assert_eq!(mgr.trusted_firmware_hash("COM3"), None);
+    }
+
+    /// Unknown port is never trusted — no panic, no fabrication of
+    /// device state. Regression guard: the deploy handler calls this
+    /// with a user-supplied port string that may not be in the
+    /// daemon's enumeration cache yet.
+    #[test]
+    fn trusted_hash_unknown_port_is_none() {
+        let mgr = DeviceManager::new();
+        assert_eq!(mgr.trusted_firmware_hash("COM99"), None);
+    }
+
+    /// A disconnected device must never be trusted, even if the hash
+    /// was previously recorded. Re-enumeration can come back with a
+    /// physically different board on the same port name — trust
+    /// across that boundary is unsafe.
+    #[test]
+    fn trusted_hash_invalid_after_disconnect() {
+        let mgr = make_manager_with_device("COM3");
+        mgr.set_trusted_firmware_hash("COM3", [9u8; 32]);
+        // Simulate a disconnect that happened *after* the trust was
+        // recorded — exactly the condition
+        // `trusted_firmware_hash` must treat as "unsafe to trust".
+        {
+            let mut devices = mgr.devices.lock().unwrap();
+            let state = devices.get_mut("COM3").unwrap();
+            state.is_connected = false;
+            state.last_disconnect_at = Some(Instant::now());
+        }
+        assert_eq!(mgr.trusted_firmware_hash("COM3"), None);
+    }
+
+    /// A stale disconnect stamp from *before* the trust was set
+    /// (e.g. device was unplugged earlier in the session but the
+    /// user reconnected and we re-trusted) does NOT invalidate the
+    /// fresh trust. Ordering is what matters: `disconnect > set` ⇒
+    /// untrusted; `set > disconnect` ⇒ trusted.
+    #[test]
+    fn trusted_hash_survives_older_disconnect_stamp() {
+        let mgr = make_manager_with_device("COM3");
+        // Plant an old disconnect stamp first, then re-set trust
+        // later (what happens on a re-enumerate + fresh deploy).
+        {
+            let mut devices = mgr.devices.lock().unwrap();
+            let state = devices.get_mut("COM3").unwrap();
+            state.last_disconnect_at = Some(Instant::now());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        mgr.set_trusted_firmware_hash("COM3", [3u8; 32]);
+        assert_eq!(mgr.trusted_firmware_hash("COM3"), Some([3u8; 32]));
     }
 
     #[test]

--- a/crates/fbuild-daemon/src/handlers/operations.rs
+++ b/crates/fbuild-daemon/src/handlers/operations.rs
@@ -1135,6 +1135,16 @@ pub async fn deploy(
     // without needing a cross-thread lock handshake.
     let ctx_for_deploy = Arc::clone(&ctx);
     let trusted_hash_enabled = trust_device_hash_enabled();
+    // Refresh the enumeration cache so the trust-hash invalidation
+    // path (`last_disconnect_at`) sees any unplug/replug that
+    // happened between the previous deploy and now. Without this,
+    // a user who swapped boards at the same COM port without hitting
+    // a device-list endpoint could trip the trust check into a
+    // false match. Cost is a single OS-level port enumeration
+    // (~10–30 ms on Windows), paid once per deploy.
+    if trusted_hash_enabled {
+        ctx.device_manager.refresh_devices();
+    }
     let deploy_result = tokio::task::spawn_blocking(move || {
         // Populated by the Espressif32 arm with (image_hash, port).
         // The tail of the closure consults it after `deployer.deploy`

--- a/crates/fbuild-daemon/src/handlers/operations.rs
+++ b/crates/fbuild-daemon/src/handlers/operations.rs
@@ -1441,27 +1441,42 @@ pub async fn deploy(
     // Clear preemption then wait for USB re-enumeration.
     // Fast-poll the serial port instead of a hard 2s sleep — most ESP32-S3
     // boards with native USB re-enumerate in <500ms.
+    //
+    // Skip the poll entirely when the deploy didn't actually touch
+    // flash (VerifySkip): no reset happened, no USB re-enumeration
+    // is coming, and the poll's `open()` probe would conflict with
+    // any already-attached monitor and burn the full 3 s timeout.
+    // This is load-bearing for the < 4 s warm-trust-skip budget.
+    let deploy_skipped_bus_work = matches!(
+        &deploy_result,
+        Ok(Ok(r)) if r.success && matches!(
+            r.outcome,
+            fbuild_deploy::DeployOutcome::VerifySkip
+        )
+    );
     if let Some(ref p) = deploy_port_str {
         ctx.serial_manager.clear_preemption(p).await;
-        let port_name = p.clone();
-        let _ = tokio::task::spawn_blocking(move || {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-            while std::time::Instant::now() < deadline {
-                if serialport::new(&port_name, 115200)
-                    .timeout(std::time::Duration::from_millis(50))
-                    .open()
-                    .is_ok()
-                {
-                    return;
+        if !deploy_skipped_bus_work {
+            let port_name = p.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+                while std::time::Instant::now() < deadline {
+                    if serialport::new(&port_name, 115200)
+                        .timeout(std::time::Duration::from_millis(50))
+                        .open()
+                        .is_ok()
+                    {
+                        return;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(100));
                 }
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-            tracing::warn!(
-                "USB re-enumeration: port {} not available after 3s",
-                port_name
-            );
-        })
-        .await;
+                tracing::warn!(
+                    "USB re-enumeration: port {} not available after 3s",
+                    port_name
+                );
+            })
+            .await;
+        }
     }
 
     let (deploy_success, deploy_stdout, deploy_stderr, deploy_outcome) = match deploy_result {

--- a/crates/fbuild-daemon/src/handlers/operations.rs
+++ b/crates/fbuild-daemon/src/handlers/operations.rs
@@ -33,6 +33,64 @@ pub(crate) fn native_verify_enabled() -> bool {
     }
 }
 
+/// Returns `true` when the daemon should trust an in-memory firmware
+/// hash (keyed by port) and skip the `verify-flash` MD5 round-trip on
+/// a warm redeploy.
+///
+/// Safety model: the hash is only honoured if the port has been
+/// continuously enumerated since the hash was recorded (enforced by
+/// [`DeviceManager::trusted_firmware_hash`]). If the user unplugged
+/// the board and something else flashed it before it came back, the
+/// disconnect edge invalidates the cached hash and the deploy falls
+/// through to the normal verify-flash path.
+///
+/// Controlled by the `FBUILD_TRUST_DEVICE_HASH` environment variable
+/// (set to `1`, `true`, `yes`, or `on` — case-insensitive). Default
+/// off while the path accumulates bench time, mirroring the opt-in
+/// convention used by `FBUILD_USE_ESPFLASH_{VERIFY,WRITE}`.
+pub(crate) fn trust_device_hash_enabled() -> bool {
+    match std::env::var("FBUILD_TRUST_DEVICE_HASH") {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => false,
+    }
+}
+
+/// Compute a stable SHA-256 over the three ESP32 flash regions the
+/// daemon would otherwise MD5 with `verify-flash`. Hashes the tuple
+/// `(offset_le, len_le, bytes)` for each region in fixed order
+/// (bootloader → partitions → firmware) so the digest uniquely
+/// identifies the image that would be written; two builds of the
+/// same source with identical output hash to the same value.
+///
+/// Returns `None` if any of the three files is missing on disk, so
+/// the caller treats it as "can't trust-skip, fall through to
+/// verify-flash."
+pub(crate) fn compute_esp32_image_hash(
+    firmware_path: &std::path::Path,
+    bootloader_offset: u32,
+    partitions_offset: u32,
+    firmware_offset: u32,
+) -> Option<[u8; 32]> {
+    use sha2::{Digest, Sha256};
+    let build_dir = firmware_path.parent()?;
+    let regions: [(u32, std::path::PathBuf); 3] = [
+        (bootloader_offset, build_dir.join("bootloader.bin")),
+        (partitions_offset, build_dir.join("partitions.bin")),
+        (firmware_offset, firmware_path.to_path_buf()),
+    ];
+    let mut hasher = Sha256::new();
+    for (offset, path) in &regions {
+        let bytes = std::fs::read(path).ok()?;
+        hasher.update(offset.to_le_bytes());
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+    }
+    Some(hasher.finalize().into())
+}
+
 /// Returns `true` when the daemon should route ESP32 `write-flash`
 /// through the native [`espflash`] crate (issue #66) instead of the
 /// Python `esptool` subprocess.
@@ -1072,7 +1130,17 @@ pub async fn deploy(
     let deploy_fw = firmware_path.clone();
     let baud_override = req.baud_rate;
     let deploy_board_overrides = board_overrides.clone();
+    // Snapshot the ctx pointer so the spawn_blocking closure can
+    // consult / update the daemon's in-memory trusted-hash cache
+    // without needing a cross-thread lock handshake.
+    let ctx_for_deploy = Arc::clone(&ctx);
+    let trusted_hash_enabled = trust_device_hash_enabled();
     let deploy_result = tokio::task::spawn_blocking(move || {
+        // Populated by the Espressif32 arm with (image_hash, port).
+        // The tail of the closure consults it after `deployer.deploy`
+        // returns to record or invalidate the daemon's trusted-hash
+        // cache. Other platforms leave it `None`.
+        let mut trusted_hash_update: Option<([u8; 32], String)> = None;
         let deployer: Box<dyn fbuild_deploy::Deployer> = match platform {
             fbuild_core::Platform::Espressif32 => {
                 let board_config =
@@ -1141,6 +1209,68 @@ pub async fn deploy(
                 // until the native write path has bench time on every
                 // ESP32 family member.
                 let deployer = deployer.with_native_write(native_write_enabled());
+
+                // Compute a deterministic SHA-256 over the three
+                // regions we'd otherwise verify-flash. Used twice
+                // below: once to consult the daemon's trusted-hash
+                // cache (opt-in via `FBUILD_TRUST_DEVICE_HASH=1`),
+                // and once to *record* the hash after a successful
+                // deploy so the next warm redeploy can skip the MD5
+                // round-trip entirely. A `None` return means one of
+                // the three files isn't on disk yet — treat it as
+                // "can't trust-skip" rather than erroring, so the
+                // fallback path is free to rebuild missing artefacts.
+                let image_hash = compute_esp32_image_hash(
+                    &deploy_fw,
+                    u32::from_str_radix(
+                        mcu_config.bootloader_offset().trim_start_matches("0x"),
+                        16,
+                    )
+                    .unwrap_or(0),
+                    u32::from_str_radix(
+                        mcu_config.partitions_offset().trim_start_matches("0x"),
+                        16,
+                    )
+                    .unwrap_or(0),
+                    u32::from_str_radix(
+                        mcu_config.firmware_offset().trim_start_matches("0x"),
+                        16,
+                    )
+                    .unwrap_or(0),
+                );
+
+                // Session-trusted verify-skip: if the daemon last
+                // flashed *this exact image* onto *this port* and the
+                // port has been continuously enumerated since then,
+                // no external agent could have re-flashed the chip
+                // without breaking our enumeration (`last_disconnect_at`
+                // is how we detect it). Skip the entire serial open +
+                // espflash connect + MD5 round-trip.
+                if let (Some(port), Some(hash)) = (deploy_port.as_deref(), image_hash) {
+                    if trusted_hash_enabled {
+                        if let Some(trusted) =
+                            ctx_for_deploy.device_manager.trusted_firmware_hash(port)
+                        {
+                            if trusted == hash {
+                                tracing::info!(
+                                    port,
+                                    "trusted-hash: session-trusted match; skipping verify-flash entirely"
+                                );
+                                return Ok(fbuild_deploy::DeploymentResult {
+                                    success: true,
+                                    message: format!(
+                                        "firmware already current on {} (skipped via session trust)",
+                                        port
+                                    ),
+                                    port: Some(port.to_string()),
+                                    stdout: String::new(),
+                                    stderr: String::new(),
+                                    outcome: fbuild_deploy::DeployOutcome::VerifySkip,
+                                });
+                            }
+                        }
+                    }
+                }
 
                 // Fast deploy: ask the device whether it already holds
                 // the exact firmware/bootloader/partitions we'd be about
@@ -1211,8 +1341,35 @@ pub async fn deploy(
                 }
 
                 if let (Some(regions), Some(port)) = (selective_regions, deploy_port.as_deref()) {
-                    return deployer.deploy_regions(&deploy_fw, port, &regions);
+                    let result = deployer.deploy_regions(&deploy_fw, port, &regions);
+                    // Record/invalidate the trusted hash based on
+                    // the selective-flash outcome so the next warm
+                    // redeploy can short-circuit via trust-skip.
+                    if let Some(hash) = image_hash {
+                        match &result {
+                            Ok(r) if r.success => {
+                                ctx_for_deploy
+                                    .device_manager
+                                    .set_trusted_firmware_hash(port, hash);
+                            }
+                            _ => {
+                                ctx_for_deploy.device_manager.clear_trusted_firmware_hash(port);
+                            }
+                        }
+                    }
+                    return result;
                 }
+
+                // Capture the hash into the boxed deployer closure
+                // below — the full-flash path (`deployer.deploy(...)`)
+                // at the end of this `spawn_blocking` applies the
+                // same record/invalidate rule. We stash the hash +
+                // port via a small impl-only wrapper because the
+                // `Deployer` trait doesn't expose the cache hook.
+                // Stored here so the common tail after the `match`
+                // can reach it without re-threading every arm.
+                // (AVR / other arms leave it `None` → no-op.)
+                trusted_hash_update = image_hash.zip(deploy_port.as_deref().map(str::to_string));
 
                 Box::new(deployer)
             }
@@ -1251,12 +1408,33 @@ pub async fn deploy(
                 )));
             }
         };
-        deployer.deploy(
+        let result = deployer.deploy(
             &deploy_project,
             &deploy_env,
             &deploy_fw,
             deploy_port.as_deref(),
-        )
+        );
+        // Session-trusted verify-skip: record (or invalidate) the
+        // image hash the daemon associates with this port. Scoped
+        // to the Espressif32 arm above — other platforms leave
+        // `trusted_hash_update` as `None` and this block no-ops.
+        // Failed or partial deploys clear the cache so the next
+        // warm run falls back to the verify-flash path.
+        if let Some((hash, port)) = trusted_hash_update {
+            match &result {
+                Ok(r) if r.success => {
+                    ctx_for_deploy
+                        .device_manager
+                        .set_trusted_firmware_hash(&port, hash);
+                }
+                _ => {
+                    ctx_for_deploy
+                        .device_manager
+                        .clear_trusted_firmware_hash(&port);
+                }
+            }
+        }
+        result
     })
     .await;
 

--- a/crates/fbuild-daemon/src/main.rs
+++ b/crates/fbuild-daemon/src/main.rs
@@ -5,7 +5,7 @@ use axum::routing::{get, post};
 use axum::Router;
 use clap::Parser;
 use fbuild_daemon::context::{
-    BroadcastHub, DaemonContext, IDLE_TIMEOUT, SELF_EVICTION_TIMEOUT, STALE_LOCK_CHECK_INTERVAL,
+    self_eviction_timeout, BroadcastHub, DaemonContext, IDLE_TIMEOUT, STALE_LOCK_CHECK_INTERVAL,
 };
 use fbuild_daemon::handlers::{cache, devices, emulator, health, locks, operations, websockets};
 use fbuild_daemon::log_layer::BroadcastLogLayer;
@@ -184,7 +184,7 @@ async fn main() {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-                // --- Self-eviction: 0 ops + 0 serial sessions for SELF_EVICTION_TIMEOUT ---
+                // --- Self-eviction: 0 ops + 0 serial sessions for self_eviction_timeout ---
                 match ctx.busy_reason() {
                     None => {
                         if last_busy_reason.is_some() {
@@ -195,10 +195,10 @@ async fn main() {
                             daemon_empty_since = Some(std::time::Instant::now());
                             tracing::info!(
                                 "Daemon is idle; self-eviction in {:.0}s unless new work arrives",
-                                SELF_EVICTION_TIMEOUT.as_secs_f64()
+                                self_eviction_timeout().as_secs_f64()
                             );
                         } else if let Some(since) = daemon_empty_since {
-                            if since.elapsed() >= SELF_EVICTION_TIMEOUT {
+                            if since.elapsed() >= self_eviction_timeout() {
                                 tracing::info!(
                                     "Self-eviction triggered: daemon empty for {:.1}s, shutting down",
                                     since.elapsed().as_secs_f64()


### PR DESCRIPTION
## Summary

Implements the session-trusted verify-skip optimization flagged in #114 / LOOP.md: when the daemon has just deployed a known image to a port **and** the port has stayed continuously enumerated since then, no external agent could have re-flashed the chip without breaking our serial enumeration. The next deploy of the same image can therefore return `VerifySkip` immediately — skipping the full verify-flash path (serial open + espflash connect + stub upload + 3× `FLASH_MD5SUM`), which measured ~1.5 s on the native path in #66.

Implements the design the user called out:
> if we have exclusive control over a port, then we can guarantee it has the same firmware, otherwise someone else would have broken the exclusive serial connect that we have

## What's in the PR

1. **`TrustedFirmwareHash` on `DeviceState`** (`crates/fbuild-daemon/src/device_manager.rs`) — SHA-256 + `set_at` Instant, stored in the existing in-memory map. Invalidated by `last_disconnect_at` stamped on the `true → false` enumeration edge in `refresh_devices`.
2. **`DeviceManager::{trusted_firmware_hash, set_trusted_firmware_hash, clear_trusted_firmware_hash}`** API methods.
3. **`compute_esp32_image_hash`** in `handlers::operations` — deterministic SHA-256 over `(offset_le, len_le, bytes)` for bootloader + partitions + firmware, so identical builds hash to identical values.
4. **Deploy-handler wiring** — check the hash before the existing `try_verify_deployment` call; short-circuit with `VerifySkip` on match; refresh enumeration once per deploy so the `last_disconnect_at` invalidation is sound; record/invalidate the hash after the deploy returns.
5. **Skip the post-deploy USB re-enum poll on `VerifySkip` outcome** — on the trust-skip path the port was never closed, so the 3 s poll loop (which collides with an attached monitor) is pure overhead. Load-bearing for the < 4 s warm-trust-skip budget.
6. **`FBUILD_SELF_EVICTION_SECS` env override** on `SELF_EVICTION_TIMEOUT` — lets the warm-deploy benchmark keep one daemon alive across T1→T2→T3 without the 30 s idle timer racing against spawn latency.

## Opt-in

Gated by `FBUILD_TRUST_DEVICE_HASH=1`, mirroring the opt-in convention from #66's `FBUILD_USE_ESPFLASH_{VERIFY,WRITE}`. Default off until benched on every ESP32 family member.

## Tests

- 5 new `device_manager` unit tests: round-trip, clear, unknown-port, invalidation after disconnect, survival across older disconnect stamp.
- All 116 `fbuild-daemon` lib tests pass.
- `uv run cargo clippy -p fbuild-daemon --all-targets -- -D warnings` clean.

## Benchmarking

Hardware bench on the real ESP32-S3 on `COM13` was attempted but blocked by a pre-existing ESP32 cold-build stall (orchestrator hangs mid-Arduino-framework-library compile with no active compiler processes, stays "operation in progress" for 15+ minutes). That stall is orthogonal to this PR's code path and will be investigated separately.

Verified warm-case fast paths that don't depend on ESP32:
- `tests/platform/uno` cold build: 4.3 s (healthy)
- `tests/platform/uno` warm rebuild: **211 ms** (fingerprint hit, well inside the 500 ms LOOP.md budget)

Theoretical warm-deploy savings under the new path, once end-to-end bench returns clean:
- Today (native verify-skip): ~1.5 s verify + ~100-3000 ms USB wait ≈ 2-5 s
- With trust-skip: SHA-256 compute (~10 ms for 2.4 MB) + DashMap lookup + early return ≈ < 50 ms server side; monitor reattach adds ~100-300 ms
- Budget room recovered: 1-4 s, comfortably inside the 4 s total target

## Test plan

- [ ] Apply `FBUILD_TRUST_DEVICE_HASH=1` on a daemon + real ESP32 board, run back-to-back deploys of the same image, confirm the second deploy emits `"trusted-hash: session-trusted match"` instead of the `verify-flash` line.
- [ ] Unplug/replug the board between deploys — confirm the next deploy falls back to the full verify-flash path (trust invalidated by disconnect edge).
- [ ] Modify the sketch slightly — confirm the hash mismatch causes a full flash and the trust entry updates to the new hash.

Related: #66 (native espflash migration), #91 (warm-build instrumentation), #114 (warm-deploy loop tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment optimization for Espressif32 devices using cached device verification to reduce deployment time and eliminate redundant checks.

* **Configuration**
  * New environment variable `FBUILD_TRUST_DEVICE_HASH` enables hardware-backed verification optimization (disabled by default for safety).
  * New environment variable `FBUILD_SELF_EVICTION_SECS` configures the daemon's idle timeout duration in seconds (defaults to 30 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->