### PR TITLE
fix(packages): migrate older DiskCache schemas to add leases.refcount

### DIFF
--- a/crates/fbuild-packages/src/disk_cache/index.rs
+++ b/crates/fbuild-packages/src/disk_cache/index.rs
@@ -2,6 +2,19 @@
 //!
 //! Opened in WAL mode with `synchronous=NORMAL` for multi-reader/single-writer
 //! safety and crash recovery. The WAL is replayed on next open after a crash.
+//!
+//! # Schema migrations
+//!
+//! Migrations are tracked in the `schema_migrations` table keyed by a
+//! stable migration id (`m001_initial_schema`, `m002_add_leases_refcount`,
+//! ...). On open, every registered migration is applied in order, inside
+//! its own transaction, unless it has already been recorded. This lets
+//! older production databases (created before a column existed) pick up
+//! schema deltas idempotently — adding a new migration is append-only.
+//!
+//! The legacy `cache_meta.schema_version` key is still written for
+//! backwards compatibility with any tooling that inspects it, but the
+//! authoritative source of truth is `schema_migrations`.
 
 use super::paths::{self, Kind};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -9,7 +22,41 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const SCHEMA_VERSION: i64 = 1;
+/// Legacy version pin written to `cache_meta` for backwards compatibility.
+///
+/// The real source of truth is the `schema_migrations` table. This value
+/// is mirrored so older tools that read `cache_meta.schema_version` keep
+/// working.
+const LEGACY_SCHEMA_VERSION: i64 = 1;
+
+/// A single ordered schema migration. Applied idempotently on open.
+///
+/// `id` must be stable and unique. Append new migrations to [`MIGRATIONS`]
+/// — never reorder or rename existing ids.
+struct Migration {
+    id: &'static str,
+    up: fn(&Connection) -> rusqlite::Result<()>,
+}
+
+/// The ordered list of migrations. Append-only.
+///
+/// - `m001_initial_schema` — the original tables + indexes. Uses
+///   `CREATE TABLE IF NOT EXISTS` so it is safe on databases where these
+///   objects already exist (e.g. older production caches).
+/// - `m002_add_leases_refcount` — adds `leases.refcount` when absent.
+///   Older databases (pre-#119) had a `leases` table without this column,
+///   which broke `pin()`/`unpin()`. New databases already get it from
+///   `m001`, so this migration only mutates old caches.
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        id: "m001_initial_schema",
+        up: migrate_m001_initial_schema,
+    },
+    Migration {
+        id: "m002_add_leases_refcount",
+        up: migrate_m002_add_leases_refcount,
+    },
+];
 
 /// A row in the `entries` table.
 #[derive(Debug, Clone)]
