### PR TITLE
chore(hooks): scope readme_guard to repo tree only

### DIFF
--- a/ci/hooks/readme_guard.py
+++ b/ci/hooks/readme_guard.py
@@ -27,6 +27,17 @@ def main():
     if not file_path:
         return 0
 
+    # Scope the guard to THIS repo only. Writes outside the project tree
+    # (e.g. to ~/.claude/projects/.../memory/) are not covered.
+    # The hook runs with cwd set to `git rev-parse --show-toplevel` by
+    # settings.json, so cwd is the project root at invocation time.
+    try:
+        repo_root = Path.cwd().resolve()
+        abs_path = Path(file_path).resolve()
+        abs_path.relative_to(repo_root)
+    except (ValueError, OSError):
+        return 0
+
     # Normalize path
     file_path = file_path.replace("\\", "/")
     filename = os.path.basename(file_path)


### PR DESCRIPTION
## Summary
`ci/hooks/readme_guard.py` was blocking `Write` operations anywhere on disk, including outside the fbuild repo. That came up while writing to Claude's user-level memory directory (`~/.claude/projects/.../memory/`) — the hook demanded a `README.md` in a directory the repo doesn't own.

## Change
Early-return when the written file resolves outside the repo root (the hook runs with `cwd = git rev-parse --show-toplevel`, so `Path.cwd().resolve()` is the repo root at invocation time).

Verified:

| File location | README present? | Exit |
|---|---|---|
| Outside repo | — | 0 (skip) |
| Inside repo, dir has no README | no | 2 (block) |
| Inside repo, dir has README | yes | 0 (pass) |

## Test plan
- [x] Manual: three stdin probes above.
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)