### PR TITLE
Integrate soldr into build workflows

### DIFF
--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -21,13 +21,19 @@ jobs:
           repository: zackees/soldr
           ref: v0.7.4
           path: soldr
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - name: Install soldr bootstrap
+        shell: bash
+        run: python -m pip install soldr==0.7.4
       - name: Build soldr from source
         shell: bash
         working-directory: soldr
-        run: cargo build --package soldr-cli --release --locked
+        run: soldr cargo build --package soldr-cli --release --locked
       - name: Add soldr to PATH
         shell: bash
         run: echo "${{ github.workspace }}/soldr/target/release" >> "$GITHUB_PATH"

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -16,21 +16,28 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: zackees/soldr
+          ref: v0.7.4
+          path: soldr
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ runner.os }}-check
+      - name: Build soldr from source
+        shell: bash
+        working-directory: soldr
+        run: cargo build --package soldr-cli --release --locked
+      - name: Add soldr to PATH
+        shell: bash
+        run: echo "${{ github.workspace }}/soldr/target/release" >> "$GITHUB_PATH"
 
       - name: Check
-        run: cargo check --workspace --all-targets
+        shell: bash
+        run: soldr cargo check --workspace --all-targets
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        shell: bash
+        run: soldr cargo clippy --workspace --all-targets -- -D warnings
       - name: Test
-        run: cargo test --workspace
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main
+        shell: bash
+        run: soldr cargo test --workspace

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -19,18 +19,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ runner.os }}-check
+      - name: Install soldr 0.7.4
+        shell: bash
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check
-        run: cargo check --workspace --all-targets
+        run: soldr cargo check --workspace --all-targets
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: soldr cargo clippy --workspace --all-targets -- -D warnings
       - name: Test
-        run: cargo test --workspace
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main
+        run: soldr cargo test --workspace

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -21,13 +21,19 @@ jobs:
           repository: zackees/soldr
           ref: v0.7.4
           path: soldr
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - name: Install soldr bootstrap
+        shell: bash
+        run: python -m pip install soldr==0.7.4
       - name: Build soldr from source
         shell: bash
         working-directory: soldr
-        run: cargo build --package soldr-cli --release --locked
+        run: soldr cargo build --package soldr-cli --release --locked
       - name: Add soldr to PATH
         shell: bash
         run: echo "${{ github.workspace }}/soldr/target/release" >> "$GITHUB_PATH"

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -16,21 +16,28 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          repository: zackees/soldr
+          ref: v0.7.4
+          path: soldr
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ runner.os }}-check
+      - name: Build soldr from source
+        shell: bash
+        working-directory: soldr
+        run: cargo build --package soldr-cli --release --locked
+      - name: Add soldr to PATH
+        shell: bash
+        run: echo "${{ github.workspace }}/soldr/target/release" >> "$GITHUB_PATH"
 
       - name: Check
-        run: cargo check --workspace --all-targets
+        shell: bash
+        run: soldr cargo check --workspace --all-targets
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        shell: bash
+        run: soldr cargo clippy --workspace --all-targets -- -D warnings
       - name: Test
-        run: cargo test --workspace
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main
+        shell: bash
+        run: soldr cargo test --workspace

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,14 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: docs
+      - name: Install soldr 0.7.4
+        shell: bash
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Build docs
-        run: cargo doc --workspace --no-deps
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main
+        run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -15,5 +15,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
+      - name: Install soldr 0.7.4
+        shell: bash
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: soldr cargo fmt --all -- --check

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -13,14 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.75.0
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: msrv
+      - name: Install soldr 0.7.4
+        shell: bash
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check MSRV
-        run: cargo check --workspace
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main
+        run: soldr cargo check --workspace

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,10 +35,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ runner.os }}-${{ inputs.env-name }}
+      - name: Install soldr 0.7.4
+        shell: bash
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Restore fbuild toolchains
         uses: actions/cache/restore@v5
@@ -68,7 +69,7 @@ jobs:
 
       - name: Build fbuild binaries
         run: |
-          cargo build -p fbuild-cli -p fbuild-daemon
+          soldr cargo build -p fbuild-cli -p fbuild-daemon
 
       - name: Add fbuild to PATH
         run: echo "${{ github.workspace }}/target/debug" >> $GITHUB_PATH
