### PR TITLE
ci(security): add-to-project uses pull_request, tolerates missing App

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -21,11 +21,17 @@ name: add-to-project
 on:
   issues:
     types: [opened]
-  pull_request_target:
+  pull_request:
     types: [opened]
 
+# pull_request (not pull_request_target) — fork PRs run in the fork's context
+# without access to PROJECT_APP_PRIVATE_KEY, so they simply won't be
+# auto-added. That is an intentional security trade-off: pull_request_target
+# would run with base-repo secrets against fork-authored metadata, which is a
+# known exfiltration vector even when no code is checked out.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   add:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -34,13 +34,21 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ vars.PROJECT_APP_ID }}
           private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
           owner: ${{ vars.PROJECT_OWNER }}
 
+      - name: App not installed — skipping project sync
+        if: ${{ steps.app-token.outcome != 'success' }}
+        run: |
+          echo "::warning::FastLED Project Sync App is not installed on '${{ vars.PROJECT_OWNER }}'."
+          echo "::warning::Install it at https://github.com/organizations/${{ vars.PROJECT_OWNER }}/settings/installations to enable auto-add-to-project."
+
       - name: Add to project
+        if: ${{ steps.app-token.outcome == 'success' }}
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/${{ vars.PROJECT_OWNER }}/projects/${{ vars.PROJECT_NUMBER }}


### PR DESCRIPTION
## Summary
Two related fixes to the `add-to-project` workflow:

### 1. Security: `pull_request_target` → `pull_request`
`pull_request_target` runs in the base repo's context with access to secrets (`PROJECT_APP_PRIVATE_KEY`) but uses the PR's metadata. That's an exfiltration vector even when no code is checked out — malicious fork PRs could coerce `actions/add-to-project` or `actions/create-github-app-token` inputs in ways that leak the token. Switching to `pull_request` means fork PRs run without secrets (and therefore won't be auto-added) — an intentional trade-off for safety.

### 2. Tolerate missing GitHub App installation
After the repo transfer from `zackees/fbuild` to `FastLED/fbuild`, the **FastLED Project Sync** App is not installed on the new org. Every event was failing at the token step:
```
Failed to create token for "FastLED": Not Found
  url: https://api.github.com/users/FastLED/installation, status: 404
```
`continue-on-error` on the token step + gate the "Add to project" step on its outcome, plus a `::warning::` annotation pointing at the org Installations page. (Re-installing the App is still a separate admin step to restore functionality.)

## Test plan
- [ ] CI green
- [ ] After merge, future PRs don't show `add-to-project` as failing
- [ ] Reinstall the `FastLED Project Sync` App on the FastLED org to restore auto-add

🤖 Generated with [Claude Code](https://claude.com/claude-code)