### PR TITLE
Fix Teensy framework library resolution

### DIFF
--- a/crates/fbuild-build/src/teensy/orchestrator.rs
+++ b/crates/fbuild-build/src/teensy/orchestrator.rs
@@ -12,11 +12,14 @@
 //! 9. Link (with linker script from teensy4/)
 //! 10. Convert to hex + report size
 
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use fbuild_core::{Platform, Result};
+use fbuild_packages::library::TeensyFrameworkLibrary;
 use serde::Serialize;
+use walkdir::{DirEntry, WalkDir};
 
 use crate::build_fingerprint::{
     hash_watch_set_stamps_cached, save_json, stable_hash_json, FastPathInputs,
@@ -87,6 +90,215 @@ fn expected_fast_path_artifacts(
         build_dir.join("firmware.hex"),
         CompileDatabase::expected_output_path(build_dir, project_dir),
     )
+}
+
+fn resolve_teensy_framework_library_sources(
+    framework: &fbuild_packages::library::TeensyCores,
+    project_dir: &Path,
+    src_dir: &Path,
+) -> Vec<PathBuf> {
+    let libraries = framework.get_framework_libraries();
+    let roots = teensy_include_scan_roots(project_dir, src_dir);
+    resolve_teensy_framework_library_sources_from_libraries(&libraries, &roots)
+}
+
+fn resolve_teensy_framework_library_sources_from_libraries(
+    libraries: &[TeensyFrameworkLibrary],
+    roots: &[PathBuf],
+) -> Vec<PathBuf> {
+    let mut header_to_library = HashMap::new();
+    for (idx, library) in libraries.iter().enumerate() {
+        let mut headers = HashSet::new();
+        for include_dir in &library.include_dirs {
+            collect_header_names(include_dir, &mut headers);
+        }
+        for header in headers {
+            header_to_library.entry(header).or_insert(idx);
+        }
+    }
+
+    let mut pending = HashSet::new();
+    for root in roots {
+        collect_included_headers(root, &mut pending);
+    }
+
+    let mut selected = HashSet::new();
+    let mut queue: Vec<String> = pending.iter().cloned().collect();
+    while let Some(header) = queue.pop() {
+        let Some(&library_idx) = header_to_library.get(&header) else {
+            continue;
+        };
+        if !selected.insert(library_idx) {
+            continue;
+        }
+
+        let mut transitive_headers = HashSet::new();
+        collect_framework_included_headers(&libraries[library_idx].dir, &mut transitive_headers);
+        for transitive in transitive_headers {
+            if pending.insert(transitive.clone()) {
+                queue.push(transitive);
+            }
+        }
+    }
+
+    let mut selected_indices: Vec<_> = selected.into_iter().collect();
+    selected_indices.sort_unstable();
+
+    let mut sources = Vec::new();
+    for idx in selected_indices {
+        tracing::info!(
+            "selected Teensy framework library '{}': {} source files",
+            libraries[idx].name,
+            libraries[idx].source_files.len()
+        );
+        sources.extend(libraries[idx].source_files.iter().cloned());
+    }
+    sources.sort();
+    sources.dedup();
+    sources
+}
+
+fn teensy_include_scan_roots(project_dir: &Path, src_dir: &Path) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    push_existing_unique(&mut roots, src_dir.to_path_buf());
+    push_existing_unique(&mut roots, project_dir.join("src"));
+    push_existing_unique(&mut roots, project_dir.join("include"));
+    push_existing_unique(&mut roots, project_dir.join("lib"));
+    roots
+}
+
+fn push_existing_unique(roots: &mut Vec<PathBuf>, path: PathBuf) {
+    if !path.exists() {
+        return;
+    }
+    if !roots.iter().any(|existing| existing == &path) {
+        roots.push(path);
+    }
+}
+
+fn collect_header_names(root: &Path, headers: &mut HashSet<String>) {
+    if !root.exists() {
+        return;
+    }
+
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(should_scan_framework_entry)
+        .flatten()
+    {
+        if !entry.file_type().is_file() || !is_header_file(entry.path()) {
+            continue;
+        }
+        if let Some(name) = entry.path().file_name().and_then(|name| name.to_str()) {
+            headers.insert(name.to_string());
+        }
+    }
+}
+
+fn collect_included_headers(root: &Path, headers: &mut HashSet<String>) {
+    collect_included_headers_with_filter(root, headers, should_scan_entry);
+}
+
+fn collect_framework_included_headers(root: &Path, headers: &mut HashSet<String>) {
+    collect_included_headers_with_filter(root, headers, should_scan_framework_entry);
+}
+
+fn collect_included_headers_with_filter(
+    root: &Path,
+    headers: &mut HashSet<String>,
+    filter: fn(&DirEntry) -> bool,
+) {
+    if !root.exists() {
+        return;
+    }
+
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(filter)
+        .flatten()
+    {
+        if !entry.file_type().is_file() || !is_source_or_header_file(entry.path()) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        for line in content.lines() {
+            if let Some(header) = parse_include_header(line) {
+                headers.insert(header);
+            }
+        }
+    }
+}
+
+fn should_scan_entry(entry: &DirEntry) -> bool {
+    let name = entry.file_name().to_string_lossy().to_lowercase();
+    !matches!(
+        name.as_str(),
+        ".git"
+            | ".pio"
+            | ".fbuild"
+            | ".zap"
+            | ".build"
+            | "build"
+            | "target"
+            | ".venv"
+            | "venv"
+            | "node_modules"
+            | "__pycache__"
+    )
+}
+
+fn should_scan_framework_entry(entry: &DirEntry) -> bool {
+    if !should_scan_entry(entry) {
+        return false;
+    }
+    let name = entry.file_name().to_string_lossy().to_lowercase();
+    !matches!(
+        name.as_str(),
+        "examples" | "example" | "extras" | "test" | "tests" | "fontconvert"
+    )
+}
+
+fn is_source_or_header_file(path: &Path) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    matches!(
+        ext.as_str(),
+        "c" | "cpp" | "cc" | "cxx" | "s" | "ino" | "h" | "hh" | "hpp" | "hxx"
+    )
+}
+
+fn is_header_file(path: &Path) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    matches!(ext.as_str(), "h" | "hh" | "hpp" | "hxx")
+}
+
+fn parse_include_header(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let directive = trimmed.strip_prefix('#')?.trim_start();
+    let rest = directive.strip_prefix("include")?.trim_start();
+    let mut chars = rest.chars();
+    let opener = chars.next()?;
+    let closer = match opener {
+        '<' => '>',
+        '"' => '"',
+        _ => return None,
+    };
+    let remainder = &rest[opener.len_utf8()..];
+    let end = remainder.find(closer)?;
+    let include_path = &remainder[..end];
+    Path::new(include_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_string())
 }
 
 impl BuildOrchestrator for TeensyOrchestrator {
@@ -190,6 +402,16 @@ impl BuildOrchestrator for TeensyOrchestrator {
             .core_sources
             .retain(|p| p.file_name().map(|f| f != "Blink.cc").unwrap_or(true));
 
+        let framework_library_sources =
+            resolve_teensy_framework_library_sources(&framework, &params.project_dir, &ctx.src_dir);
+        if !framework_library_sources.is_empty() {
+            tracing::info!(
+                "Teensy framework library sources added: {}",
+                framework_library_sources.len()
+            );
+            sources.core_sources.extend(framework_library_sources);
+        }
+
         tracing::info!(
             "sources: {} sketch, {} core",
             sources.sketch_sources.len(),
@@ -204,6 +426,7 @@ impl BuildOrchestrator for TeensyOrchestrator {
         let mut include_dirs = vec![core_dir.clone()];
         include_dirs.push(ctx.src_dir.clone());
         pipeline::discover_project_includes(&params.project_dir, &mut include_dirs);
+        include_dirs.extend(framework.get_framework_library_include_dirs());
         // Toolchain sysroot includes (ARM CMSIS headers, etc.)
         include_dirs.extend(toolchain.get_include_dirs());
 
@@ -392,5 +615,126 @@ mod tests {
 
         assert_eq!(app_compile_db, app_project.join("compile_commands.json"));
         assert_eq!(lib_compile_db, build_dir.join("compile_commands.json"));
+    }
+
+    #[test]
+    fn test_parse_include_header_extracts_basename() {
+        assert_eq!(
+            parse_include_header("#include <SPI.h>"),
+            Some("SPI.h".to_string())
+        );
+        assert_eq!(
+            parse_include_header("  # include \"utility/foo.hpp\""),
+            Some("foo.hpp".to_string())
+        );
+        assert_eq!(parse_include_header("int x = 1;"), None);
+    }
+
+    #[test]
+    fn test_resolve_teensy_framework_libraries_from_project_includes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project_src = tmp.path().join("project").join("src");
+        std::fs::create_dir_all(&project_src).unwrap();
+        std::fs::write(
+            project_src.join("main.cpp"),
+            "#include <SPI.h>\n#include <OctoWS2811.h>\n",
+        )
+        .unwrap();
+
+        let spi_dir = tmp.path().join("framework").join("libraries").join("SPI");
+        std::fs::create_dir_all(&spi_dir).unwrap();
+        std::fs::write(spi_dir.join("SPI.h"), "").unwrap();
+        std::fs::write(spi_dir.join("SPI.cpp"), "").unwrap();
+
+        let octo_dir = tmp
+            .path()
+            .join("framework")
+            .join("libraries")
+            .join("OctoWS2811");
+        std::fs::create_dir_all(&octo_dir).unwrap();
+        std::fs::write(octo_dir.join("OctoWS2811.h"), "").unwrap();
+        std::fs::write(octo_dir.join("OctoWS2811.cpp"), "").unwrap();
+        std::fs::write(octo_dir.join("OctoWS2811_imxrt.cpp"), "").unwrap();
+
+        let libraries = vec![
+            TeensyFrameworkLibrary {
+                name: "OctoWS2811".to_string(),
+                dir: octo_dir.clone(),
+                include_dirs: vec![octo_dir.clone()],
+                source_files: vec![
+                    octo_dir.join("OctoWS2811.cpp"),
+                    octo_dir.join("OctoWS2811_imxrt.cpp"),
+                ],
+            },
+            TeensyFrameworkLibrary {
+                name: "SPI".to_string(),
+                dir: spi_dir.clone(),
+                include_dirs: vec![spi_dir.clone()],
+                source_files: vec![spi_dir.join("SPI.cpp")],
+            },
+        ];
+
+        let mut sources = resolve_teensy_framework_library_sources_from_libraries(
+            &libraries,
+            &[project_src.clone()],
+        );
+        sources.sort();
+
+        assert_eq!(
+            sources,
+            vec![
+                octo_dir.join("OctoWS2811.cpp"),
+                octo_dir.join("OctoWS2811_imxrt.cpp"),
+                spi_dir.join("SPI.cpp"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_resolve_teensy_framework_libraries_follows_transitive_includes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project_src = tmp.path().join("project").join("src");
+        std::fs::create_dir_all(&project_src).unwrap();
+        std::fs::write(project_src.join("main.cpp"), "#include <NeedsSpi.h>\n").unwrap();
+
+        let spi_dir = tmp.path().join("framework").join("libraries").join("SPI");
+        std::fs::create_dir_all(&spi_dir).unwrap();
+        std::fs::write(spi_dir.join("SPI.h"), "").unwrap();
+        std::fs::write(spi_dir.join("SPI.cpp"), "").unwrap();
+
+        let wrapper_dir = tmp
+            .path()
+            .join("framework")
+            .join("libraries")
+            .join("NeedsSpi");
+        std::fs::create_dir_all(&wrapper_dir).unwrap();
+        std::fs::write(wrapper_dir.join("NeedsSpi.h"), "#include <SPI.h>\n").unwrap();
+        std::fs::write(wrapper_dir.join("NeedsSpi.cpp"), "").unwrap();
+
+        let libraries = vec![
+            TeensyFrameworkLibrary {
+                name: "NeedsSpi".to_string(),
+                dir: wrapper_dir.clone(),
+                include_dirs: vec![wrapper_dir.clone()],
+                source_files: vec![wrapper_dir.join("NeedsSpi.cpp")],
+            },
+            TeensyFrameworkLibrary {
+                name: "SPI".to_string(),
+                dir: spi_dir.clone(),
+                include_dirs: vec![spi_dir.clone()],
+                source_files: vec![spi_dir.join("SPI.cpp")],
+            },
+        ];
+
+        let mut sources = resolve_teensy_framework_library_sources_from_libraries(
+            &libraries,
+            &[project_src.clone()],
+        );
+        sources.sort();
+
+        assert_eq!(
+            sources,
+            vec![wrapper_dir.join("NeedsSpi.cpp"), spi_dir.join("SPI.cpp")]
+        );
     }
 }

--- a/crates/fbuild-build/tests/teensy_build.rs
+++ b/crates/fbuild-build/tests/teensy_build.rs
@@ -88,6 +88,67 @@ void loop() {
     );
 }
 
+/// Build a Teensy 4.1 sketch that includes Teensyduino framework libraries.
+#[test]
+#[ignore]
+fn build_teensy41_spi_octo_headers() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let project_dir = tmp.path();
+
+    fs::write(
+        project_dir.join("platformio.ini"),
+        "[env:teensy41]\nplatform = teensy\nboard = teensy41\nframework = arduino\n",
+    )
+    .unwrap();
+
+    let src_dir = project_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        src_dir.join("main.cpp"),
+        "\
+#include <Arduino.h>
+#include <SPI.h>
+#include <OctoWS2811.h>
+
+void setup() {
+  SPI.begin();
+}
+
+void loop() {}
+",
+    )
+    .unwrap();
+
+    let build_dir = project_dir.join(".fbuild/build");
+    let params = BuildParams {
+        project_dir: project_dir.to_path_buf(),
+        env_name: "teensy41".to_string(),
+        clean: true,
+        profile: BuildProfile::Release,
+        build_dir,
+        verbose: true,
+        jobs: None,
+        generate_compiledb: false,
+        compiledb_only: false,
+        log_sender: None,
+        symbol_analysis: false,
+        symbol_analysis_path: None,
+        no_timestamp: false,
+        src_dir: None,
+        pio_env: Default::default(),
+        extra_build_flags: Vec::new(),
+        watch_set_cache: None,
+    };
+
+    let orchestrator = fbuild_build::teensy::orchestrator::TeensyOrchestrator;
+    let result = orchestrator
+        .build(&params)
+        .expect("Teensy framework library headers should build");
+
+    assert!(result.success);
+    assert!(result.firmware_path.expect("should produce hex").exists());
+}
+
 /// Build using Teensy test fixture from the repo.
 #[test]
 #[ignore]

--- a/crates/fbuild-packages/src/library/mod.rs
+++ b/crates/fbuild-packages/src/library/mod.rs
@@ -47,4 +47,4 @@ pub use sam_core::SamCores;
 pub use samd_core::SamdCores;
 pub use silabs_core::SilabsCores;
 pub use stm32_core::Stm32Cores;
-pub use teensy_core::TeensyCores;
+pub use teensy_core::{TeensyCores, TeensyFrameworkLibrary};

--- a/crates/fbuild-packages/src/library/teensy_core.rs
+++ b/crates/fbuild-packages/src/library/teensy_core.rs
@@ -1,16 +1,25 @@
-//! Teensy cores framework package.
+//! Teensy Arduino framework package.
 //!
-//! Downloads and manages the Teensy cores from PaulStoffregen/cores on GitHub.
-//! Key difference from ArduinoCore: no `cores/` wrapper directory. The archive
-//! extracts as `cores-master/` containing `teensy4/` directly.
+//! Downloads and manages PlatformIO's `framework-arduinoteensy` package, which
+//! contains the Teensy cores plus Teensyduino framework libraries such as SPI
+//! and OctoWS2811.
 
 use std::path::{Path, PathBuf};
 
 use crate::{CacheSubdir, Framework, PackageBase, PackageInfo};
 
-const TEENSY_CORE_VERSION: &str = "master";
-const TEENSY_CORE_URL: &str =
-    "https://github.com/PaulStoffregen/cores/archive/refs/heads/master.zip";
+/// Framework package used by platform-teensy 5.1.0.
+const TEENSY_CORE_VERSION: &str = "1.160.0";
+const TEENSY_CORE_URL: &str = "https://dl.registry.platformio.org/download/platformio/tool/framework-arduinoteensy/1.160.0/framework-arduinoteensy-1.160.0.tar.gz";
+
+/// A bundled Teensyduino framework library.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeensyFrameworkLibrary {
+    pub name: String,
+    pub dir: PathBuf,
+    pub include_dirs: Vec<PathBuf>,
+    pub source_files: Vec<PathBuf>,
+}
 
 /// Teensy cores framework manager.
 pub struct TeensyCores {
@@ -22,11 +31,11 @@ impl TeensyCores {
     pub fn new(project_dir: &Path) -> Self {
         Self {
             base: PackageBase::new(
-                "teensy-cores",
+                "framework-arduinoteensy",
                 TEENSY_CORE_VERSION,
                 TEENSY_CORE_URL,
                 TEENSY_CORE_URL,
-                None, // No checksum for master branch
+                None,
                 CacheSubdir::Platforms,
                 project_dir,
             ),
@@ -38,7 +47,7 @@ impl TeensyCores {
     fn with_cache_root(project_dir: &Path, cache_root: &Path) -> Self {
         Self {
             base: PackageBase::with_cache_root(
-                "teensy-cores",
+                "framework-arduinoteensy",
                 TEENSY_CORE_VERSION,
                 TEENSY_CORE_URL,
                 TEENSY_CORE_URL,
@@ -51,27 +60,25 @@ impl TeensyCores {
         }
     }
 
-    /// Get the resolved root directory of the core.
+    /// Get the resolved root directory of the framework.
     fn resolved_dir(&self) -> PathBuf {
         self.install_dir
             .clone()
             .unwrap_or_else(|| find_core_root(&self.base.install_path()))
     }
 
-    /// Validate the extracted core has required structure.
+    /// Validate the extracted framework has required structure.
     fn validate(install_dir: &Path) -> fbuild_core::Result<()> {
         let root = find_core_root(install_dir);
 
-        // Teensy cores have teensy4/ directory directly (no cores/ wrapper)
-        let teensy4 = root.join("teensy4");
+        let teensy4 = core_dir_for_root(&root, "teensy4");
         if !teensy4.exists() {
             return Err(fbuild_core::FbuildError::PackageError(format!(
-                "Teensy cores missing teensy4/ directory (in {})",
+                "Teensy framework missing teensy4 core directory (in {})",
                 root.display()
             )));
         }
 
-        // Check for key source files
         let arduino_h = teensy4.join("Arduino.h");
         if !arduino_h.exists() {
             return Err(fbuild_core::FbuildError::PackageError(
@@ -86,12 +93,28 @@ impl TeensyCores {
             ));
         }
 
+        let libraries_dir = root.join("libraries");
+        if !libraries_dir.join("SPI").join("SPI.h").exists() {
+            return Err(fbuild_core::FbuildError::PackageError(
+                "Teensy framework missing libraries/SPI/SPI.h".to_string(),
+            ));
+        }
+        if !libraries_dir
+            .join("OctoWS2811")
+            .join("OctoWS2811.h")
+            .exists()
+        {
+            return Err(fbuild_core::FbuildError::PackageError(
+                "Teensy framework missing libraries/OctoWS2811/OctoWS2811.h".to_string(),
+            ));
+        }
+
         Ok(())
     }
 
     /// Get the core source directory for a specific core name (e.g. "teensy4").
     pub fn get_core_dir(&self, core_name: &str) -> PathBuf {
-        self.resolved_dir().join(core_name)
+        self.get_cores_dir().join(core_name)
     }
 
     /// Get the linker script for a board.
@@ -109,6 +132,47 @@ impl TeensyCores {
     pub fn get_core_sources(&self, core_name: &str) -> Vec<PathBuf> {
         let core_dir = self.get_core_dir(core_name);
         collect_sources(&core_dir)
+    }
+
+    /// List bundled Teensyduino framework libraries.
+    pub fn get_framework_libraries(&self) -> Vec<TeensyFrameworkLibrary> {
+        let libraries_dir = self.get_libraries_dir();
+        let mut libs = Vec::new();
+        let Ok(entries) = std::fs::read_dir(&libraries_dir) else {
+            return libs;
+        };
+
+        for entry in entries.flatten() {
+            let dir = entry.path();
+            if !dir.is_dir() {
+                continue;
+            }
+            let name = dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default()
+                .to_string();
+            if name.is_empty() {
+                continue;
+            }
+            libs.push(TeensyFrameworkLibrary {
+                name,
+                include_dirs: library_include_dirs(&dir),
+                source_files: collect_library_sources(&dir),
+                dir,
+            });
+        }
+
+        libs.sort_by(|a, b| a.name.cmp(&b.name));
+        libs
+    }
+
+    /// All include directories needed to make bundled framework headers visible.
+    pub fn get_framework_library_include_dirs(&self) -> Vec<PathBuf> {
+        self.get_framework_libraries()
+            .into_iter()
+            .flat_map(|lib| lib.include_dirs)
+            .collect()
     }
 }
 
@@ -139,7 +203,10 @@ impl crate::Package for TeensyCores {
             return false;
         }
         let root = find_core_root(&self.base.install_path());
-        root.join("teensy4").join("Arduino.h").exists()
+        core_dir_for_root(&root, "teensy4")
+            .join("Arduino.h")
+            .exists()
+            && root.join("libraries").join("SPI").join("SPI.h").exists()
     }
 
     fn get_info(&self) -> PackageInfo {
@@ -148,42 +215,56 @@ impl crate::Package for TeensyCores {
 }
 
 impl Framework for TeensyCores {
-    /// For Teensy, cores_dir is the framework root itself (not a `cores/` subdirectory).
     fn get_cores_dir(&self) -> PathBuf {
-        self.resolved_dir()
+        let root = self.resolved_dir();
+        let cores = root.join("cores");
+        if cores.is_dir() {
+            cores
+        } else {
+            root
+        }
     }
 
-    /// Teensy cores have no variants/ directory — returns the root as fallback.
+    /// Teensy cores have no variants/ directory; returns the framework root as fallback.
     fn get_variants_dir(&self) -> PathBuf {
         self.resolved_dir()
     }
 
-    /// Libraries directory (if present in core).
     fn get_libraries_dir(&self) -> PathBuf {
         self.resolved_dir().join("libraries")
     }
 }
 
-/// Find the actual core root inside an extracted archive.
+/// Find the actual framework root inside an extracted archive.
 ///
-/// GitHub archives extract as `cores-master/` with the core dirs inside.
+/// PlatformIO framework archives extract with files directly at the root, while
+/// older GitHub core archives used a single nested directory.
 fn find_core_root(install_dir: &Path) -> PathBuf {
-    // Direct teensy4/ in install dir
-    if install_dir.join("teensy4").exists() {
+    if install_dir.join("cores").join("teensy4").exists() || install_dir.join("teensy4").exists() {
         return install_dir.to_path_buf();
     }
 
-    // Check one level deep (e.g. cores-master/)
     if let Ok(entries) = std::fs::read_dir(install_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_dir() && path.join("teensy4").exists() {
+            if path.is_dir()
+                && (path.join("cores").join("teensy4").exists() || path.join("teensy4").exists())
+            {
                 return path;
             }
         }
     }
 
     install_dir.to_path_buf()
+}
+
+fn core_dir_for_root(root: &Path, core_name: &str) -> PathBuf {
+    let nested = root.join("cores").join(core_name);
+    if nested.exists() {
+        nested
+    } else {
+        root.join(core_name)
+    }
 }
 
 /// Files to exclude from core compilation.
@@ -198,7 +279,6 @@ fn collect_sources(dir: &Path) -> Vec<PathBuf> {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_file() {
-                // Exclude known test files
                 let filename = path.file_name().unwrap_or_default().to_string_lossy();
                 if EXCLUDED_CORE_FILES.contains(&filename.as_ref()) {
                     continue;
@@ -219,6 +299,75 @@ fn collect_sources(dir: &Path) -> Vec<PathBuf> {
     sources
 }
 
+fn library_include_dirs(lib_dir: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let src = lib_dir.join("src");
+    if src.is_dir() {
+        dirs.push(src);
+    } else {
+        dirs.push(lib_dir.to_path_buf());
+    }
+
+    let utility = lib_dir.join("utility");
+    if utility.is_dir() {
+        dirs.push(utility);
+    }
+    let include = lib_dir.join("include");
+    if include.is_dir() {
+        dirs.push(include);
+    }
+    dirs
+}
+
+fn collect_library_sources(lib_dir: &Path) -> Vec<PathBuf> {
+    let search_dir = {
+        let src = lib_dir.join("src");
+        if src.is_dir() {
+            src
+        } else {
+            lib_dir.to_path_buf()
+        }
+    };
+
+    let mut sources = Vec::new();
+    collect_library_sources_inner(&search_dir, &mut sources);
+    sources.sort();
+    sources
+}
+
+fn collect_library_sources_inner(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_lowercase();
+            if matches!(
+                name.as_str(),
+                "example" | "examples" | "test" | "tests" | "extras"
+            ) {
+                continue;
+            }
+            collect_library_sources_inner(&path, out);
+        } else {
+            let ext = path
+                .extension()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_lowercase();
+            if matches!(ext.as_str(), "c" | "cpp" | "cc" | "cxx" | "s") {
+                out.push(path);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,15 +383,15 @@ mod tests {
     #[test]
     fn test_find_core_root_direct() {
         let tmp = tempfile::TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join("teensy4")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("cores").join("teensy4")).unwrap();
         assert_eq!(find_core_root(tmp.path()), tmp.path().to_path_buf());
     }
 
     #[test]
     fn test_find_core_root_nested() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let nested = tmp.path().join("cores-master");
-        std::fs::create_dir_all(nested.join("teensy4")).unwrap();
+        let nested = tmp.path().join("framework-arduinoteensy");
+        std::fs::create_dir_all(nested.join("cores").join("teensy4")).unwrap();
         assert_eq!(find_core_root(tmp.path()), nested);
     }
 
@@ -271,7 +420,6 @@ mod tests {
         std::fs::write(tmp.path().join("startup.S"), "").unwrap();
         std::fs::write(tmp.path().join("Arduino.h"), "").unwrap();
         let sources = collect_sources(tmp.path());
-        // .cpp, .c, .S (lowercased to "s") collected; .h excluded
         assert_eq!(sources.len(), 3);
     }
 
@@ -285,9 +433,32 @@ mod tests {
     #[test]
     fn test_validate_missing_arduino_h() {
         let tmp = tempfile::TempDir::new().unwrap();
-        std::fs::create_dir_all(tmp.path().join("teensy4")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("cores").join("teensy4")).unwrap();
         let result = TeensyCores::validate(tmp.path());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Arduino.h"));
+    }
+
+    #[test]
+    fn test_library_include_dirs_for_root_layout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let lib = tmp.path().join("SPI");
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(lib.join("SPI.h"), "").unwrap();
+
+        assert_eq!(library_include_dirs(&lib), vec![lib]);
+    }
+
+    #[test]
+    fn test_collect_library_sources_skips_examples_and_extras() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("OctoWS2811.cpp"), "").unwrap();
+        std::fs::create_dir_all(tmp.path().join("examples")).unwrap();
+        std::fs::write(tmp.path().join("examples").join("Demo.cpp"), "").unwrap();
+        std::fs::create_dir_all(tmp.path().join("extras")).unwrap();
+        std::fs::write(tmp.path().join("extras").join("tool.c"), "").unwrap();
+
+        let sources = collect_library_sources(tmp.path());
+        assert_eq!(sources, vec![tmp.path().join("OctoWS2811.cpp")]);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #163.

- Switches the Teensy framework package from the core-only `PaulStoffregen/cores` archive to PlatformIO's full `framework-arduinoteensy` package.
- Adds Teensyduino framework library include discovery so headers like `SPI.h` and `OctoWS2811.h` are visible to Teensy builds.
- Selects and compiles only bundled framework libraries referenced by project sources, following transitive framework includes while skipping examples/extras/tests.
- Adds unit coverage for Teensy framework library resolution and an ignored integration build that includes `SPI.h` and `OctoWS2811.h`.

## Verification

- `cargo test -p fbuild-packages library::teensy_core`
- `cargo test -p fbuild-build teensy::orchestrator`
- `cargo test -p fbuild-build --test teensy_build build_teensy41_blink -- --ignored --nocapture`
- `cargo test -p fbuild-build --test teensy_build build_teensy41_spi_octo_headers -- --ignored --nocapture`