@@ -88,10 +89,6 @@ jobs:
         run: |
           test -f ${{ inputs.test-dir }}/.fbuild/build/${{ inputs.env-name }}/release/firmware.${{ inputs.firmware-ext }}
           echo "Release build successful - firmware.${{ inputs.firmware-ext }} generated"
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main
 
       - name: Save fbuild toolchains
         if: always()

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
+      - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.1
+          components: clippy, rustfmt
 
       - name: Install soldr 0.7.4
         shell: bash

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -56,10 +56,18 @@ jobs:
         with:
           targets: ${{ inputs.target }}
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install soldr bootstrap
+        shell: bash
+        run: python -m pip install soldr==0.7.4
+
       - name: Build soldr from source
         shell: bash
         working-directory: soldr
-        run: cargo build --package soldr-cli --release --locked
+        run: soldr cargo build --package soldr-cli --release --locked
 
       - name: Add soldr to PATH
         shell: bash
@@ -69,11 +77,6 @@ jobs:
       # ensure the target stdlib is installed for the pinned toolchain too
       - name: Add Rust target
         run: rustup target add ${{ inputs.target }}
-
-      - uses: actions/setup-python@v6
-        if: ${{ !inputs.linux_cross && !inputs.macos_cross || inputs.linux_cross }}
-        with:
-          python-version: "3.13"
 
       # Linux musl toolchain (libudev is auto-excluded for musl targets by serialport)
       - name: Install Linux dependencies
@@ -95,8 +98,8 @@ jobs:
         shell: bash
         run: |
           if [ "${{ inputs.linux_cross }}" = "true" ]; then
-            soldr cargo zigbuild build --release --target ${{ inputs.target }} -p fbuild-cli
-            soldr cargo zigbuild build --release --target ${{ inputs.target }} -p fbuild-daemon
+            soldr cargo zigbuild --release --target ${{ inputs.target }} -p fbuild-cli
+            soldr cargo zigbuild --release --target ${{ inputs.target }} -p fbuild-daemon
           else
             soldr cargo build --release --target ${{ inputs.target }} -p fbuild-cli
             soldr cargo build --release --target ${{ inputs.target }} -p fbuild-daemon
@@ -122,7 +125,7 @@ jobs:
             ARCH="${TARGET%%-*}"
             PYO3_TARGET="${ARCH}-unknown-linux-gnu"
             rustup target add "$PYO3_TARGET"
-            PYO3_NO_PYTHON=1 soldr cargo zigbuild build --release \
+            PYO3_NO_PYTHON=1 soldr cargo zigbuild --release \
               --target "${PYO3_TARGET}.2.17" -p fbuild-python \
               --features extension-module
           elif [ "${{ inputs.macos_cross }}" = "true" ]; then

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,6 +54,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.94.1
+          components: clippy, rustfmt
           targets: ${{ inputs.target }}
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -46,9 +46,24 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
+      - uses: actions/checkout@v6
+        with:
+          repository: zackees/soldr
+          ref: v0.7.4
+          path: soldr
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ inputs.target }}
+
+      - name: Build soldr from source
+        shell: bash
+        working-directory: soldr
+        run: cargo build --package soldr-cli --release --locked
+
+      - name: Add soldr to PATH
+        shell: bash
+        run: echo "${{ github.workspace }}/soldr/target/release" >> "$GITHUB_PATH"
 
       # rust-toolchain.toml pins 1.94.1 which overrides the above;
       # ensure the target stdlib is installed for the pinned toolchain too
@@ -59,11 +74,6 @@ jobs:
         if: ${{ !inputs.linux_cross && !inputs.macos_cross || inputs.linux_cross }}
         with:
           python-version: "3.13"
-
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ inputs.target }}
 
       # Linux musl toolchain (libudev is auto-excluded for musl targets by serialport)
       - name: Install Linux dependencies
@@ -85,11 +95,11 @@ jobs:
         shell: bash
         run: |
           if [ "${{ inputs.linux_cross }}" = "true" ]; then
-            cargo-zigbuild build --release --target ${{ inputs.target }} -p fbuild-cli
-            cargo-zigbuild build --release --target ${{ inputs.target }} -p fbuild-daemon
+            soldr cargo zigbuild build --release --target ${{ inputs.target }} -p fbuild-cli
+            soldr cargo zigbuild build --release --target ${{ inputs.target }} -p fbuild-daemon
           else
