### PR TITLE
Fix Windows native extension staging

### DIFF
--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -157,8 +157,11 @@ jobs:
             ext_src="target/${{ inputs.target }}/release/lib_native.dylib"
             [ -f "$ext_src" ] && cp "$ext_src" staging/_native.abi3.so
           elif [ "${{ inputs.binary_ext }}" = ".exe" ]; then
-            [ -f target/release/_native.dll ] && \
-              cp target/release/_native.dll staging/_native.pyd
+            for ext_src in \
+              "target/${{ inputs.target }}/release/_native.dll" \
+              "target/release/_native.dll"; do
+              [ -f "$ext_src" ] && cp "$ext_src" staging/_native.pyd && break
+            done
           else
             for ext in so dylib; do
               src="target/release/lib_native.$ext"
@@ -182,6 +185,7 @@ jobs:
             strip staging/fbuild${{ inputs.binary_ext }} || true
             strip staging/fbuild-daemon${{ inputs.binary_ext }} || true
             strip staging/_native.abi3.so 2>/dev/null || true
+            strip staging/_native.pyd 2>/dev/null || true
           fi
 
       - name: Upload artifacts


### PR DESCRIPTION
## Summary
- stage the Windows PyO3 extension from the target-specific Cargo output directory
- keep the old target/release path as a fallback
- strip the staged .pyd when strip is available

Fixes the Windows native build failure from https://github.com/FastLED/fbuild/actions/runs/24751722826/job/72416416472 where Stage artifacts reported '_native.pyd missing'.

## Verification
- uv run soldr cargo build --release -p fbuild-python --features extension-module
- confirmed local artifact exists at target/x86_64-pc-windows-msvc/release/_native.dll
- copied that artifact with the patched staging loop to staging/_native.pyd
- parsed .github/workflows/template_native_build.yml with PyYAML
- git diff --check