### PR TITLE
docs: record soldr build benchmark

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,6 +29,7 @@ A grep-friendly FAQ that maps common questions to the file that answers them. Bo
 | What's safe to cache in GitHub Actions?                   | [CI_CACHING.md](CI_CACHING.md#what-the-cache-holds)        |
 | Why does warm-pass build take ~30 s per sketch? (#91)     | [PERF_WARM_BUILD.md](PERF_WARM_BUILD.md)                   |
 | What does `FBUILD_PERF_LOG=1` do?                          | [PERF_WARM_BUILD.md](PERF_WARM_BUILD.md#instrumentation)   |
+| How fast is `soldr` when building fbuild itself?            | [SOLDR_BUILD_PERF.md](SOLDR_BUILD_PERF.md)                 |
 | What architecture docs should I read for a given crate?   | [CLAUDE.md](CLAUDE.md)                                     |
 
 ## Conventions

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Architecture and design documentation for the fbuild project.
 - **`DEVELOPMENT.md`** -- Testing, troubleshooting, local development setup
 - **`CI_CACHE.md`** -- Consumer-facing cross-run CI cache strategy
 - **`CI_CACHING.md`** -- How to save/restore fbuild's cache across CI runs
+- **`SOLDR_BUILD_PERF.md`** -- Local soldr build benchmark for the Rust workspace
 - **`DESIGN_DECISIONS.md`** -- ADR-style decisions with rationale
 - **`ROADMAP.md`** -- Implementation phases for the Rust port
 - **`architecture/`** -- Subsystem-specific architecture documents

--- a/docs/SOLDR_BUILD_PERF.md
+++ b/docs/SOLDR_BUILD_PERF.md
@@ -1,0 +1,50 @@
+# soldr Rust Build Performance
+
+Measured local `soldr` performance for building the Rust `fbuild` CLI and
+daemon from this workspace.
+
+## Environment
+
+- Host: Windows, `x86_64-pc-windows-msvc`
+- Tool wrapper: `soldr 0.7.4`
+- Managed cache: `zccache 1.3.0`
+- Rust toolchain: `rustc 1.94.1`
+- Command:
+
+```powershell
+uv run soldr cargo build --release -p fbuild-cli -p fbuild-daemon
+```
+
+The benchmark used temporary target directories under `.cache/` so the normal
+workspace `target/` directory was not part of the measurement.
+
+## Results
+
+| Case | Time |
+|------|-----:|
+| Cold: empty target dir and cleared `soldr` cache | 165.536 s |
+| Warm cache: same target dir after `cargo clean`, hot `soldr` cache | 55.898 s |
+| No-op rebuild: same target dir, no source changes | 0.787 s |
+| Fresh different target dir with hot `soldr` cache | 162.834 s |
+
+## Notes
+
+`soldr` is correctly routing Cargo through its managed `zccache`, but cache
+reuse was target-directory sensitive in this local run. Rebuilding the same
+target directory after `cargo clean` was about 3x faster than the cold build,
+while compiling into a different fresh target directory got effectively no
+benefit.
+
+Final cache status after the run reported:
+
+```text
+Compilations: 1393 total (216 cached, 849 cold, 311 non-cacheable)
+Hit rate:     20.3%
+Time saved:   ~9m 21s
+Artifacts:    849 (2.5 GB)
+```
+
+An initial stale cache-daemon state was observed before the benchmark:
+`soldr cargo --version` reported that a daemon PID existed but was not accepting
+connections. Running `soldr cargo --version` again started a healthy managed
+`zccache` daemon, after which the timed runs completed successfully.


### PR DESCRIPTION
## Summary

- add a local soldr benchmark for building fbuild-cli and fbuild-daemon
- document cold, warm cache, no-op, and fresh-target timings
- link the new doc from the docs README and FAQ index

## Testing

- Not run; documentation-only change.