### PR TITLE
fix(daemon): register test-emu endpoint OperationGuard and propagate exit code to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,7 @@ dependencies = [
  "libc",
  "mimalloc",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "serialport",

--- a/crates/fbuild-cli/src/main.rs
+++ b/crates/fbuild-cli/src/main.rs
@@ -1405,7 +1405,17 @@ async fn run_test_emu(
     print_operation_streams(&resp);
     println!("{}", resp.message);
     if !resp.success {
-        std::process::exit(resp.exit_code);
+        // Guarantee a non-zero exit when the daemon reports failure. A
+        // structured error response carries `exit_code`, but if the
+        // daemon handler or an intermediate proxy returns 0 alongside
+        // success=false (issue #130), we must still surface failure to
+        // the shell rather than silently exiting 0.
+        let code = if resp.exit_code == 0 {
+            1
+        } else {
+            resp.exit_code
+        };
+        std::process::exit(code);
     }
     Ok(())
 }

--- a/crates/fbuild-cli/tests/README.md
+++ b/crates/fbuild-cli/tests/README.md
@@ -1,0 +1,10 @@
+# fbuild-cli integration tests
+
+Integration tests that spawn the `fbuild` binary (`CARGO_BIN_EXE_fbuild`)
+and drive it against a stand-in daemon or environment so the CLI exit-code
+and message contracts are covered end-to-end.
+
+- **`test_emu_exit_code.rs`** -- regression for issue #130. Spawns a mock
+  HTTP daemon on an ephemeral loopback port, points the CLI at it via
+  `FBUILD_DEV_MODE=1` + `FBUILD_DAEMON_PORT`, and asserts the CLI exits
+  non-zero when the daemon returns a structured failure response.

--- a/crates/fbuild-cli/tests/test_emu_exit_code.rs
+++ b/crates/fbuild-cli/tests/test_emu_exit_code.rs
@@ -1,0 +1,172 @@
+//! Integration test: `fbuild test-emu` must exit non-zero when the daemon
+//! reports a failure. Regression for issue #130 where the CLI printed the
+//! daemon error but then exited with code 0, so shells / CI treated
+//! failures as success.
+//!
+//! Strategy: spin up a mock HTTP server on an ephemeral port that
+//! pretends to be a healthy daemon, then returns a structured failure
+//! for `POST /api/test-emu`. Point the CLI at that port via
+//! `FBUILD_DAEMON_PORT` and assert the child process exit status is
+//! non-zero.
+//!
+//! We do NOT spawn the real daemon; the mock is enough to exercise the
+//! CLI's error-handling contract without dragging in toolchain/emulator
+//! dependencies.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Minimal HTTP/1.1 request parser — reads headers, then the body based
+/// on `Content-Length`. Keeps the test hermetic (no reqwest-server-side
+/// dependency) and makes the response semantics impossible to
+/// misinterpret. Only intended for loopback, fixed-shape requests from
+/// the CLI under test.
+fn read_request(stream: &mut TcpStream) -> (String, Vec<u8>) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut request_line = String::new();
+    reader
+        .read_line(&mut request_line)
+        .expect("read request line");
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read header line");
+        if line == "\r\n" || line.is_empty() {
+            break;
+        }
+        if let Some(rest) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = rest.trim().parse().unwrap_or(0);
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 {
+        reader.read_exact(&mut body).expect("read request body");
+    }
+    (request_line, body)
+}
+
+fn write_response(stream: &mut TcpStream, status_line: &str, body: &str) {
+    let resp = format!(
+        "{}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        status_line,
+        body.len(),
+        body
+    );
+    stream.write_all(resp.as_bytes()).ok();
+    stream.flush().ok();
+}
+
+/// Spawn a mock HTTP daemon on an OS-assigned port. Returns the port.
+/// The server handles:
+/// - GET /health — 200 healthy (so `ensure_daemon_running` short-circuits).
+/// - GET /api/daemon/info — 200 with `source_mtime=0` so the CLI does not
+///   try to restart the "stale" daemon.
+/// - POST /api/test-emu — 500 + structured OperationResponse JSON.
+fn spawn_mock_daemon(stop: Arc<AtomicBool>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    listener
+        .set_nonblocking(true)
+        .expect("set listener nonblocking");
+    let port = listener.local_addr().expect("local_addr").port();
+
+    std::thread::spawn(move || {
+        let healthy_body =
+            "{\"status\":\"healthy\",\"uptime_seconds\":1.0,\"version\":\"test\",\"pid\":1,\"source_mtime\":0.0}";
+        let info_body = "{\"status\":\"healthy\",\"uptime_seconds\":1.0,\"version\":\"test\",\"pid\":1,\"port\":0,\"dev_mode\":true,\"operation_in_progress\":false,\"daemon_state\":\"idle\",\"current_operation\":null,\"client_count\":0,\"spawner_cwd\":null,\"source_mtime\":0.0}";
+        let fail_body = "{\"success\":false,\"request_id\":\"mock-1\",\"message\":\"mock daemon: simulated test-emu failure\",\"exit_code\":0,\"output_file\":null,\"output_dir\":null,\"launch_url\":null,\"stdout\":null,\"stderr\":null}";
+
+        while !stop.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream
+                        .set_nonblocking(false)
+                        .expect("blocking per-connection");
+                    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+                    let (request_line, _body) = read_request(&mut stream);
+                    if request_line.starts_with("GET /health") {
+                        write_response(&mut stream, "HTTP/1.1 200 OK", healthy_body);
+                    } else if request_line.starts_with("GET /api/daemon/info") {
+                        write_response(&mut stream, "HTTP/1.1 200 OK", info_body);
+                    } else if request_line.starts_with("POST /api/test-emu") {
+                        // Return 500 with structured body + exit_code=0 to
+                        // stress-test the CLI's fallback: it must still
+                        // exit non-zero because success=false.
+                        write_response(
+                            &mut stream,
+                            "HTTP/1.1 500 Internal Server Error",
+                            fail_body,
+                        );
+                    } else {
+                        write_response(&mut stream, "HTTP/1.1 404 Not Found", "{}");
+                    }
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(_) => break,
+            }
+        }
+    });
+    port
+}
+
+/// Minimal platformio.ini in a temp dir — enough for the CLI to form a
+/// request, the mock daemon does not actually build anything.
+fn make_test_project() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("platformio.ini"),
+        "[env:uno]\nplatform = atmelavr\nboard = uno\nframework = arduino\n",
+    )
+    .expect("write platformio.ini");
+    dir
+}
+
+#[test]
+fn test_emu_exits_non_zero_when_daemon_returns_failure() {
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_daemon(Arc::clone(&stop));
+
+    let project = make_test_project();
+    let bin = env!("CARGO_BIN_EXE_fbuild");
+
+    // Drive the CLI at the mock daemon. We clear FBUILD_DEV_MODE so the
+    // CLI sticks to prod-mode path assumptions, and pin
+    // FBUILD_DAEMON_PORT so the client calls 127.0.0.1:<port>.
+    let output = Command::new(bin)
+        .args([
+            "test-emu",
+            project.path().to_str().expect("utf-8 path"),
+            "-e",
+            "uno",
+            "--emulator",
+            "simavr",
+            "--timeout",
+            "1",
+        ])
+        .env("FBUILD_DAEMON_PORT", port.to_string())
+        .env_remove("FBUILD_DEV_MODE")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn fbuild");
+
+    stop.store(true, Ordering::Relaxed);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let code = output.status.code().unwrap_or(-1);
+
+    // Regression for issue #130: exit code must be non-zero even when the
+    // daemon returns success=false, exit_code=0.
+    assert_ne!(
+        code, 0,
+        "CLI must exit non-zero on daemon failure.\nstdout: {}\nstderr: {}",
+        stdout, stderr
+    );
+}