-            cargo build --release --target ${{ inputs.target }} -p fbuild-cli
-            cargo build --release --target ${{ inputs.target }} -p fbuild-daemon
+            soldr cargo build --release --target ${{ inputs.target }} -p fbuild-cli
+            soldr cargo build --release --target ${{ inputs.target }} -p fbuild-daemon
           fi
 
       # PyO3 extension — built for ALL targets, including cross-compiled.
@@ -112,17 +122,17 @@ jobs:
             ARCH="${TARGET%%-*}"
             PYO3_TARGET="${ARCH}-unknown-linux-gnu"
             rustup target add "$PYO3_TARGET"
-            PYO3_NO_PYTHON=1 cargo-zigbuild build --release \
+            PYO3_NO_PYTHON=1 soldr cargo zigbuild build --release \
               --target "${PYO3_TARGET}.2.17" -p fbuild-python \
               --features extension-module
           elif [ "${{ inputs.macos_cross }}" = "true" ]; then
-            PYO3_NO_PYTHON=1 cargo build --release \
+            PYO3_NO_PYTHON=1 soldr cargo build --release \
               --target ${{ inputs.target }} -p fbuild-python \
               --features extension-module
           elif [ "${{ runner.os }}" = "macOS" ]; then
-            cargo build --release -p fbuild-python --features extension-module
+            soldr cargo build --release -p fbuild-python --features extension-module
           else
-            cargo build --release -p fbuild-python --features extension-module
+            soldr cargo build --release -p fbuild-python --features extension-module
           fi
 
       - name: Stage artifacts
@@ -175,7 +185,3 @@ jobs:
           name: binaries-${{ inputs.target }}
           path: staging/
           if-no-files-found: error
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,6 @@ uv run cargo run -p fbuild-cli -- test-emu tests/platform/mega -e megaatmega2560
 ./_cargo clippy --workspace --all-targets -- -D warnings
 ./_rustfmt --check <file.rs>
 
-# Local zccache setup (optional, configures rustc-wrapper)
-uv run python ci/zccache_setup.py
-
 # Board definition management
 uv run python ci/validate_boards.py                    # validate against PlatformIO
 uv run python ci/validate_boards.py --external         # compare against Arduino + Zephyr
@@ -59,6 +56,12 @@ uv run python ci/build_dist.py --ref main
 
 # Publish to PyPI
 ./publish
+```
+
+Optional wrapper-mode only; do not use for standard soldr builds:
+
+```bash
+uv run python ci/zccache_setup.py  # writes rustc-wrapper = "zccache"
 ```
 
 ## Hooks (enforced automatically)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ fbuild is a PlatformIO-compatible embedded build tool (11 crates). See @docs/CLA
 
 ## Essential Rules
 
-- **Always use `uv run`, `soldr`, or `_cargo`/`_rustc`/`_rustfmt` trampolines to execute Rust commands.** Bare cargo/rustc are blocked by hook. All three forms resolve through [soldr](https://github.com/zackees/soldr), which uses `rustup which` to pick the rustup-managed toolchain; the cargo path adds `--no-cache` so the previous bare-cargo semantics are preserved.
+- **Always use `uv run`, `soldr`, or `_cargo`/`_rustc`/`_rustfmt` trampolines to execute Rust commands.** Bare cargo/rustc are blocked by hook. All three forms resolve through [soldr](https://github.com/zackees/soldr), which uses `rustup which` to pick the rustup-managed toolchain. The standard Cargo path is `soldr cargo ...`; do not add repo-specific `RUSTC_WRAPPER` wiring for normal builds.
 - **Always use `uv` for Python.** Bare `python`/`pip` are blocked by hook. Use `uv run ...` or `uv pip ...`.
 - MSRV: 1.75 | Edition: 2021 | Toolchain: 1.94.1 pinned in `rust-toolchain.toml` (clippy + rustfmt)
 - CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)

--- a/CODEX.md
+++ b/CODEX.md
@@ -41,9 +41,15 @@ uv run cargo fmt --all
 uv run test
 uv run test --full
 uv run test -p fbuild-build -- some_test_name
+```
 
+## Optional wrapper-mode
+
+```powershell
 uv run python ci/zccache_setup.py
 ```
