### PR TITLE
style: apply rustfmt to lnk pipeline files

### DIFF
--- a/crates/fbuild-build/src/esp32/orchestrator.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator.rs
@@ -1058,13 +1058,10 @@ impl BuildOrchestrator for Esp32Orchestrator {
                     if fbuild_packages::lnk::has_lnk_extension(&p) {
                         let cache = lnk_cache.as_ref().ok_or_else(|| {
                             fbuild_core::FbuildError::PackageError(
-                                "disk cache unavailable; cannot resolve .lnk entries"
-                                    .to_string(),
+                                "disk cache unavailable; cannot resolve .lnk entries".to_string(),
                             )
                         })?;
-                        let m = fbuild_packages::lnk::materialize_lnk_entry(
-                            &p, &lnk_dir, cache,
-                        )?;
+                        let m = fbuild_packages::lnk::materialize_lnk_entry(&p, &lnk_dir, cache)?;
                         out.push(m.target_path.to_string_lossy().into_owned());
                     } else {
                         out.push(entry.clone());

--- a/crates/fbuild-cli/src/main.rs
+++ b/crates/fbuild-cli/src/main.rs
@@ -2951,17 +2951,14 @@ async fn run_lnk(
 
     fn open_cache() -> fbuild_core::Result<fbuild_packages::DiskCache> {
         fbuild_packages::DiskCache::open().map_err(|e| {
-            fbuild_core::FbuildError::PackageError(format!(
-                "failed to open lnk disk cache: {e}"
-            ))
+            fbuild_core::FbuildError::PackageError(format!("failed to open lnk disk cache: {e}"))
         })
     }
 
-    fn resolve_root(
-        explicit: Option<String>,
-        fallback: &Option<String>,
-    ) -> PathBuf {
-        let chosen = explicit.or_else(|| fallback.clone()).unwrap_or_else(|| ".".to_string());
+    fn resolve_root(explicit: Option<String>, fallback: &Option<String>) -> PathBuf {
+        let chosen = explicit
+            .or_else(|| fallback.clone())
+            .unwrap_or_else(|| ".".to_string());
         PathBuf::from(chosen)
     }
 
@@ -2993,7 +2990,10 @@ async fn run_lnk(
                     }
                 }
             }
-            println!("\nlnk pull: {ok} ok, {failed} failed (of {})", discovered.len());
+            println!(
+                "\nlnk pull: {ok} ok, {failed} failed (of {})",
+                discovered.len()
+            );
             if failed > 0 {
                 std::process::exit(1);
             }
@@ -3012,25 +3012,34 @@ async fn run_lnk(
             let mut missing = 0usize;
             let mut mismatched = 0usize;
             for d in &discovered {
-                let entry = cache.lookup(
-                    fbuild_packages::disk_cache::Kind::LnkBlobs,
-                    &d.lnk.url,
-                    &d.lnk.sha256,
-                ).map_err(|e| {
-                    fbuild_core::FbuildError::PackageError(format!(
-                        "lnk cache lookup failed for {}: {e}",
-                        d.path.display()
-                    ))
-                })?;
+                let entry = cache
+                    .lookup(
+                        fbuild_packages::disk_cache::Kind::LnkBlobs,
+                        &d.lnk.url,
+                        &d.lnk.sha256,
+                    )
+                    .map_err(|e| {
+                        fbuild_core::FbuildError::PackageError(format!(
+                            "lnk cache lookup failed for {}: {e}",
+                            d.path.display()
+                        ))
+                    })?;
                 let Some(entry) = entry else {
                     missing += 1;
-                    println!("MISSING {}  (run `fbuild lnk pull` to fetch)", d.path.display());
+                    println!(
+                        "MISSING {}  (run `fbuild lnk pull` to fetch)",
+                        d.path.display()
+                    );
                     continue;
                 };
                 let blob_path = PathBuf::from(entry.archive_path.unwrap_or_default());
                 if !blob_path.exists() {
                     missing += 1;
-                    println!("MISSING {}  (cache index points at {} which is gone)", d.path.display(), blob_path.display());
+                    println!(
+                        "MISSING {}  (cache index points at {} which is gone)",
+                        d.path.display(),
+                        blob_path.display()
+                    );
                     continue;
                 }
                 let bytes = std::fs::read(&blob_path).map_err(|e| {
@@ -3086,9 +3095,7 @@ async fn run_lnk(
 
             // Download to a temp dir, hash it, then write the .lnk.
             let tmp = tempfile::tempdir().map_err(|e| {
-                fbuild_core::FbuildError::PackageError(format!(
-                    "failed to create temp dir: {e}"
-                ))
+                fbuild_core::FbuildError::PackageError(format!("failed to create temp dir: {e}"))
             })?;
             let downloaded = fbuild_packages::downloader::download_file(&url, tmp.path()).await?;
             let bytes = std::fs::read(&downloaded).map_err(|e| {

--- a/crates/fbuild-packages/src/lnk/embed.rs
+++ b/crates/fbuild-packages/src/lnk/embed.rs
@@ -104,10 +104,7 @@ mod tests {
     #[test]
     fn passes_through_non_lnk_entries() {
         let project = Path::new("/proj");
-        let entries = vec![
-            "data/file.bin".to_string(),
-            "/abs/path/x.txt".to_string(),
-        ];
+        let entries = vec!["data/file.bin".to_string(), "/abs/path/x.txt".to_string()];
         let resolved = expand_lnk_entries(&entries, project, |_| {
             panic!("should not be called for non-lnk entries")
         })
@@ -129,7 +126,10 @@ mod tests {
         .unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0], Path::new("/proj/data/asset.bin.lnk"));
-        assert_eq!(resolved, vec![PathBuf::from("/build/resources/data/asset.bin")]);
+        assert_eq!(
+            resolved,
+            vec![PathBuf::from("/build/resources/data/asset.bin")]
+        );
     }
 
     #[test]
@@ -156,10 +156,7 @@ mod tests {
 
     #[test]
     fn resolver_error_aborts_expansion() {
-        let entries = vec![
-            "good.bin.lnk".to_string(),
-            "bad.bin.lnk".to_string(),
-        ];
+        let entries = vec!["good.bin.lnk".to_string(), "bad.bin.lnk".to_string()];
         let mut count = 0;
         let result = expand_lnk_entries(&entries, Path::new("/p"), |_| {
             count += 1;

--- a/crates/fbuild-packages/tests/lnk_e2e.rs
+++ b/crates/fbuild-packages/tests/lnk_e2e.rs
@@ -38,17 +38,19 @@ async fn spawn_test_server(blobs: Vec<(String, Vec<u8>)>) -> (u16, tokio::task::
 
     let app = Router::new().route(
         "/:name",
-        get(move |axum::extract::Path(name): axum::extract::Path<String>| {
-            let blobs = Arc::clone(&blobs_for_handler);
-            async move {
-                for (n, bytes) in blobs.iter() {
-                    if n == &name {
-                        return (StatusCode::OK, Bytes::from(bytes.clone())).into_response();
+        get(
+            move |axum::extract::Path(name): axum::extract::Path<String>| {
+                let blobs = Arc::clone(&blobs_for_handler);
+                async move {
+                    for (n, bytes) in blobs.iter() {
+                        if n == &name {
+                            return (StatusCode::OK, Bytes::from(bytes.clone())).into_response();
+                        }
                     }
+                    (StatusCode::NOT_FOUND, "not found").into_response()
                 }
-                (StatusCode::NOT_FOUND, "not found").into_response()
-            }
-        }),
+            },
+        ),
     );
 
     // Bind to port 0 to get a free port from the OS.
@@ -99,7 +101,11 @@ async fn lnk_pipeline_e2e_fetches_verifies_and_materializes() {
     assert_eq!(materialized.len(), 1);
 
     let target = build_dir.join("data/asset.bin");
-    assert!(target.exists(), "materialized file should exist at {}", target.display());
+    assert!(
+        target.exists(),
+        "materialized file should exist at {}",
+        target.display()
+    );
     let got = std::fs::read(&target).unwrap();
     assert_eq!(got, blob_bytes, "materialized bytes should match source");
 
@@ -185,7 +191,10 @@ async fn lnk_pipeline_handles_404() {
     // Either the downloader bails on the non-2xx, or we bail on sha verify.
     // Both are acceptable failure modes — the assertion is just "errors out".
     let result = materialize_all(&discovered, &src_root, &build_dir, &cache);
-    assert!(result.is_err(), "expected error for unreachable/missing blob");
+    assert!(
+        result.is_err(),
+        "expected error for unreachable/missing blob"
+    );
 
     server_handle.abort();
 }


### PR DESCRIPTION
## Summary
- rustfmt-only cleanup in 4 files touched by the `.lnk` resource-pointer work (#119): `esp32/orchestrator.rs`, `fbuild-cli/src/main.rs`, `lnk/embed.rs`, and `lnk_e2e.rs`.
- No behavior changes — purely whitespace/line-wrapping to match `cargo fmt`.

## Test plan
- [x] `cargo fmt --check` passes (these were the delta)
- [ ] CI green across Linux / macOS / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code formatting and restructuring improvements across build orchestration and CLI modules.

* **Tests**
  * Updated test code formatting and assertion structure for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->