### PR TITLE
Fix PyPI trusted publisher environment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -67,3 +67,9 @@ PyPI publishing requires a Trusted Publisher configured on PyPI for:
 - project: `fbuild`
 - repository: `FastLED/fbuild`
 - workflow: `.github/workflows/release-auto.yml`
+- environment: `pypi`
+
+The PyPI publish job declares the `pypi` GitHub environment so PyPI receives an
+OIDC token with `environment: pypi`. The Trusted Publisher entry on PyPI must
+match that environment exactly; otherwise PyPI rejects the exchange with
+`invalid-publisher`.

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -283,6 +283,10 @@ jobs:
     needs: [prepare, build-pypi]
     if: needs.prepare.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Download PyPI distributions


### PR DESCRIPTION
## Summary
- declare the \pypi\ GitHub environment on the PyPI publish job so the OIDC token includes \environment: pypi\`n- scope publish job permissions to \contents: read\ and \id-token: write\`n- document the exact PyPI Trusted Publisher fields needed for \FastLED/fbuild\`n
Fixes the PyPI trusted publishing failure from https://github.com/FastLED/fbuild/actions/runs/24754127872/job/72425538784, where PyPI rejected the OIDC exchange with \invalid-publisher\ and \environment: MISSING\.

## Verification
- rebased branch on current \origin/main\ before editing and again before push
- parsed \.github/workflows/release-auto.yml\ with PyYAML and asserted \publish-pypi.environment == pypi\ plus expected permissions
- \git diff --check\`n- confirmed branch worktree has no untracked or uncommitted files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release workflow documentation to clarify PyPI GitHub Actions Trusted Publisher configuration requirements.

* **Chores**
  * Enhanced release automation security by configuring GitHub Actions environment settings and explicit permission constraints for PyPI publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->