+
+This configures `rustc-wrapper = "zccache"` for local wrapper-mode experiments. Standard builds should use `uv run`, `soldr`, or the `_cargo`/`_rustc`/`_rustfmt` trampolines above.
 
 ## Allowed fallback
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -22,7 +22,7 @@ Codex working notes for this repo. Start with [CLAUDE.md](./CLAUDE.md) for the f
 - Repo hooks enforce this.
 - All three forms dispatch through [soldr](https://github.com/zackees/soldr), which resolves each tool via `rustup which` so the rustup-managed toolchain is always used instead of a stale system or Chocolatey install.
 - `uv run cargo ...` works because `ci/dev-tools` registers `cargo`/`rustc`/`rustfmt` as repo-local uv scripts that now dispatch through `ci/trampoline.py` → `soldr`.
-- The `cargo` path passes `--no-cache` so the previous bare-cargo semantics are preserved (no RUSTC_WRAPPER / managed zccache inserted).
+- The normal Cargo path is `soldr cargo ...`; do not add repo-specific `RUSTC_WRAPPER` wiring for standard builds.
 - If you bypass them, you can hit wrong-toolchain errors.
 
 ## Use these

--- a/_cargo
+++ b/_cargo
@@ -1,5 +1,4 @@
 #!/bin/bash
 # Trampoline: runs cargo through soldr so the rustup-managed toolchain
-# is always used. --no-cache keeps the compilation wrapper off to
-# match the previous bare-cargo behavior.
-exec uv run soldr --no-cache cargo "$@"
+# is always used.
+exec uv run soldr cargo "$@"

--- a/ci/README.md
+++ b/ci/README.md
@@ -11,7 +11,7 @@ Python scripts for CI, packaging, and development tooling. All invoked via `uv r
 - **`test.py`** -- Workspace test runner with `--full` (stress + integration) and per-crate filtering
 - **`trampoline.py`** -- Rust toolchain trampolines (cargo, rustc, rustfmt, clippy-driver) registered as `uv` project scripts
 - **`validate_boards.py`** -- Validates fbuild board JSON assets against PlatformIO board definitions
-- **`zccache_setup.py`** -- Optional local setup for zccache as the Cargo rustc-wrapper
+- **`zccache_setup.py`** -- Optional local wrapper-mode setup for zccache; not used by the standard soldr build path
 
 ## Subdirectories
 

--- a/ci/dev-tools/README.md
+++ b/ci/dev-tools/README.md
@@ -2,7 +2,7 @@
 
 Pip-installable package that registers Rust toolchain trampolines as console scripts, so `uv run cargo` resolves to the rustup-managed toolchain without polluting global installs.
 
-The trampolines route through [soldr](https://github.com/zackees/soldr) (pulled in via the `soldr>=0.7.0` dependency), which uses `rustup which` to pick the right toolchain. `cargo` is invoked with `--no-cache` so the previous bare-cargo semantics are preserved — no RUSTC_WRAPPER is inserted.
+The trampolines route through [soldr](https://github.com/zackees/soldr) (pulled in via the `soldr>=0.7.0` dependency), which uses `rustup which` to pick the right toolchain. The standard Cargo path is `soldr cargo ...`, matching soldr's integration guidance without repo-specific `RUSTC_WRAPPER` wiring.
 
 ## Contents
 

--- a/ci/trampoline.py
+++ b/ci/trampoline.py
@@ -9,10 +9,9 @@ Why soldr:
 - soldr resolves each tool via `rustup which`, which respects
   `rust-toolchain.toml` the same way the old PATH-based trampolines
   did, but without requiring PATH to be pre-shaped.
-- `soldr --no-cache cargo` preserves the prior bare-cargo semantics
-  (no RUSTC_WRAPPER, no managed zccache) so this migration is
-  behavior-preserving for CI and local dev. Adopting soldr's built-in
-  zccache wrapper is a separate, deliberate decision.
+- The normal Cargo path is `soldr cargo ...`, matching Soldr's
+  integration guidance and letting Soldr manage its own wrapper
+  behavior without repo-specific `RUSTC_WRAPPER` wiring.
 """
 
 import shutil
@@ -21,8 +20,8 @@ import sys
 from pathlib import Path
 
 
-def _soldr_prefix(no_cache: bool):
-    """Return the argv prefix that runs soldr, with `--no-cache` if asked."""
+def _soldr_prefix():
+    """Return the argv prefix that runs soldr."""
     if not shutil.which("soldr"):
         print(
             "error: `soldr` not found on PATH. Run ./install (or `uv sync`) "
@@ -30,35 +29,30 @@ def _soldr_prefix(no_cache: bool):
             file=sys.stderr,
         )
         sys.exit(1)
-    prefix = ["soldr"]
-    if no_cache:
-        prefix.append("--no-cache")
-    return prefix
+    return ["soldr"]
 
 
-def _run_via_soldr(subcommand: str, *, no_cache: bool):
-    """Exec `soldr [--no-cache] <subcommand> <argv...>`."""
-    cmd = _soldr_prefix(no_cache) + [subcommand] + sys.argv[1:]
+def _run_via_soldr(subcommand: str):
+    """Exec `soldr <subcommand> <argv...>`."""
+    cmd = _soldr_prefix() + [subcommand] + sys.argv[1:]
     result = subprocess.run(cmd)
     sys.exit(result.returncode)
 
 
 def cargo():
-    # --no-cache keeps soldr's RUSTC_WRAPPER / zccache path off, matching
-    # the previous bare-cargo behavior of this trampoline.
-    _run_via_soldr("cargo", no_cache=True)
+    _run_via_soldr("cargo")
 
 
 def rustc():
-    _run_via_soldr("rustc", no_cache=False)
+    _run_via_soldr("rustc")
 
 
 def rustfmt():
-    _run_via_soldr("rustfmt", no_cache=False)
+    _run_via_soldr("rustfmt")
 
 
 def clippy_driver():
-    _run_via_soldr("clippy-driver", no_cache=False)
+    _run_via_soldr("clippy-driver")
 
 
 def _run_cargo_bin(package):
@@ -67,7 +61,7 @@ def _run_cargo_bin(package):
     # Strip leading '--' that uv inserts.
     if extra and extra[0] == "--":
         extra = extra[1:]
-    cmd = _soldr_prefix(no_cache=True) + ["cargo", "run", "-p", package]
+    cmd = _soldr_prefix() + ["cargo", "run", "-p", package]
     if extra:
         cmd.append("--")
         cmd.extend(extra)

--- a/crates/fbuild-build/src/build_fingerprint/mod.rs
+++ b/crates/fbuild-build/src/build_fingerprint/mod.rs
@@ -134,7 +134,7 @@ pub fn hash_files(paths: &[PathBuf]) -> Result<String> {
 
 pub fn hash_watch_set(watches: &[FingerprintWatch]) -> Result<String> {
     let mut ordered = watches.to_vec();
-    ordered.sort_by(|a, b| watch_identity(a).cmp(&watch_identity(b)));
+    ordered.sort_by_key(watch_identity);
 
     let mut hasher = Sha256::new();
     for watch in &ordered {
@@ -228,7 +228,7 @@ where
     F: FnMut(&Path) -> Result<String>,
 {
     let mut ordered = watches.to_vec();
-    ordered.sort_by(|a, b| watch_identity(a).cmp(&watch_identity(b)));
+    ordered.sort_by_key(watch_identity);
 
     let mut hasher = Sha256::new();
     for watch in &ordered {


### PR DESCRIPTION
## Summary
- switch local cargo trampolines from \\soldr --no-cache cargo\\ to standard \\soldr cargo ...\\
- update GitHub Actions check/build/docs/native workflows to install or build soldr and run cargo through it
- remove normal-path workflow zccache wiring and update docs to match the soldr integration model

## Verification
- \\uv run python -m py_compile ci/trampoline.py ci/hooks/tool_guard.py ci/hooks/test_tool_guard.py\\
- \\uv run python ci/hooks/test_tool_guard.py\\
- \\uv run cargo --version\\

## Notes
- Linux workflows install released \\soldr 0.7.4\\
- macOS, Windows, and the reusable native-build template build soldr from source for a cross-environment fallback
- \\	emplate_native_build.yml\\ routes \\cargo-zigbuild\\ usage through \\soldr cargo zigbuild ...\\ so the cargo entrypoint stays inside soldr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions workflows and build infrastructure across all platforms to improve consistency and efficiency
  * Refreshed build documentation and development scripts to align with updated tooling requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->