### PR TITLE
Add SAM warm-build fast path

### DIFF
--- a/crates/fbuild-build/src/sam/orchestrator.rs
+++ b/crates/fbuild-build/src/sam/orchestrator.rs
@@ -20,9 +20,15 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use fbuild_core::{Platform, Result};
+use serde::Serialize;
 
+use crate::build_fingerprint::{
+    hash_watch_set_stamps_cached, save_json, stable_hash_json, FastPathInputs,
+    PersistedBuildFingerprint, BUILD_FINGERPRINT_VERSION,
+};
 use crate::compile_database::TargetArchitecture;
 use crate::pipeline;
+use crate::zccache::FingerprintWatch;
 use crate::{BuildOrchestrator, BuildParams, BuildResult, SourceScanner};
 
 use super::sam_compiler::SamCompiler;
@@ -37,6 +43,63 @@ fn is_samd_mcu(mcu: &str) -> bool {
 /// SAM platform build orchestrator.
 pub struct SamOrchestrator;
 
+#[derive(Debug, Serialize)]
+struct SamFingerprintMetadata {
+    version: u32,
+    env_name: String,
+    profile: String,
+    board_name: String,
+    board_mcu: String,
+    board_define: String,
+    board_core: String,
+    board_variant: String,
+    board_f_cpu: String,
+    board_extra_flags: Option<String>,
+    board_vid: Option<String>,
+    board_pid: Option<String>,
+    platform: String,
+    max_flash: Option<u64>,
+    max_ram: Option<u64>,
+}
+
+fn profile_label(profile: fbuild_core::BuildProfile) -> &'static str {
+    match profile {
+        fbuild_core::BuildProfile::Release => "release",
+        fbuild_core::BuildProfile::Quick => "quick",
+    }
+}
+
+fn build_fingerprint_path(build_dir: &Path) -> PathBuf {
+    build_dir.join("build_fingerprint.json")
+}
+
+fn collect_fast_path_watches(build_dir: &Path, project_dir: &Path) -> Vec<FingerprintWatch> {
+    let mut watches = Vec::new();
+    if let Some(watch) =
+        crate::build_fingerprint::fast_path_watch("project", build_dir, project_dir)
+    {
+        watches.push(watch);
+    }
+    let resolved_libs_dir = build_dir.join("libs");
+    if let Some(watch) =
+        crate::build_fingerprint::fast_path_watch("dep_libs", build_dir, &resolved_libs_dir)
+    {
+        watches.push(watch);
+    }
+    watches
+}
+
+fn expected_fast_path_artifacts(
+    build_dir: &Path,
+    project_dir: &Path,
+) -> (PathBuf, PathBuf, PathBuf) {
+    (
+        build_dir.join("firmware.elf"),
+        build_dir.join("firmware.bin"),
+        crate::compile_database::CompileDatabase::expected_output_path(build_dir, project_dir),
+    )
+}
+
 impl BuildOrchestrator for SamOrchestrator {
     fn platform(&self) -> Platform {
         Platform::AtmelSam
@@ -44,6 +107,7 @@ impl BuildOrchestrator for SamOrchestrator {
 
     fn build(&self, params: &BuildParams) -> Result<BuildResult> {
         let start = Instant::now();
+        let compiler_cache = crate::zccache::find_zccache().map(std::path::Path::to_path_buf);
 
         // 1-2. Parse config, load board, setup build dirs, resolve src dir, collect flags
         let mut ctx = pipeline::BuildContext::new(params)?;
@@ -67,6 +131,64 @@ impl BuildOrchestrator for SamOrchestrator {
             } else {
                 install_sam_core(params, &ctx.board.core, &ctx.board.variant)?
             };
+
+        let build_dir = &ctx.build_dir;
+        let fingerprint_path = build_fingerprint_path(build_dir);
+        let metadata_hash = stable_hash_json(&SamFingerprintMetadata {
+            version: BUILD_FINGERPRINT_VERSION,
+            env_name: params.env_name.clone(),
+            profile: profile_label(params.profile).to_string(),
+            board_name: ctx.board.name.clone(),
+            board_mcu: ctx.board.mcu.clone(),
+            board_define: ctx.board.board.clone(),
+            board_core: ctx.board.core.clone(),
+            board_variant: ctx.board.variant.clone(),
+            board_f_cpu: ctx.board.f_cpu.clone(),
+            board_extra_flags: ctx.board.extra_flags.clone(),
+            board_vid: ctx.board.vid.clone(),
+            board_pid: ctx.board.pid.clone(),
+            platform: "atmelsam".to_string(),
+            max_flash: ctx.board.max_flash,
+            max_ram: ctx.board.max_ram,
+        })?;
+        let fingerprint_watches = collect_fast_path_watches(build_dir, &params.project_dir);
+
+        if !params.compiledb_only
+            && !params.symbol_analysis
+            && params.symbol_analysis_path.is_none()
+        {
+            let (fast_elf, fast_bin, fast_compile_db) =
+                expected_fast_path_artifacts(build_dir, &params.project_dir);
+            let required_artifacts = [fast_elf.clone(), fast_bin.clone(), fast_compile_db.clone()];
+            let inputs = FastPathInputs {
+                fingerprint_path: &fingerprint_path,
+                metadata_hash: &metadata_hash,
+                watches: &fingerprint_watches,
+                required_artifacts: &required_artifacts,
+                extra_artifact_ok: None,
+                watch_set_cache: params.watch_set_cache.as_deref(),
+                compiler_cache: compiler_cache.as_deref(),
+            };
+            if let Some(hit) = crate::build_fingerprint::fast_path_check(&inputs)? {
+                ctx.build_log
+                    .push("No-op fingerprint matched; reusing existing SAM artifacts.".to_string());
+                let elapsed = start.elapsed().as_secs_f64();
+                return Ok(BuildResult {
+                    success: true,
+                    firmware_path: Some(fast_bin),
+                    elf_path: Some(fast_elf),
+                    size_info: hit.size_info,
+                    symbol_map: None,
+                    build_time_secs: elapsed,
+                    message: format!(
+                        "SAM ({}) build for {} reused cached artifacts",
+                        ctx.board.mcu, params.env_name
+                    ),
+                    compile_database_path: Some(fast_compile_db),
+                    build_log: ctx.build_log,
+                });
+            }
+        }
 
         // 5. Scan sources
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
@@ -176,7 +298,7 @@ impl BuildOrchestrator for SamOrchestrator {
         };
 
         // 9. Run shared sequential build pipeline
-        pipeline::run_sequential_build_with_libs(
+        let build_result = pipeline::run_sequential_build_with_libs(
             &compiler,
             &linker,
             ctx,
@@ -187,7 +309,45 @@ impl BuildOrchestrator for SamOrchestrator {
             TargetArchitecture::Arm,
             "SAM",
             start,
-        )
+        )?;
+
+        if build_result.success
+            && !params.compiledb_only
+            && !params.symbol_analysis
+            && params.symbol_analysis_path.is_none()
+        {
+            let persisted_fingerprint = PersistedBuildFingerprint {
+                version: BUILD_FINGERPRINT_VERSION,
+                metadata_hash: metadata_hash.clone(),
+                file_set_hash: match hash_watch_set_stamps_cached(
+                    &fingerprint_watches,
+                    params.watch_set_cache.as_deref(),
+                ) {
+                    Ok(hash) => Some(hash),
+                    Err(e) => {
+                        tracing::warn!("failed to hash watched inputs for fingerprint save: {}", e);
+                        None
+                    }
+                },
+                size_info: build_result.size_info.clone(),
+            };
+            if let Err(e) = save_json(&fingerprint_path, &persisted_fingerprint) {
+                tracing::warn!("failed to write build fingerprint: {}", e);
+            }
+            if let Some(ref zcc) = compiler_cache {
+                for watch in &fingerprint_watches {
+                    if let Err(e) = crate::zccache::mark_fingerprint_success(zcc, watch) {
+                        tracing::warn!(
+                            "failed to mark zccache fingerprint success for {}: {}",
+                            watch.root.display(),
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(build_result)
     }
 }
 
@@ -286,5 +446,42 @@ mod tests {
     fn test_sam_orchestrator_platform() {
         let orch = SamOrchestrator;
         assert_eq!(orch.platform(), Platform::AtmelSam);
+    }
+
+    #[test]
+    fn test_collect_fast_path_watches_skips_missing_dep_libs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let build_dir = tmp.path().join("build");
+        let project_dir = tmp.path().join("project");
+        std::fs::create_dir_all(&build_dir).unwrap();
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let watches = collect_fast_path_watches(&build_dir, &project_dir);
+        assert_eq!(watches.len(), 1);
+        assert_eq!(watches[0].root, project_dir);
+    }
+
+    #[test]
+    fn test_expected_fast_path_artifacts_follow_compile_db_location() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let build_dir = tmp.path().join("build");
+        let app_project = tmp.path().join("app");
+        let lib_project = tmp.path().join("libproj");
+        std::fs::create_dir_all(&build_dir).unwrap();
+        std::fs::create_dir_all(&app_project).unwrap();
+        std::fs::create_dir_all(&lib_project).unwrap();
+        std::fs::write(lib_project.join("library.json"), r#"{"name":"libproj"}"#).unwrap();
+
+        let (app_elf, app_bin, app_compile_db) =
+            expected_fast_path_artifacts(&build_dir, &app_project);
+        let (lib_elf, lib_bin, lib_compile_db) =
+            expected_fast_path_artifacts(&build_dir, &lib_project);
+
+        assert_eq!(app_elf, build_dir.join("firmware.elf"));
+        assert_eq!(app_bin, build_dir.join("firmware.bin"));
+        assert_eq!(app_compile_db, app_project.join("compile_commands.json"));
+        assert_eq!(lib_elf, build_dir.join("firmware.elf"));
+        assert_eq!(lib_bin, build_dir.join("firmware.bin"));
+        assert_eq!(lib_compile_db, build_dir.join("compile_commands.json"));
     }
 }


### PR DESCRIPTION
## Summary
- add SAM-local warm-build fingerprint metadata, watch collection, and expected artifact helpers
- short-circuit SAM builds when fingerprinted inputs and existing artifacts still match
- persist the SAM fingerprint after successful builds and cover the local artifact/watch contract with unit tests

## Verification
- cargo test -p fbuild-build --lib sam::orchestrator::tests -- --nocapture
- cargo check -p fbuild-build --lib