### PR TITLE
chore: bump version to 2.1.20 — cuts CI-unblocking release (exec bit + warm-build P0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-build"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "async-trait",
  "fbuild-config",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "blake3",
  "clap",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "libc",
  "running-process-core",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "async-trait",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "async-trait",
  "espflash",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "axum",
  "bzip2",
@@ -912,14 +912,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "async-trait",
  "base64",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.1.19"
+version = "2.1.20"
 dependencies = [
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.1.19"
+version = "2.1.20"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.1.19"
+version = "2.1.20"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 requires-python = ">=3.10"
 dependencies = ["zccache>=1.2.12"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.1.19"
+version = "2.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },


### PR DESCRIPTION
## Summary
Cuts 2.1.20 with the two P0 fixes merged since 2.1.19. Both are currently blocking every FastLED uno build on GitHub Actions:

- #134 — P0 regression: `Operation not permitted (os error 1)` on warm build
- #135 — fix(ci): preserve exec bit on fbuild console script in wheel

Symptom on CI (from https://github.com/FastLED/FastLED/actions/runs/24621693195):

```
/opt/hostedtoolcache/Python/3.12.13/x64/bin/fbuild: Permission denied
fbuild --version not yet supported on this release
...
FAILED: Blink
build error: build failed: io error: Operation not permitted (os error 1)
FAILED: Cylon
...
```

2.1.19's wheel installs the `fbuild` console script without +x, so CI can't even run `fbuild --version`; then every example compile fails with the warm-build `os error 1`.

## Also included (2.1.19 → 2.1.20)
- #131 style: rustfmt on lnk pipeline files
- #133 fix(packages): migrate older DiskCache schemas to add leases.refcount
- #127 perf(daemon): watch-set cache hit/miss telemetry (closes #123)
- #126 perf(daemon): FBUILD_WATCH_SET_CACHE_SECS env override (closes #122)
- #128 perf(build): add fast-path fingerprint check to AVR orchestrator
- f8533d3f perf(build): extend watch-set fingerprint fast-path to AVR orchestrator

## What this PR contains
Pure version bump across the four lock/manifest files:

- `Cargo.toml` workspace version 2.1.19 → 2.1.20
- `Cargo.lock` — all 9 workspace crates bumped via `cargo update --workspace`
- `pyproject.toml` — 2.1.19 → 2.1.20
- `uv.lock` — fbuild package bumped via `uv lock`

## Post-merge
Run `uv run ci/publish.py` (zero-arg release pipeline) to trigger the GitHub Actions build and upload wheels to PyPI. Downstream consumers (FastLED) will then bump their `fbuild>=2.1.19` pin to `>=2.1.20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)