--- a/crates/fbuild-daemon/Cargo.toml
+++ b/crates/fbuild-daemon/Cargo.toml
@@ -59,6 +59,10 @@ workspace = true
 
 [dev-dependencies]
 fbuild-test-support = { path = "../fbuild-test-support" }
+# reqwest is used by tests/test_emu_endpoint.rs to issue a real HTTP POST
+# against a router mounted on an ephemeral loopback port, matching the
+# client-side path that fails in issue #130.
+reqwest = { workspace = true }
 
 # libc::kill(pid, SIGKILL) is used by the process-containment integration
 # test (tests/process_containment.rs). Unix-only; Windows uses taskkill /F.

--- a/crates/fbuild-daemon/src/handlers/emulator.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator.rs
@@ -2037,6 +2037,18 @@ pub async fn test_emu(
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let project_dir = PathBuf::from(&req.project_dir);
 
+    // Mark the daemon as busy for the full build + emulate lifecycle.
+    // Without this guard the 30 s self-eviction loop sees an "empty"
+    // daemon during long (>30 s) ESP32/QEMU builds and triggers graceful
+    // shutdown, which closes the in-flight HTTP connection and surfaces
+    // as `error sending request for url (.../api/test-emu)` on the CLI
+    // side. See issue #130.
+    let _op_guard = crate::handlers::operations::OperationGuard::new(
+        &ctx,
+        fbuild_core::DaemonState::Building,
+        Some(format!("test-emu {}", req.project_dir)),
+    );
+
     if !project_dir.exists() {
         return (
             StatusCode::BAD_REQUEST,

--- a/crates/fbuild-daemon/src/handlers/operations.rs
+++ b/crates/fbuild-daemon/src/handlers/operations.rs
@@ -165,14 +165,14 @@ pub(crate) fn qemu_extra_build_flags(platform: fbuild_core::Platform, mcu: &str)
 
 /// RAII guard that sets `operation_in_progress` to true on creation
 /// and false on drop. Also tracks daemon state and current operation description.
-struct OperationGuard {
+pub(crate) struct OperationGuard {
     flag: Arc<std::sync::atomic::AtomicBool>,
     state: Arc<std::sync::RwLock<fbuild_core::DaemonState>>,
     operation: Arc<std::sync::RwLock<Option<String>>>,
 }
 
 impl OperationGuard {
-    fn new(
+    pub(crate) fn new(
         ctx: &DaemonContext,
         daemon_state: fbuild_core::DaemonState,
         description: Option<String>,

--- a/crates/fbuild-daemon/tests/test_emu_endpoint.rs
+++ b/crates/fbuild-daemon/tests/test_emu_endpoint.rs
@@ -1,0 +1,189 @@
+//! Integration tests for the `POST /api/test-emu` endpoint.
+//!
+//! Regression coverage for issue #130: the CLI saw
+//! `error sending request for url (.../api/test-emu)` while the daemon was
+//! healthy. The root cause was that the `test_emu` handler did not hold an
+//! `OperationGuard`, so the daemon's 30 s self-eviction loop classified the
+//! daemon as "empty" during a long ESP32/QEMU build and forced graceful
+//! shutdown mid-request.
+//!
+//! These tests assert:
+//! 1. The route is registered and returns a structured error (non-500) for
+//!    a missing project directory — the error path the user hits when the
+//!    daemon crashes during a real test-emu is now testable without
+//!    producing a real firmware build.
+//! 2. While the handler is running, `operation_in_progress` is set so the
+//!    self-eviction loop will not fire.
+
+use axum::routing::post;
+use axum::Router;
+use fbuild_daemon::context::DaemonContext;
+use fbuild_daemon::handlers::emulator;
+use fbuild_daemon::models::TestEmuRequest;
+use std::net::SocketAddr;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Build an axum app wired to the `/api/test-emu` endpoint exactly like
+/// `main.rs` does. Kept in one place so route-registration regressions are
+/// caught here instead of silently diverging from production wiring.
+fn build_test_app(ctx: Arc<DaemonContext>) -> Router {
+    Router::new()
+        .route("/api/test-emu", post(emulator::test_emu))
+        .with_state(ctx)
+}
+
+fn make_test_context() -> Arc<DaemonContext> {
+    let (tx, _rx) = tokio::sync::watch::channel(false);
+    Arc::new(DaemonContext::new(
+        0, // port unused; we bind our own listener below
+        tx,
+        "test".to_string(),
+    ))
+}
+
+/// Spawn the test app on an OS-assigned port and return the bound address.
+async fn spawn_test_server(ctx: Arc<DaemonContext>) -> SocketAddr {
+    let app = build_test_app(ctx);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("axum::serve should not fail in test");
+    });
+    addr
+}
+
+/// The endpoint is registered. A request with a non-existent project dir
+/// must round-trip as a structured JSON error (HTTP 400 with
+/// `success=false`, `exit_code=1`) — not a connection drop or a 404.
+#[tokio::test]
+async fn test_emu_endpoint_returns_structured_error_for_missing_project() {
+    let ctx = make_test_context();
+    let addr = spawn_test_server(ctx).await;
+
+    let body = serde_json::json!({
+        "project_dir": "C:/definitely/does/not/exist/at/this/path",
+        "environment": "uno",
+        "verbose": false,
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{}/api/test-emu", addr))
+        .json(&body)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("POST /api/test-emu should not drop the connection");
+
+    // Regression for issue #130: must NOT be a 5xx crash / panic and must
+    // NOT be 404 (missing route). BAD_REQUEST is the handler's chosen
+    // error status for invalid input.
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "expected 400 for missing project dir, got {}",
+        resp.status()
+    );
+
+    // OperationResponse only derives Serialize (not Deserialize), so we
+    // read the body as a JSON Value and assert against the same fields
+    // the CLI consumes via daemon_client::OperationResponse.
+    let body: serde_json::Value = resp.json().await.expect("body must deserialize as JSON");
+    assert_eq!(
+        body.get("success").and_then(|v| v.as_bool()),
+        Some(false),
+        "success must be false on missing project"
+    );
+    assert_eq!(
+        body.get("exit_code").and_then(|v| v.as_i64()),
+        Some(1),
+        "exit_code must be non-zero on failure"
+    );
+    let message = body
+        .get("message")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        message.contains("project directory does not exist"),
+        "message should describe the error, got {:?}",
+        message
+    );
+}
+
+/// Core regression for issue #130: the `test_emu` handler MUST register
+/// an `OperationGuard` so the daemon's self-eviction loop does not tear
+/// down the connection during a long (>30 s) build + emulate run.
+///
+/// We can't observe the flag mid-handler on the missing-project path
+/// (it returns synchronously with no await points), but we CAN prove
+/// the guard was constructed by asserting the guard's side-effect on
+/// `last_activity`: `OperationGuard::new` calls `ctx.touch_activity()`,
+/// so if we artificially back-date `last_activity` before calling the
+/// handler, a correctly-registered guard will pull it forward. Without
+/// the guard, `last_activity` stays back-dated and this test fails.
+#[tokio::test]
+async fn test_emu_registers_operation_guard() {
+    use axum::extract::State;
+    use axum::Json;
+    use std::time::Instant;
+
+    let ctx = make_test_context();
+
+    // Back-date `last_activity` by 60 s so we can unambiguously detect a
+    // `touch_activity()` call from inside the handler. If the handler
+    // did not construct an OperationGuard, idle_duration would still be
+    // ~60 s after the call.
+    {
+        let mut last = ctx
+            .last_activity
+            .lock()
+            .expect("last_activity should be lockable");
+        *last = Instant::now() - Duration::from_secs(60);
+    }
+    assert!(
+        ctx.idle_duration() >= Duration::from_secs(55),
+        "sanity: back-dated idle_duration should report ≥55 s before handler runs"
+    );
+
+    let req = TestEmuRequest {
+        project_dir: "C:/definitely/does/not/exist/at/this/path".to_string(),
+        environment: Some("uno".to_string()),
+        verbose: false,
+        timeout: None,
+        halt_on_error: None,
+        halt_on_success: None,
+        expect: None,
+        emulator: None,
+        show_timestamp: true,
+        request_id: Some("test-op-flag".to_string()),
+        caller_pid: None,
+        caller_cwd: None,
+        pio_env: Default::default(),
+    };
+
+    let ctx_clone = Arc::clone(&ctx);
+    let (_status, Json(resp)) = emulator::test_emu(State(ctx_clone), Json(req)).await;
+    assert!(!resp.success, "missing project dir must fail");
+
+    // The OperationGuard's `ctx.touch_activity()` call must have pulled
+    // `last_activity` forward. Without the guard (the bug), idle_duration
+    // would still be ~60 s.
+    assert!(
+        ctx.idle_duration() < Duration::from_secs(5),
+        "handler must register an OperationGuard — touch_activity should have run. \
+         idle_duration is {:?}",
+        ctx.idle_duration()
+    );
+
+    // The guard must be dropped by the time the response returns, so
+    // the flag is cleared and self-eviction is not permanently blocked.
+    assert!(
+        !ctx.operation_in_progress.load(Ordering::Relaxed),
+        "operation_in_progress must be cleared after handler returns"
+    );
+}


### PR DESCRIPTION
Fixes #130.

## Summary

On Windows 10 users saw `error: daemon error: request failed: error sending request for url (http://127.0.0.1:8765/api/test-emu)` when running `fbuild test-emu` against a healthy daemon. A second bug made the CLI exit with code **0** even though it had just printed `error:`.

## Root cause 1 — daemon tore down the connection mid-request

`POST /api/test-emu` did not construct an `OperationGuard`, so the daemon's 30 s self-eviction loop classified itself as "empty" during long (>30 s) ESP32/QEMU builds and triggered graceful shutdown. Graceful shutdown closed the in-flight HTTP connection, and reqwest surfaced that as `error sending request for url`.

## Root cause 2 — CLI exited 0 on daemon failure

`run_test_emu` called `std::process::exit(resp.exit_code)` when `resp.success == false`. If the daemon (or an intermediate proxy) returned `exit_code=0` alongside `success=false`, the CLI silently exited 0 and CI / shell scripts treated the failure as success.

## Fix

- `handlers/operations.rs` — expose `OperationGuard` as `pub(crate)`.
- `handlers/emulator.rs::test_emu` — construct an `OperationGuard` at the top of the handler (before any early-returns) so the self-eviction loop leaves the daemon alone for the entire build + emulate lifecycle.
- `fbuild-cli/src/main.rs::run_test_emu` — clamp exit code to ≥1 when `success=false`, so daemon failures always surface as non-zero shell exits.

## Tests

- `crates/fbuild-daemon/tests/test_emu_endpoint.rs` — asserts the route is registered (structured 400 on missing project) and proves the `OperationGuard` is installed via `touch_activity()` side-effect. Reverting the emulator.rs fix causes this test to fail with `idle_duration is 60.0001571s`.
- `crates/fbuild-cli/tests/test_emu_exit_code.rs` — spawns a mock HTTP daemon that returns `success=false, exit_code=0` and asserts the CLI exits non-zero.

## Manual repro (Windows 10)

**Before:**
```
$ fbuild test-emu tests/platform/uno -e uno --emulator simavr --timeout 5
error: daemon error: request failed: error sending request for url (...)
$ echo $?
0
```

**After:**
```
$ fbuild test-emu tests/platform/uno -e uno --emulator simavr --timeout 5
FBUILD_DEV_MODE=1 (dev mode: port 8865, ~/.fbuild/dev/)
emulator error: deploy failed: simavr is required but 'simavr.exe' was not found on PATH. ...
$ echo $?
1
```

`fbuild build tests/platform/uno -e uno` also builds + exits cleanly after the fix.

## Test plan

- [x] `uv run cargo clippy --workspace --all-targets -- -D warnings`
- [x] `uv run cargo fmt --all --check`
- [x] `uv run cargo test -p fbuild-daemon` (2 new tests pass)
- [x] `uv run cargo test -p fbuild-cli` (1 new test passes)
- [x] `uv run cargo test --workspace` — 0 failures across 34 test binaries
- [x] Manual smoke: `fbuild test-emu tests/platform/uno -e uno --emulator simavr --timeout 5` → non-zero exit + explicit diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)