### PR TITLE
chore: use soldr managed zccache by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ fbuild is a PlatformIO-compatible embedded build tool (11 crates). See @docs/CLA
 
 ## Essential Rules
 
-- **Always use `uv run`, `soldr`, or `_cargo`/`_rustc`/`_rustfmt` trampolines to execute Rust commands.** Bare cargo/rustc are blocked by hook. All three forms resolve through [soldr](https://github.com/zackees/soldr), which uses `rustup which` to pick the rustup-managed toolchain. The standard Cargo path is `soldr cargo ...`; do not add repo-specific `RUSTC_WRAPPER` wiring for normal builds.
+- **Always use `uv run`, `soldr`, or `_cargo`/`_rustc`/`_rustfmt` trampolines to execute Rust commands.** Bare cargo/rustc are blocked by hook. All three forms resolve through [soldr](https://github.com/zackees/soldr), which uses `rustup which` to pick the rustup-managed toolchain. The standard Cargo path is `soldr cargo ...`, so repo Rust builds get soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for normal builds.
 - **Always use `uv` for Python.** Bare `python`/`pip` are blocked by hook. Use `uv run ...` or `uv pip ...`.
 - MSRV: 1.75 | Edition: 2021 | Toolchain: 1.94.1 pinned in `rust-toolchain.toml` (clippy + rustfmt)
 - CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)

--- a/CODEX.md
+++ b/CODEX.md
@@ -21,8 +21,8 @@ Codex working notes for this repo. Start with [CLAUDE.md](./CLAUDE.md) for the f
 
 - Repo hooks enforce this.
 - All three forms dispatch through [soldr](https://github.com/zackees/soldr), which resolves each tool via `rustup which` so the rustup-managed toolchain is always used instead of a stale system or Chocolatey install.
-- `uv run cargo ...` works because `ci/dev-tools` registers `cargo`/`rustc`/`rustfmt` as repo-local uv scripts that now dispatch through `ci/trampoline.py` → `soldr`.
-- The normal Cargo path is `soldr cargo ...`; do not add repo-specific `RUSTC_WRAPPER` wiring for standard builds.
+- `uv run cargo ...` works because `ci/dev-tools` registers `cargo`/`rustc`/`rustfmt` as repo-local uv scripts that now dispatch through `ci/trampoline.py` -> `soldr`.
+- The normal Cargo path is `soldr cargo ...`, so repo Rust builds use soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for standard builds.
 - If you bypass them, you can hit wrong-toolchain errors.
 
 ## Use these

--- a/_cargo
+++ b/_cargo
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Trampoline: runs cargo through soldr so the rustup-managed toolchain
-# is always used.
+# is always used and soldr's managed zccache path stays on by default.
 exec uv run soldr cargo "$@"

--- a/ci/dev-tools/README.md
+++ b/ci/dev-tools/README.md
@@ -2,8 +2,8 @@
 
 Pip-installable package that registers Rust toolchain trampolines as console scripts, so `uv run cargo` resolves to the rustup-managed toolchain without polluting global installs.
 
-The trampolines route through [soldr](https://github.com/zackees/soldr) (pulled in via the `soldr>=0.7.0` dependency), which uses `rustup which` to pick the right toolchain. The standard Cargo path is `soldr cargo ...`, matching soldr's integration guidance without repo-specific `RUSTC_WRAPPER` wiring.
+The trampolines route through [soldr](https://github.com/zackees/soldr) (pulled in via the `soldr>=0.7.4` dependency), which uses `rustup which` to pick the right toolchain. The standard Cargo path is `soldr cargo ...`, so soldr's managed zccache path is enabled by default for repo Rust builds without repo-specific `RUSTC_WRAPPER` wiring.
 
 ## Contents
 
-- **`pyproject.toml`** -- Declares the `soldr>=0.7.0` dependency and defines console script entry points: `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `run_fbuild`, `run_fbuild_daemon`, `publish`
+- **`pyproject.toml`** -- Declares the `soldr>=0.7.4` dependency and defines console script entry points: `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `run_fbuild`, `run_fbuild_daemon`, `publish`

--- a/ci/dev-tools/pyproject.toml
+++ b/ci/dev-tools/pyproject.toml
@@ -3,7 +3,7 @@ name = "fbuild-dev-tools"
 version = "0.0.0"
 description = "Repo-local Rust toolchain trampolines for fbuild development"
 requires-python = ">=3.10"
-dependencies = ["soldr>=0.7.0"]
+dependencies = ["soldr>=0.7.4"]
 
 [project.scripts]
 cargo = "ci.trampoline:cargo"

--- a/ci/trampoline.py
+++ b/ci/trampoline.py
@@ -9,9 +9,9 @@ Why soldr:
 - soldr resolves each tool via `rustup which`, which respects
   `rust-toolchain.toml` the same way the old PATH-based trampolines
   did, but without requiring PATH to be pre-shaped.
-- The normal Cargo path is `soldr cargo ...`, matching Soldr's
-  integration guidance and letting Soldr manage its own wrapper
-  behavior without repo-specific `RUSTC_WRAPPER` wiring.
+- The normal Cargo path is `soldr cargo ...`, so local dev and CI get
+  soldr's managed zccache path by default without repo-specific
+  `RUSTC_WRAPPER` wiring.
 """
 
 import shutil

--- a/uv.lock
+++ b/uv.lock
@@ -30,19 +30,19 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "soldr", specifier = ">=0.7.0" }]
+requires-dist = [{ name = "soldr", specifier = ">=0.7.4" }]
 
 [[package]]
 name = "soldr"
-version = "0.7.0"
+version = "0.7.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/3b/c03ade86970c66712753986377ba1adfa9693cf73acbfabf9dcc70482c3b/soldr-0.7.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:009f08913325f807cb48bd58525a664102c63a1838cc7ed25d7dc053dfdbb380", size = 2775435, upload-time = "2026-04-16T23:08:58.003Z" },
-    { url = "https://files.pythonhosted.org/packages/57/2c/38b0366677e5a7b1f3e8a612f7787a07e04b81177bb2c9e034308eef39e7/soldr-0.7.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:27e5ad1933c213c37da1c0354ebe961d5a443c0d3cc30a458ba25b8bbcddf644", size = 2651596, upload-time = "2026-04-16T23:09:00.01Z" },
-    { url = "https://files.pythonhosted.org/packages/29/d6/827acd12fc8d4c291cfd6c71daf59e73a23282584db7aa1ec135f0a51311/soldr-0.7.0-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:0804c5e12bffe1219f573d66e666de15f2b032175cae83b8f75e56c8a7a1d2ce", size = 2888157, upload-time = "2026-04-16T23:09:01.854Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/e3/468ac6e5f86f5b5f966a5de8dd605f00efcd5c7a05f47844d6c5966b338a/soldr-0.7.0-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:003b75cf684c1be78ede590690283a646fead8ca287b03c63671dca833ad29d0", size = 2961724, upload-time = "2026-04-16T23:09:03.617Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bc/bc4182dfde721d8042fffd9b80bd6322e0961dc58bfbae04da7e4b72f857/soldr-0.7.0-py3-none-win_amd64.whl", hash = "sha256:1b749e51595abca5b325f37b6217104f19cbabbf73b895558a75b9f2522d9bef", size = 2557703, upload-time = "2026-04-16T23:09:05.158Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/76/e3a348a05251b5a80df0ece4e9c2c830b1ce1adb9418d288060618b71e14/soldr-0.7.0-py3-none-win_arm64.whl", hash = "sha256:9e297c34296ebbac3036f9011fbd0b0c7409a5765b9770626280f4600f1ebdb3", size = 2439090, upload-time = "2026-04-16T23:09:06.593Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ca/3eea52ee622fb6fee3cf4d448c5d92f700e47d1a0f0d6839dd5b9dbfda8a/soldr-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ff59a9fc4c0419cfd5ea7d88c0c6bfa7bd8d8315d56ee13a4fa400cff0595ee0", size = 2785010, upload-time = "2026-04-20T01:22:20.144Z" },
+    { url = "https://files.pythonhosted.org/packages/87/69/7e934b078b9a10aa2e24eebdb3105e8c5d06737e05027f47eca223583026/soldr-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c84c35ce7ebe8058a23e735a8bde70b297af4d421db8b916d08737ced306612a", size = 2658121, upload-time = "2026-04-20T01:22:22.038Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/14/98783007f6c7cb3df9c0d0662a0a00b882c7853b42b12e5367833dc3f45e/soldr-0.7.4-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:2546c0a0f88db525d542817bd8905cd01d3f6332fb842d6e9f9ae7af07300106", size = 2902517, upload-time = "2026-04-20T01:22:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/e9/6ba7a0b58488cf8eb58f721bf9e0ba777468c41928624b40f884389d415e/soldr-0.7.4-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:beb757bf260e165e465083960006cf507bf45c99d7f6a467d35315ee9681d45a", size = 2972375, upload-time = "2026-04-20T01:22:25.905Z" },
+    { url = "https://files.pythonhosted.org/packages/54/26/f860b15ac40a6c1fa16cc034aa3e92fabdf1482b12828ae2415c1a732b84/soldr-0.7.4-py3-none-win_amd64.whl", hash = "sha256:3f60e73d8a4743720bfa5f87e9fd99e4afed4003a2d96b0883c29a5f8f75ff75", size = 2564899, upload-time = "2026-04-20T01:22:27.199Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/35/993057d64b2cce5bfc6d60099fbcbfabb8c7a5ca55559038ef66a54bb3fc/soldr-0.7.4-py3-none-win_arm64.whl", hash = "sha256:a14ec225f49cf83dfcc03433fe9a73cd51f3af2b422f3ac03f680624750a7d90", size = 2443430, upload-time = "2026-04-20T01:22:28.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump fbuild dev-tools to `soldr>=0.7.4`
- document that the standard `soldr cargo` path uses soldr-managed zccache by default
- keep guidance against repo-specific `RUSTC_WRAPPER` wiring for normal builds

## Validation
- `git diff --check`
- checked conflict markers after resolving the rebase/stash conflicts

Benchmark artifact notes from local untracked files:
- no-cache cold build completed in 55.17s
- no-cache rebuild completed in 54.03s
- stock cold run repeatedly failed installing `zccache-cli 1.3.0` via soldr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build system documentation to clarify default cache path behavior for repository Rust builds. Refined technical integration explanations and guidance across configuration, setup, and README documentation.

* **Chores**
  * Updated minimum version requirement for a core build system dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->