### PR TITLE
fix(ci): preserve exec bit on fbuild console script in wheel

### DIFF
--- a/ci/publish.py
+++ b/ci/publish.py
@@ -438,6 +438,15 @@ def build_wheel(
         info = zipfile.ZipInfo(arcname)
         info.compress_type = zipfile.ZIP_DEFLATED
         if executable:
+            # Unix permission bits live in the upper 16 of external_attr,
+            # BUT only when create_system == 3 (Unix). The Python
+            # `ZipInfo` default is 0 (DOS/Windows), under which
+            # external_attr encodes DOS file-attribute flags instead,
+            # and every unpacker (pip, installer, unzip) then ignores
+            # the Unix mode and installs the file without +x. That's
+            # what caused `fbuild --version` → Permission denied after
+            # `pip install fbuild==2.1.18` — see FastLED/fbuild#129.
+            info.create_system = 3
             info.external_attr = exec_perms << 16
         whl.writestr(info, data)
         record_rows.append((arcname, record_hash(data), len(data)))


### PR DESCRIPTION
## Summary

Fixes the packaging half of #129. After ``pip install fbuild==2.1.18``, the installed console script at ``<env>/bin/fbuild`` had the execute bit cleared:

```
$ fbuild --version
bash: /.../bin/fbuild: Permission denied
```

The only workaround was ``chmod +x $(which fbuild)``.

## Root cause

``ci/publish.py::add_file`` builds the wheel via ``zipfile.ZipInfo`` and sets ``info.external_attr = exec_perms << 16`` but leaves ``info.create_system`` at the default value of ``0`` (DOS/Windows). In the ZIP format, the upper 16 bits of ``external_attr`` are interpreted as Unix permissions **only when ``create_system == 3`` (Unix)**; otherwise they encode DOS file-attribute flags and every unpacker — pip, installer, unzip — ignores the mode and installs the file without ``+x``.

That's why the fbuild binary shipped through PyPI had no execute bit on Linux/macOS.

## Fix

Set ``info.create_system = 3`` alongside the existing ``external_attr`` assignment in the ``executable=True`` branch of ``add_file``. A round-trip sanity check (``zipfile → re-open → inspect``) confirms the mode survives as ``0o755``.

## Test plan

- [x] Local round-trip check:
  ```
  python -c \"import zipfile,io; ...\"  # create_system=3, mode=0o755 → confirmed
  ```
- [ ] Next published wheel (2.1.19+) installs with ``+x`` on Linux/macOS — verified by end-to-end ``pip install fbuild && fbuild --version`` after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)