### PR TITLE
perf(deploy): make espflash a build-time-optional cargo feature

### DIFF
--- a/crates/fbuild-daemon/Cargo.toml
+++ b/crates/fbuild-daemon/Cargo.toml
@@ -14,6 +14,15 @@ path = "src/main.rs"
 name = "fbuild_daemon"
 path = "src/lib.rs"
 
+[features]
+# Issue #66 spike. Forwards to `fbuild-deploy/espflash-native` so
+# `FBUILD_USE_ESPFLASH_VERIFY=1` / `FBUILD_USE_ESPFLASH_WRITE=1` can
+# actually route through espflash at runtime. Default-off: the daemon
+# binary we ship keeps the conservative esptool-subprocess path unless
+# the CI/release pipeline flips this on explicitly.
+default = []
+espflash-native = ["fbuild-deploy/espflash-native"]
+
 [dependencies]
 fbuild-core = { path = "../fbuild-core" }
 fbuild-config = { path = "../fbuild-config" }

--- a/crates/fbuild-daemon/src/handlers/operations.rs
+++ b/crates/fbuild-daemon/src/handlers/operations.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 /// Any other value — including unset — keeps the default esptool path,
 /// so users on unusual setups retain the existing escape hatch until
 /// the native path has bench time on every ESP32 family member.
