### PR TITLE
Fix Teensy clippy slice refs

### DIFF
--- a/crates/fbuild-build/src/teensy/orchestrator.rs
+++ b/crates/fbuild-build/src/teensy/orchestrator.rs
@@ -676,7 +676,7 @@ mod tests {
 
         let mut sources = resolve_teensy_framework_library_sources_from_libraries(
             &libraries,
-            &[project_src.clone()],
+            std::slice::from_ref(&project_src),
         );
         sources.sort();
 
@@ -728,7 +728,7 @@ mod tests {
 
         let mut sources = resolve_teensy_framework_library_sources_from_libraries(
             &libraries,
-            &[project_src.clone()],
+            std::slice::from_ref(&project_src),
         );
         sources.sort();
 


### PR DESCRIPTION
## Summary
- Replace cloned one-element path slices in Teensy framework library tests with std::slice::from_ref
- Fix Rust 1.94 Clippy cloned_ref_to_slice_refs failures under -D warnings

## Verification
- uv run soldr cargo fmt --check
- uv run soldr cargo clippy -p fbuild-build --all-targets -- -D warnings
- uv run soldr cargo clippy --workspace --all-targets -- -D warnings