@@ -83,73 +130,53 @@ impl CacheIndex {
 
     fn migrate(&self) -> rusqlite::Result<()> {
         let conn = self.conn.lock().unwrap();
-        let version: i64 = conn
-            .query_row(
-                "SELECT value FROM cache_meta WHERE key = 'schema_version'",
-                [],
-                |row| {
-                    let v: String = row.get(0)?;
-                    Ok(v.parse::<i64>().unwrap_or(0))
-                },
-            )
-            .unwrap_or(0);
-
-        if version < 1 {
-            Self::migrate_v1(&conn)?;
-        }
-        Ok(())
+        Self::run_migrations(&conn)
     }
 
-    fn migrate_v1(conn: &Connection) -> rusqlite::Result<()> {
-        let tx = conn.unchecked_transaction()?;
-
-        tx.execute_batch(
-            "CREATE TABLE IF NOT EXISTS cache_meta (
-                key   TEXT PRIMARY KEY,
-                value TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS entries (
-                id              INTEGER PRIMARY KEY,
-                kind            TEXT NOT NULL,
-                url             TEXT NOT NULL,
-                stem            TEXT NOT NULL,
-                hash            TEXT NOT NULL,
-                version         TEXT NOT NULL,
-                archive_path    TEXT,
-                archive_bytes   INTEGER,
-                archive_sha256  TEXT,
-                installed_path  TEXT,
-                installed_bytes INTEGER,
-                installed_at    INTEGER,
-                archived_at     INTEGER,
-                last_used_at    INTEGER NOT NULL,
-                use_count       INTEGER NOT NULL DEFAULT 0,
-                pinned          INTEGER NOT NULL DEFAULT 0,
-                UNIQUE(kind, hash, version)
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_lru_installed
-                ON entries(last_used_at) WHERE installed_path IS NOT NULL;
-            CREATE INDEX IF NOT EXISTS idx_lru_archive
-                ON entries(last_used_at) WHERE archive_path IS NOT NULL;
-
-            CREATE TABLE IF NOT EXISTS leases (
-                entry_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
-                holder_pid   INTEGER NOT NULL,
-                holder_nonce INTEGER NOT NULL DEFAULT 0,
-                refcount     INTEGER NOT NULL DEFAULT 1,
-                acquired_at  INTEGER NOT NULL,
-                PRIMARY KEY(entry_id, holder_pid, holder_nonce)
+    /// Bootstrap the migrations-tracking table and run each registered
+    /// migration exactly once. Safe to call against fresh *or* pre-existing
+    /// databases; each migration is wrapped in its own transaction.
+    fn run_migrations(conn: &Connection) -> rusqlite::Result<()> {
+        // Bootstrap the migrations-tracking table. We can't use the
+        // migration framework itself for this because it's what records
+        // whether a migration ran.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS schema_migrations (
+                id         TEXT PRIMARY KEY,
+                applied_at INTEGER NOT NULL
             );",
         )?;
 
-        tx.execute(
-            "INSERT OR REPLACE INTO cache_meta (key, value) VALUES ('schema_version', ?1)",
-            params![SCHEMA_VERSION.to_string()],
-        )?;
+        for m in MIGRATIONS {
+            let already_applied: bool = conn
+                .query_row(
+                    "SELECT 1 FROM schema_migrations WHERE id = ?1",
+                    params![m.id],
+                    |_| Ok(true),
+                )
+                .optional()?
+                .unwrap_or(false);
+            if already_applied {
+                continue;
+            }
 
-        tx.commit()?;
+            let tx = conn.unchecked_transaction()?;
+            (m.up)(&tx)?;
+            tx.execute(
+                "INSERT INTO schema_migrations (id, applied_at) VALUES (?1, ?2)",
+                params![m.id, Self::now_epoch()],
+            )?;
+            tx.commit()?;
+        }
+
+        // Mirror the legacy cache_meta.schema_version key so any tooling
+        // that inspects it sees the expected value. Best-effort — the
+        // authoritative source is now `schema_migrations`.
+        let _ = conn.execute(
+            "INSERT OR REPLACE INTO cache_meta (key, value) VALUES ('schema_version', ?1)",
+            params![LEGACY_SCHEMA_VERSION.to_string()],
+        );
+
         Ok(())
     }
 
@@ -532,6 +559,86 @@ impl CacheIndex {
     }
 }
 
+/// m001 — original schema. Creates `cache_meta`, `entries`, the LRU
+/// indexes, and `leases` (with `refcount`). Uses `IF NOT EXISTS` so it
+/// is safe against caches that already have these objects from the
+/// pre-migration-framework era.
+fn migrate_m001_initial_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS cache_meta (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS entries (
+            id              INTEGER PRIMARY KEY,
+            kind            TEXT NOT NULL,
+            url             TEXT NOT NULL,
+            stem            TEXT NOT NULL,
+            hash            TEXT NOT NULL,
+            version         TEXT NOT NULL,
+            archive_path    TEXT,
+            archive_bytes   INTEGER,
+            archive_sha256  TEXT,
+            installed_path  TEXT,
+            installed_bytes INTEGER,
+            installed_at    INTEGER,
+            archived_at     INTEGER,
+            last_used_at    INTEGER NOT NULL,
+            use_count       INTEGER NOT NULL DEFAULT 0,
+            pinned          INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(kind, hash, version)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_lru_installed
+            ON entries(last_used_at) WHERE installed_path IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_lru_archive
+            ON entries(last_used_at) WHERE archive_path IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS leases (
+            entry_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+            holder_pid   INTEGER NOT NULL,
+            holder_nonce INTEGER NOT NULL DEFAULT 0,
+            refcount     INTEGER NOT NULL DEFAULT 1,
+            acquired_at  INTEGER NOT NULL,
+            PRIMARY KEY(entry_id, holder_pid, holder_nonce)
+        );",
+    )?;
+    Ok(())
+}
+
+/// m002 — add `leases.refcount` on pre-existing caches.
+///
+/// Older fbuild versions created `leases` without the `refcount` column.
+/// New caches already get it from `m001_initial_schema`, so this
+/// migration is a no-op for them. For old ones, we `ALTER TABLE` to add
+/// the column with `DEFAULT 1` (matching the semantic that existing rows
+/// represent a single held lease) and then rebaseline to `1` in case the
+/// column was added but left at its implicit NULL by older sqlite.
+fn migrate_m002_add_leases_refcount(conn: &Connection) -> rusqlite::Result<()> {
+    if leases_has_refcount(conn)? {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "ALTER TABLE leases ADD COLUMN refcount INTEGER NOT NULL DEFAULT 1;
+         UPDATE leases SET refcount = 1 WHERE refcount IS NULL OR refcount <= 0;",
+    )?;
+    Ok(())
+}
+
+/// Returns true iff the `leases` table has a column named `refcount`.
+/// Used by migrations to decide whether an `ALTER TABLE` is needed.
+fn leases_has_refcount(conn: &Connection) -> rusqlite::Result<bool> {
+    let mut stmt = conn.prepare("PRAGMA table_info(leases)")?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for col in rows {
+        if col? == "refcount" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Check if a PID is alive. Platform-specific.
 fn is_pid_alive(pid: u32) -> bool {
     #[cfg(unix)]
@@ -842,5 +949,105 @@ mod tests {
             .unwrap();
         assert!(entry.archive_path.is_none());
         assert_eq!(idx.entry_count().unwrap(), 1);
+    }
+
+    /// A freshly-migrated database must report every registered migration
+    /// as applied — regression guard against adding a migration to
+    /// `MIGRATIONS` but forgetting to record it.
+    #[test]
+    fn test_all_migrations_recorded_after_open() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let idx = CacheIndex::open(tmp.path()).unwrap();
+        let conn = idx.conn.lock().unwrap();
+        for m in MIGRATIONS {
+            let applied: Option<i64> = conn
+                .query_row(
+                    "SELECT 1 FROM schema_migrations WHERE id = ?1",
+                    params![m.id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .unwrap();
+            assert!(applied.is_some(), "migration {} not recorded", m.id);
+        }
+    }
+
+    /// Pre-migration schema: `leases` without `refcount`. Opening via
+    /// `CacheIndex::open` must transparently add the column, and
+    /// subsequent `pin()` calls must succeed.
+    #[test]
+    fn test_legacy_schema_missing_refcount_is_migrated() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db_path = paths::index_path(tmp.path());
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+
+        // Hand-craft the legacy schema: leases has no refcount column.
+        {
+            let raw = Connection::open(&db_path).unwrap();
+            raw.execute_batch(
+                "CREATE TABLE cache_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                 CREATE TABLE entries (
+                    id              INTEGER PRIMARY KEY,
+                    kind            TEXT NOT NULL,
+                    url             TEXT NOT NULL,
+                    stem            TEXT NOT NULL,
+                    hash            TEXT NOT NULL,
+                    version         TEXT NOT NULL,
+                    archive_path    TEXT,
+                    archive_bytes   INTEGER,
+                    archive_sha256  TEXT,
+                    installed_path  TEXT,
+                    installed_bytes INTEGER,
+                    installed_at    INTEGER,
+                    archived_at     INTEGER,
+                    last_used_at    INTEGER NOT NULL,
+                    use_count       INTEGER NOT NULL DEFAULT 0,
+                    pinned          INTEGER NOT NULL DEFAULT 0,
+                    UNIQUE(kind, hash, version)
+                 );
+                 CREATE TABLE leases (
+                    entry_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+                    holder_pid   INTEGER NOT NULL,
+                    holder_nonce INTEGER NOT NULL DEFAULT 0,
+                    acquired_at  INTEGER NOT NULL,
+                    PRIMARY KEY(entry_id, holder_pid, holder_nonce)
+                 );
+                 INSERT INTO cache_meta(key, value) VALUES ('schema_version', '1');",
+            )
+            .unwrap();
+            // raw goes out of scope → connection closes and file is flushed.
+        }
+
+        // Re-open through the normal path. Migrations should run.
+        let idx = CacheIndex::open(tmp.path()).unwrap();
+        assert!(
+            leases_has_refcount(&idx.conn.lock().unwrap()).unwrap(),
+            "m002 should have added leases.refcount"
+        );
+
+        // pin()/unpin() must now succeed end-to-end.
+        let entry = idx
+            .record_archive(Kind::Packages, "https://example.com/x", "1.0", "p", 1, "s")
+            .unwrap();
+        idx.pin(entry.id, 4242, 7).unwrap();
+        let entry = idx
+            .lookup(Kind::Packages, "https://example.com/x", "1.0")
+            .unwrap()
+            .unwrap();
+        assert_eq!(entry.pinned, 1);
+        idx.unpin(entry.id, 4242, 7).unwrap();
+    }
+
+    /// Migrations must be idempotent: opening twice must not re-apply
+    /// them and must not double-error on the `ALTER TABLE`.
+    #[test]
+    fn test_migrations_idempotent_across_reopens() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        {
+            let _idx = CacheIndex::open(tmp.path()).unwrap();
+        }
+        // Second open must succeed — no "duplicate column name" error.
+        let idx = CacheIndex::open(tmp.path()).unwrap();
+        assert!(leases_has_refcount(&idx.conn.lock().unwrap()).unwrap());
     }
 }

--- a/crates/fbuild-packages/src/lnk/resolver.rs
+++ b/crates/fbuild-packages/src/lnk/resolver.rs
@@ -73,11 +73,11 @@ pub fn resolve(lnk: &LnkFile, cache: &DiskCache) -> Result<ResolvedBlob> {
             // Best-effort sha verify on cache hit — cheap (single read,
             // not network). Catches accidental cache corruption.
             if verify_sha256(&blob_path, &lnk.sha256).is_ok() {
-                // Lease acquisition is best-effort: older cache schemas may
-                // lack the `refcount` column. A missing lease just means
-                // "blob isn't pinned against concurrent GC"; for a single-
-                // process build that's acceptable.
-                let lease = best_effort_lease(cache, &entry);
+                // Pin the entry against concurrent GC for the lifetime of
+                // the `ResolvedBlob`. Schema-migration guarantees the
+                // `leases.refcount` column exists even on old caches
+                // (see `disk_cache::index::MIGRATIONS`).
+                let lease = Some(cache.lease(&entry).map_err(map_cache_err)?);
                 let _ = cache.touch(&entry);
                 debug!(url = %lnk.url, sha = %lnk.sha256, "lnk cache hit");
                 return Ok(ResolvedBlob {
@@ -160,7 +160,7 @@ pub fn resolve(lnk: &LnkFile, cache: &DiskCache) -> Result<ResolvedBlob> {
         )
         .map_err(map_cache_err)?;
 
-    let lease = best_effort_lease(cache, &entry);
+    let lease = Some(cache.lease(&entry).map_err(map_cache_err)?);
     info!(
         url = %lnk.url,
         bytes = archive_bytes,
@@ -174,27 +174,6 @@ pub fn resolve(lnk: &LnkFile, cache: &DiskCache) -> Result<ResolvedBlob> {
         entry: Some(entry),
         lease,
     })
-}
-
-/// Attempt to acquire a cache lease, returning `None` on failure.
-///
-/// Older `DiskCache` schemas may lack the `refcount` column that
-/// `lease.rs` expects. In that case we log a warning and continue
-/// without a lease — the cached blob is still valid, it just isn't
-/// pinned against concurrent GC. For a single-process build that's
-/// acceptable; parallel builds on an old schema may race, but the
-/// same was true before this change.
-fn best_effort_lease(cache: &DiskCache, entry: &CacheEntry) -> Option<Lease> {
-    match cache.lease(entry) {
-        Ok(l) => Some(l),
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "failed to acquire lnk cache lease; continuing unpinned"
-            );
-            None
-        }
-    }
 }
 
 /// Reconstruct the on-disk blob path from a `CacheEntry`. The entry's

--- a/crates/fbuild-packages/tests/README.md
+++ b/crates/fbuild-packages/tests/README.md
@@ -1,0 +1,13 @@
+# fbuild-packages integration tests
+
+Integration tests for the `fbuild-packages` crate. Each `*.rs` file here is
+compiled as its own binary by `cargo test` (separate from the unit tests
+inside `src/`).
+
+## Tests
+
+- **`lnk_e2e.rs`** — end-to-end test of the `.lnk` resource pipeline
+  (scan → resolve → materialize) against a local axum server.
+- **`disk_cache_schema_migration.rs`** — verifies `DiskCache::open_at`
+  migrates older databases that lack the `leases.refcount` column added
+  in PR #119. Regression guard for issue #124.

--- a/crates/fbuild-packages/tests/disk_cache_schema_migration.rs
+++ b/crates/fbuild-packages/tests/disk_cache_schema_migration.rs
@@ -1,0 +1,128 @@
+//! Integration test for `DiskCache` schema migration on legacy databases.
+//!
+//! The original `leases` table (created before PR #119) had no `refcount`
+//! column. Opening such a database via `DiskCache::open_at` must
+//! transparently migrate it, and `DiskCache::lease()` must then succeed
+//! instead of erroring with "no such column: refcount".
+//!
+//! See: https://github.com/FastLED/fbuild/issues/124
+
+use fbuild_packages::disk_cache::Kind;
+use fbuild_packages::DiskCache;
+use rusqlite::Connection;
+use std::path::PathBuf;
+
+/// Reproduce the exact filesystem layout `DiskCache::open_at` expects for
+/// a *pre-migration* cache. Mirrors `disk_cache::paths::index_path`.
+fn index_path(cache_root: &std::path::Path) -> PathBuf {
+    cache_root.join("index.sqlite")
+}
+
+/// Hand-craft the legacy schema that production caches from before the
+/// `leases.refcount` column existed. No `refcount`, no `schema_migrations`
+/// table, but a legacy `cache_meta.schema_version = '1'` marker.
+fn seed_legacy_schema(db_path: &std::path::Path) {
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    let raw = Connection::open(db_path).unwrap();
+    raw.execute_batch(
+        "CREATE TABLE cache_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+         CREATE TABLE entries (
+             id              INTEGER PRIMARY KEY,
+             kind            TEXT NOT NULL,
+             url             TEXT NOT NULL,
+             stem            TEXT NOT NULL,
+             hash            TEXT NOT NULL,
+             version         TEXT NOT NULL,
+             archive_path    TEXT,
+             archive_bytes   INTEGER,
+             archive_sha256  TEXT,
+             installed_path  TEXT,
+             installed_bytes INTEGER,
+             installed_at    INTEGER,
+             archived_at     INTEGER,
+             last_used_at    INTEGER NOT NULL,
+             use_count       INTEGER NOT NULL DEFAULT 0,
+             pinned          INTEGER NOT NULL DEFAULT 0,
+             UNIQUE(kind, hash, version)
+         );
+         CREATE TABLE leases (
+             entry_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+             holder_pid   INTEGER NOT NULL,
+             holder_nonce INTEGER NOT NULL DEFAULT 0,
+             acquired_at  INTEGER NOT NULL,
+             PRIMARY KEY(entry_id, holder_pid, holder_nonce)
+         );
+         INSERT INTO cache_meta(key, value) VALUES ('schema_version', '1');",
+    )
+    .unwrap();
+    // `raw` drops here, closing the connection and flushing to disk.
+}
+
+/// Opening an older DB (no `leases.refcount`) must migrate it on the fly,
+/// and `DiskCache::lease()` must succeed afterwards. This is the exact
+/// production scenario reported in issue #124.
+#[test]
+fn legacy_cache_migrates_and_lease_succeeds() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    seed_legacy_schema(&index_path(tmp.path()));
+
+    let cache = DiskCache::open_at(tmp.path()).expect("migration-aware open must succeed");
+
+    // Record an entry so there's something to lease.
+    let entry = cache
+        .record_install(
+            Kind::LnkBlobs,
+            "https://example.com/legacy.bin",
+            "deadbeef",
+            "installed/legacy/deadbeef",
+            128,
+        )
+        .unwrap();
+
+    // The lease call is what used to fail with:
+    //   "no such column: refcount in UPDATE leases SET refcount = ..."
+    let lease = cache
+        .lease(&entry)
+        .expect("lease must succeed after schema migration");
+
+    // Pinned count should reflect the held lease.
+    let entry = cache
+        .lookup(Kind::LnkBlobs, "https://example.com/legacy.bin", "deadbeef")
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.pinned, 1);
+
+    // Releasing drops the pin.
+    drop(lease);
+    let entry = cache
+        .lookup(Kind::LnkBlobs, "https://example.com/legacy.bin", "deadbeef")
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.pinned, 0);
+}
+
+/// Regression guard: a fresh cache (no seeded legacy schema) must behave
+/// identically. Covers the common happy path so a future migration change
+/// can't silently break new users.
+#[test]
+fn fresh_cache_lease_still_works() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let cache = DiskCache::open_at(tmp.path()).unwrap();
+
+    let entry = cache
+        .record_install(
+            Kind::Packages,
+            "https://example.com/fresh",
+            "1.0",
+            "installed/fresh/1.0",
+            256,
+        )
+        .unwrap();
+
+    let _lease = cache.lease(&entry).expect("fresh cache lease must succeed");
+    let entry = cache
+        .lookup(Kind::Packages, "https://example.com/fresh", "1.0")
+        .unwrap()
+        .unwrap();
+    assert_eq!(entry.pinned, 1);
+}


