### PR TITLE
fix(docs): repair broken intra-doc links under -D warnings

### DIFF
--- a/crates/fbuild-build/src/build_fingerprint/fast_path.rs
+++ b/crates/fbuild-build/src/build_fingerprint/fast_path.rs
@@ -111,9 +111,10 @@ pub struct FastPathInputs<'a> {
     /// `compile_commands.json` also has the PlatformIO-style project-root
     /// copy. Returning `false` forces a full rebuild.
     pub extra_artifact_ok: Option<&'a dyn Fn() -> bool>,
-    /// Optional daemon-scoped memo for the [`hash_watch_set_stamps`]
-    /// walk (see [`WatchSetStampCache`]). `None` when invoked outside
-    /// the daemon (tests, direct CLI).
+    /// Optional daemon-scoped memo for the
+    /// [`super::hash_watch_set_stamps`] walk (see
+    /// [`WatchSetStampCache`]). `None` when invoked outside the daemon
+    /// (tests, direct CLI).
     pub watch_set_cache: Option<&'a dyn WatchSetStampCache>,
     /// Discovered zccache binary, if any. When present the helper
     /// uses its persistent fingerprint as the primary invalidation

--- a/crates/fbuild-daemon/src/log_layer.rs
+++ b/crates/fbuild-daemon/src/log_layer.rs
@@ -1,6 +1,6 @@
 //! Tracing-subscriber layer that forwards events to
-//! [`BroadcastHub::log_tx`] so `/ws/logs` subscribers see the same
-//! events that are written to the daemon's stderr.
+//! [`crate::context::BroadcastHub::log_tx`] so `/ws/logs` subscribers
+//! see the same events that are written to the daemon's stderr.
 //!
 //! # Why (issue #66)
 //!

--- a/crates/fbuild-deploy/src/esp32_native.rs
+++ b/crates/fbuild-deploy/src/esp32_native.rs
@@ -35,9 +35,10 @@
 //!
 //! # Opt-in
 //!
-//! `verify-flash` is guarded by [`Esp32Deployer::use_native_verify`]
-//! (daemon env: `FBUILD_USE_ESPFLASH_VERIFY`), and `write-flash` by
-//! [`Esp32Deployer::use_native_write`] (daemon env:
+//! `verify-flash` is guarded by
+//! [`super::esp32::Esp32Deployer::with_native_verify`] (daemon env:
+//! `FBUILD_USE_ESPFLASH_VERIFY`), and `write-flash` by
+//! [`super::esp32::Esp32Deployer::with_native_write`] (daemon env:
 //! `FBUILD_USE_ESPFLASH_WRITE`). The two flags are independent —
 //! users can flip one without the other while the native write path
 //! accumulates bench time on every ESP32 family member.
@@ -230,9 +231,10 @@ pub struct NativeWriteRegion {
 ///
 /// Progress from espflash is bridged into `tracing` so the daemon's
 /// existing log broadcaster surfaces it without new API surface (see
-/// [`LoggingProgressBridge`]). Structured WebSocket progress frames are
-/// a follow-up: the bridge is a drop-in replacement point for a richer
-/// callback without touching any of the call sites.
+/// the private `LoggingProgressBridge` below). Structured WebSocket
+/// progress frames are a follow-up: the bridge is a drop-in
+/// replacement point for a richer callback without touching any of
+/// the call sites.
 ///
 /// On success the chip is hard-reset (matching esptool's
 /// `--after hard-reset`) so callers can treat the `Ok` return as


### PR DESCRIPTION
## Summary
The Documentation workflow (runs/24624181584, job/72000122089) failed on main because `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings` promotes `rustdoc::broken_intra_doc_links` and `rustdoc::private_intra_doc_links` to errors. Five links in the v2.1.20 tree were broken:

- `crates/fbuild-deploy/src/esp32_native.rs:38,40` — linked bare `Esp32Deployer::use_native_{verify,write}`. The struct is in the sibling `esp32` module and the fields are private. Switched both to the public builder methods on the fully qualified path: `super::esp32::Esp32Deployer::with_native_{verify,write}`.
- `crates/fbuild-deploy/src/esp32_native.rs:233` — public fn `try_write_deployment_native` linked private `LoggingProgressBridge`. Dropped the link (kept the code-span name) — the bridge is an impl detail, not part of the public surface.
- `crates/fbuild-daemon/src/log_layer.rs:2` — linked bare `BroadcastHub::log_tx`. The type lives in `crate::context`. Fully qualified.
- `crates/fbuild-build/src/build_fingerprint/fast_path.rs:114` — linked bare `hash_watch_set_stamps`. The function is one module up (`super::hash_watch_set_stamps`) and wasn't imported into `fast_path`. Qualified.

## Test plan
- [x] `RUSTDOCFLAGS="-D warnings" uv run cargo doc --workspace --no-deps` — clean, no errors or warnings
- [ ] Re-run Documentation workflow on this branch to confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)