### PR TITLE
Add native build artifact attestations

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,6 +38,27 @@ CI/CD workflows for the fbuild project, covering lint, test, documentation, and 
 - **`template_build.yml`** -- Reusable workflow for per-board firmware builds
 - **`template_native_build.yml`** -- Reusable workflow for native Rust binary builds
 
+### Native Build Attestations
+
+Manual `build.yml` native artifacts include `SHA256SUMS.txt` and GitHub Artifact
+Attestations for every staged native file:
+
+- `fbuild` / `fbuild.exe`
+- `fbuild-daemon` / `fbuild-daemon.exe`
+- `_native.abi3.so` / `_native.pyd`
+
+After downloading and extracting a `binaries-${target}` workflow artifact:
+
+```bash
+sha256sum -c SHA256SUMS.txt
+gh attestation verify fbuild --repo FastLED/fbuild
+gh attestation verify fbuild-daemon --repo FastLED/fbuild
+gh attestation verify _native.abi3.so --repo FastLED/fbuild
+```
+
+For Windows artifacts, verify `fbuild.exe`, `fbuild-daemon.exe`, and
+`_native.pyd` instead.
+
 ### Autonomous Releases
 
 `release-auto.yml` follows the attested release pattern used by `soldr`:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: "main"
 
+permissions:
+  contents: read
+  attestations: write
+  id-token: write
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -36,6 +36,11 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
+permissions:
+  contents: read
+  attestations: write
+  id-token: write
+
 jobs:
   build:
     name: Build (${{ inputs.target }})
@@ -187,6 +192,19 @@ jobs:
             strip staging/_native.abi3.so 2>/dev/null || true
             strip staging/_native.pyd 2>/dev/null || true
           fi
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd staging
+          sha256sum * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Attest native artifacts
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-checksums: staging/SHA256SUMS.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Adds artifact attestation permissions to the manual native build workflow and reusable native build template.
- Generates SHA256SUMS.txt for staged native artifacts before upload.
- Attests staged native artifacts with actions/attest-build-provenance@v3 and documents verification steps.

## Validation
- git diff --check
- Parsed all workflow YAML files with PyYAML

Notes: this follow-up was rebuilt from current origin/main so it preserves the already-merged release retry and PyPI Trusted Publisher environment docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Native Build Attestations documentation with SHA256 checksum verification instructions and GitHub attestation verification commands for native artifacts.

* **Chores**
  * Enhanced CI/CD workflow security permissions for attestations and identity-based signing.
  * Implemented automated build provenance attestation for native artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->