### PR DESCRIPTION
## Summary

Fixes #124. Any `DiskCache::lease()` call against a production cache DB created before the `leases.refcount` column was added errors with `no such column: refcount`, blocking `fbuild lnk pull` and every other lease-consuming code path.

### Approach — option B (versioned migrations)

Replaces the single-step `migrate_v1` with an append-only, idempotent migration framework keyed by stable ids in a new `schema_migrations` table:

- `m001_initial_schema` — original tables + indexes, all `CREATE TABLE IF NOT EXISTS` so it's safe on databases that already have them.
- `m002_add_leases_refcount` — `ALTER TABLE leases ADD COLUMN refcount INTEGER NOT NULL DEFAULT 1;` guarded by a `PRAGMA table_info(leases)` check. No-op on caches that already have the column from `m001`.

Each migration runs inside its own transaction and is skipped if its id is already present in `schema_migrations`. Future deltas are append-only. The legacy `cache_meta.schema_version` key is still mirrored for tooling that inspects it, but the authoritative source of truth is now the migrations table.

Chose option B over option A because the issue itself flags option 2 as the longer-term clean answer and the framework cost is small (~60 LOC) compared to re-adding a migration infrastructure the next time a column gets added.

### `best_effort_lease` revert

This PR also reverts the `best_effort_lease()` workaround introduced in #119's `lnk/resolver.rs`. Since every opened cache now has `leases.refcount` guaranteed by the migration, the lease is once again a hard requirement — `cache.lease(entry).map_err(map_cache_err)?`. Revert is in the same commit as the migration: [`90d18d0`](https://github.com/FastLED/fbuild/pull/125/commits/90d18d0).

### Files touched

- `crates/fbuild-packages/src/disk_cache/index.rs` — migration framework + `MIGRATIONS` list + `leases_has_refcount` helper + 3 new unit tests.
- `crates/fbuild-packages/src/lnk/resolver.rs` — remove `best_effort_lease`, use `cache.lease()?` directly.
- `crates/fbuild-packages/tests/disk_cache_schema_migration.rs` — new integration test seeding a legacy schema and asserting `DiskCache::open_at` + `cache.lease()` succeed end-to-end.
- `crates/fbuild-packages/tests/README.md` — new (required by repo's readme-guard hook).

## Test plan

- [x] `uv run cargo test -p fbuild-packages` — all 391 unit tests + 2 new migration integration tests + 4 `lnk_e2e` tests pass.
- [x] `uv run cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] New `test_legacy_schema_missing_refcount_is_migrated` reproduces the exact bug scenario (pre-migration DB → open → lease) before the fix and passes after.
- [x] `test_migrations_idempotent_across_reopens` guards against re-running `ALTER TABLE` on second open.
- [x] Fresh-DB regression guard (`fresh_cache_lease_still_works`) confirms no regression for new users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)