+#[cfg(feature = "espflash-native")]
 pub(crate) fn native_verify_enabled() -> bool {
     match std::env::var("FBUILD_USE_ESPFLASH_VERIFY") {
         Ok(v) => matches!(
@@ -142,6 +143,7 @@ pub(crate) fn compute_esp32_image_hash(
 /// flipped without the other. Default off so esptool remains the safe
 /// fallback while the native write path accumulates bench time across
 /// every ESP32 family member.
+#[cfg(feature = "espflash-native")]
 pub(crate) fn native_write_enabled() -> bool {
     match std::env::var("FBUILD_USE_ESPFLASH_WRITE") {
         Ok(v) => matches!(
@@ -1258,19 +1260,18 @@ pub async fn deploy(
                 } else {
                     deployer
                 };
-                // Issue #66: opt-in native `verify-flash` via the
-                // `espflash` crate. Off by default so esptool remains
-                // the fallback path; set `FBUILD_USE_ESPFLASH_VERIFY=1`
-                // to route the verify pre-check through espflash and
-                // skip the ~1.5 s Python subprocess cost.
-                let deployer = deployer.with_native_verify(native_verify_enabled());
-                // Issue #66: opt-in native `write-flash` via the
-                // `espflash` crate. Independent of the verify toggle —
-                // set `FBUILD_USE_ESPFLASH_WRITE=1` to route write-flash
-                // through espflash. Default stays on esptool subprocess
-                // until the native write path has bench time on every
-                // ESP32 family member.
-                let deployer = deployer.with_native_write(native_write_enabled());
+                // Issue #66: opt-in native `verify-flash` + `write-flash`
+                // via the `espflash` crate. Only compiled in when the
+                // daemon is built with `--features espflash-native`;
+                // default builds keep the esptool-subprocess path and
+                // skip pulling espflash + its ~30 transitive deps. At
+                // runtime, further gated by the `FBUILD_USE_ESPFLASH_*`
+                // env vars so operators can still fall back to esptool
+                // on an espflash-native build.
+                #[cfg(feature = "espflash-native")]
+                let deployer = deployer
+                    .with_native_verify(native_verify_enabled())
+                    .with_native_write(native_write_enabled());
 
                 // Compute a deterministic SHA-256 over the three
                 // regions we'd otherwise verify-flash. Used twice

--- a/crates/fbuild-deploy/Cargo.toml
+++ b/crates/fbuild-deploy/Cargo.toml
@@ -6,6 +6,16 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[features]
+# Default is the conservative esptool-subprocess path. The native
+# espflash-backed verify/write paths compile in only when the caller
+# explicitly opts in via this feature — keeps the default dep graph slim
+# (no espflash/strum/deku/miette/... pulled in for consumers that don't
+# need it) and gives issue #66's spike a clean kill-switch while it
+# accumulates bench time on every ESP32 family member.
+default = []
+espflash-native = ["dep:espflash", "dep:md-5"]
+
 [dependencies]
 fbuild-core = { path = "../fbuild-core" }
 fbuild-config = { path = "../fbuild-config" }
@@ -23,12 +33,14 @@ object = { workspace = true }
 # Native ESP32 flasher protocol (issue #66). The `serialport` feature
 # gates the `Flasher` type (the real transport entry point) so we enable
 # it; default features stay off to keep the CLI/TUI surface out of our
-# dependency graph.
-espflash = { version = "4", default-features = false, features = ["serialport"] }
+# dependency graph. Optional so default builds don't pull espflash +
+# its ~30 transitive deps (strum, deku, miette, ...); enabled via the
+# `espflash-native` feature.
+espflash = { version = "4", default-features = false, features = ["serialport"], optional = true }
 # Local MD5 of firmware regions for comparison against espflash's on-chip
-# `FLASH_MD5SUM` command. `md-5` is already in the dep graph via espflash;
-# pinning it here keeps the native-verify module self-contained.
-md-5 = "0.10"
+# `FLASH_MD5SUM` command. Optional and gated behind `espflash-native`
+# since it's only used by the native verify path.
+md-5 = { version = "0.10", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/fbuild-deploy/src/esp32.rs
+++ b/crates/fbuild-deploy/src/esp32.rs
@@ -53,6 +53,12 @@ pub struct Esp32Deployer {
     /// var. Default `false` keeps esptool as the fallback so users on
     /// unusual setups aren't forced onto the native path until it has
     /// bench time on every ESP32 family member.
+    ///
+    /// Only compiled in when the `espflash-native` cargo feature is
+    /// enabled (issue #66 spike). Without the feature the struct layout
+    /// doesn't even carry the flag, so default builds pay zero cost for
+    /// the native path.
+    #[cfg(feature = "espflash-native")]
     use_native_verify: bool,
     /// Route `write-flash` through the native [`espflash`] crate
     /// instead of the Python `esptool` subprocess (issue #66).
@@ -60,6 +66,9 @@ pub struct Esp32Deployer {
     /// The daemon sets this from the `FBUILD_USE_ESPFLASH_WRITE` env
     /// var, independently of `use_native_verify`. Default `false` keeps
     /// esptool as the safe fallback.
+    ///
+    /// Feature-gated — see `use_native_verify`.
+    #[cfg(feature = "espflash-native")]
     use_native_write: bool,
 }
 
@@ -85,13 +94,19 @@ impl Esp32Deployer {
             before_reset: esptool_params.before_reset.clone(),
             after_reset: esptool_params.after_reset.clone(),
             verbose,
+            #[cfg(feature = "espflash-native")]
             use_native_verify: false,
+            #[cfg(feature = "espflash-native")]
             use_native_write: false,
         }
     }
 
     /// Opt this deployer into the native espflash-based verify path
     /// (issue #66). Independent of `with_native_write`.
+    ///
+    /// Only present when the `espflash-native` cargo feature is enabled;
+    /// without it the esptool-subprocess path is the only code path.
+    #[cfg(feature = "espflash-native")]
     #[must_use]
     pub fn with_native_verify(mut self, enabled: bool) -> Self {
         self.use_native_verify = enabled;
@@ -103,6 +118,9 @@ impl Esp32Deployer {
     /// both [`Deployer::deploy`] and [`Esp32Deployer::deploy_regions`]
     /// route through the in-process espflash `Flasher`, skipping the
     /// ~1.5 s Python/esptool startup per flash.
+    ///
+    /// Only present when the `espflash-native` cargo feature is enabled.
+    #[cfg(feature = "espflash-native")]
     #[must_use]
     pub fn with_native_write(mut self, enabled: bool) -> Self {
         self.use_native_write = enabled;
@@ -215,6 +233,7 @@ impl Esp32Deployer {
     /// return as "device is now running the requested firmware" without
     /// any extra reset.
     pub fn try_verify_deployment(&self, firmware_path: &Path, port: &str) -> Result<VerifyOutcome> {
+        #[cfg(feature = "espflash-native")]
         if self.use_native_verify {
             return self.try_verify_deployment_native(firmware_path, port);
         }
@@ -281,6 +300,7 @@ impl Esp32Deployer {
     /// [`VerifyOutcome`] semantics as the esptool path, so callers can
     /// swap between the two behind the `use_native_verify` flag without
     /// any result-handling changes.
+    #[cfg(feature = "espflash-native")]
     fn try_verify_deployment_native(
         &self,
         firmware_path: &Path,
@@ -340,6 +360,7 @@ impl Esp32Deployer {
     /// surfaces per-region progress via `tracing` (bridged into the
     /// daemon's existing log broadcaster). Same [`DeploymentResult`]
     /// shape as the esptool path so callers swap behind a single flag.
+    #[cfg(feature = "espflash-native")]
     fn try_deploy_native(&self, firmware_path: &Path, port: &str) -> Result<DeploymentResult> {
         let baud = self.parse_native_baud()?;
         let (boot_off, parts_off, fw_off) = self.parse_native_offsets()?;
@@ -382,6 +403,7 @@ impl Esp32Deployer {
     /// (issue #66). Used after a verify-mismatch to rewrite only the
     /// regions that actually differ — skipping the ~1s
     /// bootloader/partitions rewrite when only firmware changed.
+    #[cfg(feature = "espflash-native")]
     fn try_deploy_regions_native(
         &self,
         firmware_path: &Path,
@@ -427,6 +449,7 @@ impl Esp32Deployer {
         )
     }
 
+    #[cfg(feature = "espflash-native")]
     fn parse_native_baud(&self) -> Result<u32> {
         self.baud_rate.parse().map_err(|e| {
             fbuild_core::FbuildError::DeployFailed(format!(
@@ -436,6 +459,7 @@ impl Esp32Deployer {
         })
     }
 
+    #[cfg(feature = "espflash-native")]
     fn parse_native_offsets(&self) -> Result<(u32, u32, u32)> {
         let boot = parse_hex_offset_u32(&self.bootloader_offset)?;
         let parts = parse_hex_offset_u32(&self.partitions_offset)?;
@@ -446,7 +470,10 @@ impl Esp32Deployer {
 
 /// Parse a hex flash offset (accepts `0x` prefix) as a `u32`. espflash's
 /// `FLASH_MD5SUM` command takes 32-bit offsets, so we narrow the shared
-/// [`parse_hex_offset`] result here.
+/// [`parse_hex_offset`] result here. Only used by the native verify/write
+/// path, so gated with the crate's feature to avoid dead-code lints on
+/// default builds.
+#[cfg(feature = "espflash-native")]
 fn parse_hex_offset_u32(raw: &str) -> Result<u32> {
     let as_u64 = parse_hex_offset(raw)?;
     u32::try_from(as_u64).map_err(|_| {
@@ -1097,6 +1124,7 @@ impl Esp32Deployer {
             }
         }
 
+        #[cfg(feature = "espflash-native")]
         if self.use_native_write {
             return self.try_deploy_regions_native(firmware_path, port, regions);
         }
@@ -1167,6 +1195,7 @@ impl Deployer for Esp32Deployer {
             )
         })?;
 
+        #[cfg(feature = "espflash-native")]
         if self.use_native_write {
             return self.try_deploy_native(firmware_path, port);
         }

--- a/crates/fbuild-deploy/src/lib.rs
+++ b/crates/fbuild-deploy/src/lib.rs
@@ -8,6 +8,13 @@
 
 pub mod avr;
 pub mod esp32;
+/// Native espflash-backed verify/write path (issue #66).
+///
+/// Compiled in only when the `espflash-native` cargo feature is enabled.
+/// Default builds keep the esptool-subprocess path and pay zero cost in
+/// the dep graph (espflash pulls ~30 transitive crates: strum, deku,
+/// miette, ...).
+#[cfg(feature = "espflash-native")]
 pub mod esp32_native;
 pub mod reset;
 pub mod teensy;


### PR DESCRIPTION
## Summary

Touches issue #66 but not in the originally-requested direction. The `espflash`-based verify+write migration already landed in PRs #74 / #106 — the remaining observable cost is that every fbuild build pulls `espflash` (and its ~30 transitive deps: `strum`, `deku`, `miette`, `esp-idf-part`, ...) whether or not the operator ever sets `FBUILD_USE_ESPFLASH_*`.

This PR walks that back: `espflash` + `md-5` become optional in `fbuild-deploy`, and a new `espflash-native` cargo feature on `fbuild-deploy` + `fbuild-daemon` gates them in.

## Change

**Default build (new behaviour):**
- `espflash`, `md-5`, and their transitive deps are **not** compiled.
- `esp32_native.rs` is not compiled.
- `FBUILD_USE_ESPFLASH_VERIFY` / `FBUILD_USE_ESPFLASH_WRITE` are ignored; the daemon always takes the esptool-subprocess path.
- Sole trade-off: operators who relied on those env vars on a stock build need to rebuild with `--features fbuild-daemon/espflash-native`.

**`--features espflash-native` build:**
- Identical runtime behaviour to today's `main`. Env vars still pick native-vs-esptool.

## Feature gates (what is cfg-gated)

- `fbuild-deploy`: `pub mod esp32_native`; `Esp32Deployer::{use_native_verify, use_native_write}` struct fields; `Esp32Deployer::{with_native_verify, with_native_write}` builders; `try_verify_deployment_native`, `try_deploy_native` helper fns. Native-path dispatch arms inside the public methods are also `#[cfg(feature = "espflash-native")]`.
- `fbuild-daemon`: `native_verify_enabled` / `native_write_enabled` helper fns, plus the sole call site that wires `with_native_{verify,write}`.

## Quality gates (verified locally on Windows 10)

- `uv run cargo clippy --workspace --all-targets -- -D warnings` — clean (default, no feature).
- `uv run cargo clippy --workspace --all-targets --features fbuild-daemon/espflash-native -- -D warnings` — clean.
- `uv run cargo test -p fbuild-deploy` — 36 pass, 0 fail, 8 ignored.
- `uv run cargo fmt --all --check` — clean.

## Scope / Non-goals

- Does **not** remove any existing code paths.
- Does **not** drop esptool as a dep.
- Does **not** change the env-var contract (besides "only honoured when the feature is on").
- Does **not** attempt to measure the binary-size / build-time delta — that's for a follow-up once CI picks it up.

## Test plan
- [ ] CI green across Linux / macOS / Windows.
- [ ] Build-time delta on the default profile is measurable vs current main (expect several seconds faster cold build, ~30 fewer crates downloaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)