### PR TITLE
Bump version to 2.1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-build"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "async-trait",
  "blake3",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "blake3",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "libc",
  "running-process-core",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "async-trait",
  "axum",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "async-trait",
  "espflash",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "axum",
  "bzip2",
@@ -914,14 +914,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "async-trait",
  "base64",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.1.21"
+version = "2.1.22"
 dependencies = [
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.1.21"
+version = "2.1.22"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.1.21"
+version = "2.1.22"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump workspace/package version from `2.1.21` to `2.1.22` after the Teensy framework library resolution fix in #164.
- Update `Cargo.lock` workspace package entries and `pyproject.toml` to match.

## Verification

- `cargo metadata --format-version 1 --no-deps`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump: 2.1.21 → 2.1.22

<!-- end of auto-generated comment: release notes by coderabbit.ai -->