### PR TITLE
chore: bump version to 2.1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-build"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "async-trait",
  "fbuild-config",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "blake3",
  "clap",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "libc",
  "running-process-core",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "async-trait",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "async-trait",
  "espflash",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "axum",
  "bzip2",
@@ -912,14 +912,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "async-trait",
  "base64",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.1.18"
+version = "2.1.19"
 dependencies = [
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.1.18"
+version = "2.1.19"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "fbuild"
-version = "2.1.18"
+version = "2.1.19"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 requires-python = ">=3.10"
-dependencies = ["zccache>=1.2.11"]
+dependencies = ["zccache>=1.2.12"]
 
 [dependency-groups]
 dev = ["fbuild-dev-tools"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.1.18"
+version = "2.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },
@@ -16,7 +16,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "zccache", specifier = ">=1.2.11" }]
+requires-dist = [{ name = "zccache", specifier = ">=1.2.12" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "fbuild-dev-tools", editable = "ci/dev-tools" }]
@@ -47,13 +47,13 @@ wheels = [
 
 [[package]]
 name = "zccache"
-version = "1.2.11"
+version = "1.2.12"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/81/4e1530a56fa542a04b77550b5f7caa5af04743ade5f61829f8f3278d75fc/zccache-1.2.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c0506c248941649caf4e0c0c99412a0c27ce220370a471aa24d01e5bcde6419", size = 11483374, upload-time = "2026-04-15T21:31:46.555Z" },
-    { url = "https://files.pythonhosted.org/packages/93/dd/a6a2ebf62bec41b1f030fd34b4736e65293fbf56672cd862a0906a91a763/zccache-1.2.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:45c26b9c7f2b9ad2ed589a38258cc57da7b5c26d33ce90734631e60f9ed63ded", size = 10975620, upload-time = "2026-04-15T21:32:08.908Z" },
-    { url = "https://files.pythonhosted.org/packages/65/1e/9d16a90e4d1e3f4a0ae1be6bb04711665b712804b859648fc06a2996186b/zccache-1.2.11-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:539babc3939bfd9d64d5e383701eacf8fc49bcbf02e9f05ef10353e3eb097be9", size = 10939961, upload-time = "2026-04-15T21:32:33.385Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/57/5992da4eccecc8a9543b8454cd4b9990b88b6f04d3902dccc3c741a6056e/zccache-1.2.11-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:9562a4670b81a221d485cac61573345981341852f25e8a10fc605fe9cb0ca2b5", size = 11883144, upload-time = "2026-04-15T21:33:01.622Z" },
-    { url = "https://files.pythonhosted.org/packages/24/9f/2aeff3a8b1923c3d5a22c57395b2b8bcab2111d7fa1b335d6705eb397d84/zccache-1.2.11-py3-none-win_amd64.whl", hash = "sha256:e76a43e3064942330d201e41cc4f3280147ba701ebff1a59f33f010d826e3aa9", size = 10705481, upload-time = "2026-04-15T21:33:20.256Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/74/184244b1372e44fe16ff29d80db2d787edad3e29a5b66b8be30864af7681/zccache-1.2.11-py3-none-win_arm64.whl", hash = "sha256:fdac965a041d21d43c1c28ecc3468494e23b4e9af21089cad32cecf87778f236", size = 9952566, upload-time = "2026-04-15T21:33:42.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/a0e100342f30a928d027156046b3d510806b00abd70d3a780080fa18b753/zccache-1.2.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b26ca9fbd8c4ccd36023b657f9af699c5cbf5a805af7164cec5ed8b276e5e989", size = 11488714, upload-time = "2026-04-18T20:22:06.087Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/1a/860600f40f771244bd8bbecced9d6e356cb34cf6e0ce46aa580ab7bf1f9d/zccache-1.2.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:89d475e4ee11a0195b64da57c53f4b06376003da5d347891a12bfb363ad94269", size = 10978827, upload-time = "2026-04-18T20:22:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e2/d906f9184cfd403f6402826484cb4277af4a125a296f75c8abb3d1ffacef/zccache-1.2.12-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e7096a9716764e094c09510445a25e3ce105341ed6c498aa203622fa53eec939", size = 10941646, upload-time = "2026-04-18T20:22:57.647Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7b/e3548c4b55296f6f08f35f3bddb1cf67ccb048cb354e7f411e6f23810333/zccache-1.2.12-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:0ebacaeb0ad3080ac81a02b00267b6d6f178ca8e6ab83f0d73a424a0e6323045", size = 11886978, upload-time = "2026-04-18T20:23:24.411Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a9/c11a2f64f847d457536fc94c825dabae4a476b011c49086b53b398d70ae6/zccache-1.2.12-py3-none-win_amd64.whl", hash = "sha256:ada4bfd47c56f65aff5ce5db9e210f093bf90381705d1043ab1ad0ea5ff9d34d", size = 10714093, upload-time = "2026-04-18T20:23:46.504Z" },
+    { url = "https://files.pythonhosted.org/packages/99/23/702306c7e5d8a55fc443acab81475f9469186527be577d51d9b2277b6197/zccache-1.2.12-py3-none-win_arm64.whl", hash = "sha256:d368addaa5b5bbd102406838e86b6621ec2a9451e653e1b64078a83b454e42f3", size = 9955945, upload-time = "2026-04-18T20:24:09.38Z" },
 ]


### PR DESCRIPTION
Release cut that ships the .lnk resource pointer feature from #119. Also bumps zccache pin to >=1.2.12 (post-link deploy hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 2.1.19 for this maintenance release.
  * Updated zccache dependency to a newer minimum version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->