### PR TITLE
Remove Rust tool wrapper shims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ fbuild is a PlatformIO-compatible embedded build tool (11 crates). See @docs/CLA
 
 ## Essential Rules
 
-- **Always use `uv run`, `soldr`, or `_cargo`/`_rustc`/`_rustfmt` trampolines to execute Rust commands.** Bare cargo/rustc are blocked by hook. All three forms resolve through [soldr](https://github.com/zackees/soldr), which uses `rustup which` to pick the rustup-managed toolchain. The standard Cargo path is `soldr cargo ...`, so repo Rust builds get soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for normal builds.
+- **Always use `soldr` or `uv run soldr` to execute Rust commands.** Bare cargo/rustc and legacy `uv run cargo` shims are blocked by hook. soldr uses `rustup which` to pick the rustup-managed toolchain from `rust-toolchain.toml`. The standard Cargo path is `soldr cargo ...`, so repo Rust builds get soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for normal builds.
 - **Always use `uv` for Python.** Bare `python`/`pip` are blocked by hook. Use `uv run ...` or `uv pip ...`.
 - MSRV: 1.75 | Edition: 2021 | Toolchain: 1.94.1 pinned in `rust-toolchain.toml` (clippy + rustfmt)
 - CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)
@@ -16,25 +16,25 @@ fbuild is a PlatformIO-compatible embedded build tool (11 crates). See @docs/CLA
 uv run test                 # unit tests only
 uv run test --full          # unit + stress + integration tests
 uv run test -p <crate> -- <test_name>
-uv run cargo check --workspace --all-targets
-uv run cargo clippy --workspace --all-targets -- -D warnings
-uv run cargo fmt --all
-RUSTDOCFLAGS="-D warnings" uv run cargo doc --workspace --no-deps
+uv run soldr cargo check --workspace --all-targets
+uv run soldr cargo clippy --workspace --all-targets -- -D warnings
+uv run soldr cargo fmt --all
+RUSTDOCFLAGS="-D warnings" uv run soldr cargo doc --workspace --no-deps
 
 # Public deploy API conventions
-uv run cargo run -p fbuild-cli -- deploy tests/platform/uno -e uno --to emu
-uv run cargo run -p fbuild-cli -- deploy tests/platform/uno -e uno --to emu --monitor
-uv run cargo run -p fbuild-cli -- deploy tests/platform/esp32dev -e esp32dev-qemu --to emu --emulator qemu
+uv run soldr cargo run -p fbuild-cli -- deploy tests/platform/uno -e uno --to emu
+uv run soldr cargo run -p fbuild-cli -- deploy tests/platform/uno -e uno --to emu --monitor
+uv run soldr cargo run -p fbuild-cli -- deploy tests/platform/esp32dev -e esp32dev-qemu --to emu --emulator qemu
 
 # test-emu: build + run in emulator (CI-friendly, exits with emulator exit code)
-uv run cargo run -p fbuild-cli -- test-emu tests/platform/uno -e uno
-uv run cargo run -p fbuild-cli -- test-emu tests/platform/esp32s3 -e esp32s3 --timeout 10
-uv run cargo run -p fbuild-cli -- test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
+uv run soldr cargo run -p fbuild-cli -- test-emu tests/platform/uno -e uno
+uv run soldr cargo run -p fbuild-cli -- test-emu tests/platform/esp32s3 -e esp32s3 --timeout 10
+uv run soldr cargo run -p fbuild-cli -- test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
 
-# Shell trampolines (alternative to uv run for Rust tools)
-./_cargo check --workspace --all-targets
-./_cargo clippy --workspace --all-targets -- -D warnings
-./_rustfmt --check <file.rs>
+# Direct soldr commands (alternative to uv run soldr)
+soldr cargo check --workspace --all-targets
+soldr cargo clippy --workspace --all-targets -- -D warnings
+soldr rustfmt --check <file.rs>
 
 # Board definition management
 uv run python ci/validate_boards.py                    # validate against PlatformIO
@@ -43,7 +43,7 @@ uv run python ci/board_sources.py --search QUERY       # search all external sou
 uv run python ci/board_sources.py --compare            # find boards missing from fbuild
 uv run python ci/board_sources.py --list-arduino       # list Arduino package index boards
 uv run python ci/board_sources.py --list-zephyr        # list Zephyr boards
-uv run cargo run -p fbuild-config --bin enrich_boards  # enrich from local PlatformIO
+uv run soldr cargo run -p fbuild-config --bin enrich_boards  # enrich from local PlatformIO
 ```
 
 ## Distribution
@@ -69,7 +69,7 @@ uv run python ci/zccache_setup.py  # writes rustc-wrapper = "zccache"
 All hooks are Python scripts in `ci/hooks/`, invoked via `uv run`:
 
 - **UserPromptSubmit**: `ci/hooks/board_context.py` detects board-related prompts and injects skill guidance (board lookup workflow, external source URLs, relevant commands)
-- **PreToolUse**: `ci/hooks/tool_guard.py` blocks bare Rust commands (must use `uv run` or `_cargo`/`_rustc`/`_rustfmt` trampolines) and bare `python`/`pip` (must use `uv`) across supported shell tools, not just Bash
+- **PreToolUse**: `ci/hooks/tool_guard.py` blocks bare Rust commands and legacy `uv run cargo` shims (must use `soldr` or `uv run soldr`) and bare `python`/`pip` (must use `uv`) across supported shell tools, not just Bash
 - **PostToolUse**: `ci/hooks/lint.py` auto-formats + runs clippy on edited .rs files
 - **PostToolUse**: `ci/hooks/readme_guard.py` errors if directory lacks README.md
 - **SessionStart**: `ci/hooks/check-on-start.py` captures git fingerprint

--- a/CODEX.md
+++ b/CODEX.md
@@ -4,39 +4,36 @@ Codex working notes for this repo. Start with [CLAUDE.md](./CLAUDE.md) for the f
 
 ## Mandatory command rules
 
-- Always run Rust tooling through `uv run`, `soldr`, or the repo trampolines.
+- Always run Rust tooling through `soldr` or `uv run soldr`.
 - Never run bare `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `python`, or `pip`.
 - Approved Rust forms in this repo are:
-  - `uv run cargo ...`
-  - `uv run rustc ...`
-  - `uv run rustfmt ...`
   - `soldr cargo ...`
   - `soldr rustc ...`
   - `soldr rustfmt ...`
-  - `./_cargo ...`
-  - `./_rustc ...`
-  - `./_rustfmt ...`
+  - `uv run soldr cargo ...`
+  - `uv run soldr rustc ...`
+  - `uv run soldr rustfmt ...`
 
 ## Why
 
 - Repo hooks enforce this.
-- All three forms dispatch through [soldr](https://github.com/zackees/soldr), which resolves each tool via `rustup which` so the rustup-managed toolchain is always used instead of a stale system or Chocolatey install.
-- `uv run cargo ...` works because `ci/dev-tools` registers `cargo`/`rustc`/`rustfmt` as repo-local uv scripts that now dispatch through `ci/trampoline.py` -> `soldr`.
+- [soldr](https://github.com/zackees/soldr) resolves each tool via `rustup which` so the rustup-managed toolchain is always used instead of a stale system or Chocolatey install.
+- `uv run soldr ...` works because `ci/dev-tools` installs `soldr` into the repo-local uv environment.
 - The normal Cargo path is `soldr cargo ...`, so repo Rust builds use soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for standard builds.
 - If you bypass them, you can hit wrong-toolchain errors.
 
 ## Use these
 
 ```powershell
-uv run cargo check --workspace --all-targets
-uv run cargo test -p fbuild-build -- --ignored
-uv run cargo clippy --workspace --all-targets -- -D warnings
-uv run cargo fmt --all
+uv run soldr cargo check --workspace --all-targets
+uv run soldr cargo test -p fbuild-build -- --ignored
+uv run soldr cargo clippy --workspace --all-targets -- -D warnings
+uv run soldr cargo fmt --all
 
-./_cargo check --workspace --all-targets
-./_cargo test -p fbuild-build -- --ignored
-./_cargo clippy --workspace --all-targets -- -D warnings
-./_rustfmt --check crates/fbuild-build/src/compiler.rs
+soldr cargo check --workspace --all-targets
+soldr cargo test -p fbuild-build -- --ignored
+soldr cargo clippy --workspace --all-targets -- -D warnings
+soldr rustfmt --check crates/fbuild-build/src/compiler.rs
 
 uv run test
 uv run test --full
@@ -49,13 +46,11 @@ uv run test -p fbuild-build -- some_test_name
 uv run python ci/zccache_setup.py
 ```
 
-This configures `rustc-wrapper = "zccache"` for local wrapper-mode experiments. Standard builds should use `uv run`, `soldr`, or the `_cargo`/`_rustc`/`_rustfmt` trampolines above.
+This configures `rustc-wrapper = "zccache"` for local wrapper-mode experiments. Standard builds should use `soldr` or `uv run soldr` above.
 
-## Allowed fallback
+## Fallback
 
-- Repo trampolines: `_cargo`, `_rustc`, `_rustfmt`
-- These are first-class approved paths, not second-class workarounds.
-- Use `./_cargo`/`./_rustc`/`./_rustfmt` directly from the repo root when you want the shell trampoline form.
+- Use `uv run soldr ...` when `soldr` is not on PATH but the repo-local uv environment is available.
 
 ## If a command fails
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -223,14 +223,14 @@ libs, embed files, bootloader ELF conversion, pioarduino metadata resolution)
 
 ## Phase 2 Execution Order
 
-Each step is independently testable (`cargo check` + `cargo test` must pass after each).
+Each step is independently testable (`uv run soldr cargo check` + `uv run soldr cargo test` must pass after each).
 
 - [x] **Step 1:** Create `pipeline.rs` with all helpers, update `lib.rs`
 - [x] **Step 2:** Migrate AVR orchestrator to use pipeline helpers
 - [x] **Step 3:** Migrate Teensy orchestrator to use pipeline helpers
 - [x] **Step 4:** Migrate ESP32 orchestrator to use BuildContext + pipeline helpers
 - [x] **Step 5-10:** All helpers implemented and used (done as part of Steps 1-4)
-- [x] **Step 11:** Full verification: `cargo check + clippy + test --workspace` — all 217 tests pass
+- [x] **Step 11:** Full verification: `uv run soldr cargo check + uv run soldr cargo clippy + uv run soldr cargo test --workspace` — all 217 tests pass
 
 ---
 
@@ -269,7 +269,7 @@ helpers from Phase 2.
 - [x] **Step 2:** Add `run_sequential_build()` to `pipeline.rs`
 - [x] **Step 3:** Migrate AVR orchestrator
 - [x] **Step 4:** Migrate Teensy orchestrator
-- [x] **Step 5:** Full verification: `cargo check + clippy + test` — all 37 tests pass
+- [x] **Step 5:** Full verification: `uv run soldr cargo check + uv run soldr cargo clippy + uv run soldr cargo test` — all 37 tests pass
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -276,9 +276,9 @@ helpers from Phase 2.
 ## Verification
 
 After each step:
-1. `uv run cargo check --workspace --all-targets`
-2. `uv run cargo clippy --workspace --all-targets -- -D warnings`
-3. `uv run cargo test --workspace --lib`
+1. `uv run soldr cargo check --workspace --all-targets`
+2. `uv run soldr cargo clippy --workspace --all-targets -- -D warnings`
+3. `uv run soldr cargo test --workspace --lib`
 
 After all steps:
 4. Push → verify all 11 CI board build workflows pass

--- a/_cargo
+++ b/_cargo
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Trampoline: runs cargo through soldr so the rustup-managed toolchain
-# is always used and soldr's managed zccache path stays on by default.
-exec uv run soldr cargo "$@"

--- a/_rustc
+++ b/_rustc
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Trampoline: runs rustc through soldr so the rustup-managed toolchain
-# is always used. soldr resolves rustc via `rustup which`.
-exec uv run soldr rustc "$@"

--- a/_rustfmt
+++ b/_rustfmt
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Trampoline: runs rustfmt through soldr so the rustup-managed toolchain
-# is always used. soldr resolves rustfmt via `rustup which`.
-exec uv run soldr rustfmt "$@"

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,11 +9,11 @@ Python scripts for CI, packaging, and development tooling. All invoked via `uv r
 - **`extract_pio_build_flags.py`** -- Extracts compiler/linker flags from PlatformIO for each board and writes reference JSONs
 - **`lint.py`** -- Workspace linting (rustfmt + clippy), supports single-file and auto-fix modes
 - **`test.py`** -- Workspace test runner with `--full` (stress + integration) and per-crate filtering
-- **`trampoline.py`** -- Rust toolchain trampolines (cargo, rustc, rustfmt, clippy-driver) registered as `uv` project scripts
+- **`trampoline.py`** -- Development helpers that run fbuild workspace binaries through soldr-managed Cargo
 - **`validate_boards.py`** -- Validates fbuild board JSON assets against PlatformIO board definitions
 - **`zccache_setup.py`** -- Optional local wrapper-mode setup for zccache; not used by the standard soldr build path
 
 ## Subdirectories
 
-- **`dev-tools/`** -- Pip-installable package that registers Rust tool trampolines as console scripts
+- **`dev-tools/`** -- Pip-installable package that provides soldr and repo-local development helper scripts
 - **`hooks/`** -- Claude Code hook scripts (tool guard, lint, readme guard, session lifecycle)

--- a/ci/dev-tools/README.md
+++ b/ci/dev-tools/README.md
@@ -1,9 +1,9 @@
 # Dev Tools
 
-Pip-installable package that registers Rust toolchain trampolines as console scripts, so `uv run cargo` resolves to the rustup-managed toolchain without polluting global installs.
+Pip-installable package that provides repo-local development helpers and the `soldr` dependency.
 
-The trampolines route through [soldr](https://github.com/zackees/soldr) (pulled in via the `soldr>=0.7.4` dependency), which uses `rustup which` to pick the right toolchain. The standard Cargo path is `soldr cargo ...`, so soldr's managed zccache path is enabled by default for repo Rust builds without repo-specific `RUSTC_WRAPPER` wiring.
+Rust tooling should be invoked directly through [soldr](https://github.com/zackees/soldr), either as `soldr cargo ...` when soldr is on PATH or `uv run soldr cargo ...` through this repo-local environment. soldr uses `rustup which` to pick the right toolchain. The standard Cargo path is `soldr cargo ...`, so soldr's managed zccache path is enabled by default for repo Rust builds without repo-specific `RUSTC_WRAPPER` wiring.
 
 ## Contents
 
-- **`pyproject.toml`** -- Declares the `soldr>=0.7.4` dependency and defines console script entry points: `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `run_fbuild`, `run_fbuild_daemon`, `publish`
+- **`pyproject.toml`** -- Declares the `soldr>=0.7.4` dependency and defines helper entry points: `run_fbuild`, `run_fbuild_daemon`, `publish`

--- a/ci/dev-tools/pyproject.toml
+++ b/ci/dev-tools/pyproject.toml
@@ -1,15 +1,11 @@
 [project]
 name = "fbuild-dev-tools"
 version = "0.0.0"
-description = "Repo-local Rust toolchain trampolines for fbuild development"
+description = "Repo-local fbuild development helpers"
 requires-python = ">=3.10"
 dependencies = ["soldr>=0.7.4"]
 
 [project.scripts]
-cargo = "ci.trampoline:cargo"
-rustc = "ci.trampoline:rustc"
-rustfmt = "ci.trampoline:rustfmt"
-clippy-driver = "ci.trampoline:clippy_driver"
 run_fbuild = "ci.trampoline:run_fbuild"
 run_fbuild_daemon = "ci.trampoline:run_fbuild_daemon"
 publish = "ci.trampoline:publish"

--- a/ci/env.py
+++ b/ci/env.py
@@ -8,7 +8,7 @@ import os
 import shutil
 
 
-def _cargo_bin_from_tool(tool_name):
+def _rust_bin_from_tool(tool_name):
     """Derive a rustup-managed .cargo/bin directory from a tool on PATH."""
     tool_path = shutil.which(tool_name)
     if not tool_path:
@@ -22,7 +22,7 @@ def _cargo_bin_from_tool(tool_name):
     return None
 
 
-def find_cargo_bin():
+def find_rust_bin():
     """Locate .cargo/bin cross-platform.
 
     Checks CARGO_HOME, then ~/.cargo, then %USERPROFILE%\\.cargo.
@@ -43,7 +43,7 @@ def find_cargo_bin():
                 return os.path.abspath(bin_dir)
 
     for tool_name in ("rustup", "cargo", "rustc"):
-        bin_dir = _cargo_bin_from_tool(tool_name)
+        bin_dir = _rust_bin_from_tool(tool_name)
         if bin_dir:
             return bin_dir
     return None
@@ -54,7 +54,7 @@ def activate():
 
     Call this at the top of any CI script that invokes Rust tools.
     """
-    cargo_bin = find_cargo_bin()
+    cargo_bin = find_rust_bin()
     if not cargo_bin:
         return
     current_path = os.environ.get("PATH", "")
@@ -71,7 +71,7 @@ def clean_env():
     env = os.environ.copy()
 
     # Ensure .cargo/bin is on PATH
-    cargo_bin = find_cargo_bin()
+    cargo_bin = find_rust_bin()
     if cargo_bin:
         path_parts = env.get("PATH", "").split(os.pathsep)
         if cargo_bin not in path_parts:

--- a/ci/hooks/README.md
+++ b/ci/hooks/README.md
@@ -5,7 +5,7 @@ Python scripts invoked by Claude Code lifecycle hooks, configured in `.claude/se
 ## Contents
 
 - **`board_context.py`** -- UserPromptSubmit: detects board-related prompts (board names, MCU keywords, board error patterns) and injects guidance about the `/board-support` skill, relevant commands, and external board registries
-- **`tool_guard.py`** -- PreToolUse: blocks bare `cargo`/`rustc`/`rustfmt` and bare `python`/`pip` commands across shell tool variants such as Bash and PowerShell, requiring `uv run`, `soldr ...`, or `_cargo`/`_rustc`/`_rustfmt` trampolines
+- **`tool_guard.py`** -- PreToolUse: blocks bare `cargo`/`rustc`/`rustfmt`, legacy `uv run cargo`-style shims, and bare `python`/`pip` commands across shell tool variants such as Bash and PowerShell, requiring `soldr ...` or `uv run soldr ...` for Rust tooling and `uv run` / `uv pip` for Python tooling
 - **`lint.py`** -- PostToolUse: runs per-file rustfmt + clippy on edited `.rs` files
 - **`readme_guard.py`** -- PostToolUse: ensures every directory containing edited files has a `README.md`
 - **`check-on-start.py`** -- SessionStart: captures a git fingerprint so the stop hook can detect changes

--- a/ci/hooks/board_context.py
+++ b/ci/hooks/board_context.py
@@ -74,7 +74,7 @@ step-by-step guidance for diagnosing board issues.
 - **Validate against PlatformIO**: `uv run python ci/validate_boards.py`
 - **Search external sources**: `uv run python ci/board_sources.py --search QUERY`
 - **Compare coverage**: `uv run python ci/board_sources.py --compare`
-- **Enrich from PlatformIO**: `uv run cargo run -p fbuild-config --bin enrich_boards`
+- **Enrich from PlatformIO**: `uv run soldr cargo run -p fbuild-config --bin enrich_boards`
 
 ### External board registries (for boards not in PlatformIO):
 - Arduino package indices: `uv run python ci/board_sources.py --list-arduino`

--- a/ci/hooks/test_tool_guard.py
+++ b/ci/hooks/test_tool_guard.py
@@ -13,12 +13,22 @@ class ToolGuardTests(unittest.TestCase):
         self.assertEqual(result[0], "cargo")
 
     def test_blocks_uv_run_rust_tool_shim(self):
-        result = check_command("uv run cargo test")
-        self.assertIsNotNone(result)
-        self.assertEqual(result[0], "cargo")
-        result = check_command("uv run -- cargo test")
-        self.assertIsNotNone(result)
-        self.assertEqual(result[0], "cargo")
+        commands = (
+            "uv run cargo test",
+            "uv run -- cargo test",
+            "uv run --offline cargo build",
+            "uv run --with foo cargo test",
+            "uv run --with=foo cargo test",
+            "uv run --isolated cargo build",
+            "uv run --project . cargo check",
+            "uv run -q cargo test",
+            "uv run -- --offline cargo test",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                result = check_command(command)
+                self.assertIsNotNone(result)
+                self.assertEqual(result[0], "cargo")
 
     def test_allows_soldr_wrapped_rust_tool(self):
         self.assertIsNone(check_command("soldr cargo test"))

--- a/ci/hooks/test_tool_guard.py
+++ b/ci/hooks/test_tool_guard.py
@@ -7,19 +7,26 @@ from tool_guard import check_command, extract_command
 
 
 class ToolGuardTests(unittest.TestCase):
-    def test_blocks_bare_cargo(self):
+    def test_blocks_bare_rust_tool(self):
         result = check_command("cargo test")
         self.assertIsNotNone(result)
         self.assertEqual(result[0], "cargo")
 
-    def test_allows_uv_run_wrapped_cargo(self):
-        self.assertIsNone(check_command("uv run cargo test"))
+    def test_blocks_uv_run_rust_tool_shim(self):
+        result = check_command("uv run cargo test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "cargo")
+        result = check_command("uv run -- cargo test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], "cargo")
 
-    def test_allows_soldr_wrapped_cargo(self):
+    def test_allows_soldr_wrapped_rust_tool(self):
         self.assertIsNone(check_command("soldr cargo test"))
         self.assertIsNone(check_command("soldr --no-cache cargo build"))
         self.assertIsNone(check_command("soldr rustc --version"))
         self.assertIsNone(check_command("soldr rustfmt --check src/lib.rs"))
+        self.assertIsNone(check_command("uv run soldr cargo test"))
+        self.assertIsNone(check_command("uv run soldr rustfmt --check src/lib.rs"))
 
     def test_blocks_bare_python(self):
         result = check_command("python ci/script.py")

--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -19,6 +19,26 @@ PYTHON_TOOLS = {"python", "python3", "pip", "pip3"}
 SOLDR_PREFIXES = ("soldr ", "uv run soldr ")
 UV_RUN_PREFIX = "uv run "
 UV_PIP_PREFIX = "uv pip "
+UV_RUN_FLAGS_WITH_VALUES = {
+    "--config-setting",
+    "--directory",
+    "--env-file",
+    "--extra",
+    "--find-links",
+    "--from",
+    "--group",
+    "--index-url",
+    "--no-extra",
+    "--no-group",
+    "--only-group",
+    "--project",
+    "--python",
+    "--with",
+    "--with-editable",
+    "--with-requirements",
+    "-m",
+    "-p",
+}
 
 
 FORBIDDEN_SCRIPT_DIRS = re.compile(
@@ -34,6 +54,27 @@ DENY_PYTHON_IN_CODE = (
     "Do not use Python for benchmarks or tests. "
     "Write them in Rust instead. Python is only for CI scripts and packaging."
 )
+
+
+def uv_run_target(parts):
+    """Return the uv-run command target after leading uv options."""
+    index = 2
+    while index < len(parts):
+        token = parts[index]
+        if token == "--":
+            index += 1
+            continue
+        if token in UV_RUN_FLAGS_WITH_VALUES:
+            index += 2
+            continue
+        if any(token.startswith(f"{flag}=") for flag in UV_RUN_FLAGS_WITH_VALUES):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token
+    return ""
 
 
 def check_command(command):
@@ -68,9 +109,7 @@ def check_command(command):
             parts = seg.split()
             # `uv run soldr ...` was handled above. Block the old `uv run cargo`
             # console-script shim path so Rust tooling has one canonical entry.
-            run_target = parts[2] if len(parts) >= 3 else ""
-            if run_target == "--" and len(parts) >= 4:
-                run_target = parts[3]
+            run_target = uv_run_target(parts)
             if run_target in RUST_TOOLS:
                 return (
                     run_target,

--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """PreToolUse hook: blocks bare Rust commands and bare python/pip.
 
-All cargo/rustc/rustfmt must go through uv run (trampoline ensures correct toolchain).
+All cargo/rustc/rustfmt must go through soldr (ensures correct toolchain).
 All python must go through uv (ensures correct environment).
 
 Exit codes:
@@ -16,9 +16,9 @@ import sys
 RUST_TOOLS = {"cargo", "rustc", "rustfmt", "clippy-driver", "cargo-clippy", "cargo-fmt"}
 PYTHON_TOOLS = {"python", "python3", "pip", "pip3"}
 
-ALLOWED_PREFIXES = ("uv run ", "uv pip ", "soldr ")
-TRAMPOLINE_PREFIXES = ("./_cargo ", "./_rustc ", "./_rustfmt ",
-                       "_cargo ", "_rustc ", "_rustfmt ")
+SOLDR_PREFIXES = ("soldr ", "uv run soldr ")
+UV_RUN_PREFIX = "uv run "
+UV_PIP_PREFIX = "uv pip "
 
 
 FORBIDDEN_SCRIPT_DIRS = re.compile(
@@ -55,20 +55,38 @@ def check_command(command):
         if not seg:
             continue
 
-        # Skip if properly wrapped with uv or using a trampoline
-        if any(seg.startswith(p) for p in ALLOWED_PREFIXES):
+        # Skip if Rust tooling is explicitly routed through soldr.
+        if any(seg.startswith(p) for p in SOLDR_PREFIXES):
             continue
-        if any(seg.startswith(p) or seg == p.strip() for p in TRAMPOLINE_PREFIXES):
+
+        if seg.startswith(UV_PIP_PREFIX):
             continue
 
         first_word = seg.split()[0] if seg.split() else ""
 
+        if seg.startswith(UV_RUN_PREFIX):
+            parts = seg.split()
+            # `uv run soldr ...` was handled above. Block the old `uv run cargo`
+            # console-script shim path so Rust tooling has one canonical entry.
+            run_target = parts[2] if len(parts) >= 3 else ""
+            if run_target == "--" and len(parts) >= 4:
+                run_target = parts[3]
+            if run_target in RUST_TOOLS:
+                return (
+                    run_target,
+                    f"Use `uv run soldr {run_target} ...` instead of "
+                    f"`uv run {run_target} ...`. soldr resolves the checked-in "
+                    f"Rust toolchain directly via rustup.",
+                )
+            continue
+
         if first_word in RUST_TOOLS:
             return (
                 first_word,
-                f"Use `uv run {first_word} ...`, `soldr {first_word} ...`, or "
-                f"a `_cargo`/`_rustc`/`_rustfmt` trampoline instead of bare "
-                f"`{first_word}`. These ensure the correct Rust toolchain is used.",
+                f"Use `soldr {first_word} ...` or "
+                f"`uv run soldr {first_word} ...` instead of bare "
+                f"`{first_word}`. soldr resolves the checked-in Rust toolchain "
+                f"directly via rustup.",
             )
 
         if first_word in PYTHON_TOOLS:

--- a/ci/trampoline.py
+++ b/ci/trampoline.py
@@ -1,14 +1,12 @@
-"""Rust toolchain trampolines.
+"""Repo-local development command helpers.
 
-Routes cargo/rustc/rustfmt/clippy-driver through soldr so the
-rustup-managed toolchain is always used, without per-call PATH
-munging. Registered as project scripts in pyproject.toml so they can
-be invoked via `uv run cargo ...`, `uv run rustfmt ...`, etc.
+Rust tooling should be invoked with `soldr ...` or `uv run soldr ...`
+directly. This module only keeps helper entry points that run fbuild
+workspace binaries through soldr-managed Cargo.
 
 Why soldr:
 - soldr resolves each tool via `rustup which`, which respects
-  `rust-toolchain.toml` the same way the old PATH-based trampolines
-  did, but without requiring PATH to be pre-shaped.
+  `rust-toolchain.toml` without requiring PATH to be pre-shaped.
 - The normal Cargo path is `soldr cargo ...`, so local dev and CI get
   soldr's managed zccache path by default without repo-specific
   `RUSTC_WRAPPER` wiring.
@@ -32,30 +30,7 @@ def _soldr_prefix():
     return ["soldr"]
 
 
-def _run_via_soldr(subcommand: str):
-    """Exec `soldr <subcommand> <argv...>`."""
-    cmd = _soldr_prefix() + [subcommand] + sys.argv[1:]
-    result = subprocess.run(cmd)
-    sys.exit(result.returncode)
-
-
-def cargo():
-    _run_via_soldr("cargo")
-
-
-def rustc():
-    _run_via_soldr("rustc")
-
-
-def rustfmt():
-    _run_via_soldr("rustfmt")
-
-
-def clippy_driver():
-    _run_via_soldr("clippy-driver")
-
-
-def _run_cargo_bin(package):
+def _run_workspace_package(package):
     """Run a cargo binary with the correct toolchain via soldr."""
     extra = sys.argv[1:]
     # Strip leading '--' that uv inserts.
@@ -70,11 +45,11 @@ def _run_cargo_bin(package):
 
 
 def run_fbuild():
-    _run_cargo_bin("fbuild-cli")
+    _run_workspace_package("fbuild-cli")
 
 
 def run_fbuild_daemon():
-    _run_cargo_bin("fbuild-daemon")
+    _run_workspace_package("fbuild-daemon")
 
 
 def publish():

--- a/ci/validate_boards.py
+++ b/ci/validate_boards.py
@@ -410,7 +410,7 @@ def main() -> int:
             for diff in diffs:
                 print(f"    {diff}")
             print()
-        print("To fix: run 'uv run cargo run -p fbuild-config --bin enrich_boards' and commit the changes.")
+        print("To fix: run 'uv run soldr cargo run -p fbuild-config --bin enrich_boards' and commit the changes.")
         return 1
 
     print("All checked boards match PlatformIO definitions.")

--- a/crates/fbuild-build/tests/README.md
+++ b/crates/fbuild-build/tests/README.md
@@ -2,4 +2,4 @@
 
 Tests that download real toolchains and compile real sketches. Marked `#[ignore]` so they don't run during normal `uv run test`.
 
-Run with: `uv run cargo test -p fbuild-build -- --ignored`
+Run with: `uv run soldr cargo test -p fbuild-build -- --ignored`

--- a/crates/fbuild-build/tests/avr_build.rs
+++ b/crates/fbuild-build/tests/avr_build.rs
@@ -3,7 +3,7 @@
 //! Downloads avr-gcc + Arduino core (cached after first run), compiles a
 //! minimal blink sketch, and validates the output firmware.hex.
 //!
-//! Run with: `uv run cargo test -p fbuild-build --test avr_build -- --ignored`
+//! Run with: `uv run soldr cargo test -p fbuild-build --test avr_build -- --ignored`
 
 use std::fs;
 use std::path::PathBuf;

--- a/crates/fbuild-build/tests/esp32_build.rs
+++ b/crates/fbuild-build/tests/esp32_build.rs
@@ -3,7 +3,7 @@
 //! Downloads esp32 toolchain + framework (cached after first run), compiles a
 //! minimal blink sketch, and validates the output firmware.bin.
 //!
-//! Run with: `uv run cargo test -p fbuild-build --test esp32_build -- --ignored`
+//! Run with: `uv run soldr cargo test -p fbuild-build --test esp32_build -- --ignored`
 
 use std::fs;
 use std::path::PathBuf;

--- a/crates/fbuild-build/tests/flag_escaping_lint.rs
+++ b/crates/fbuild-build/tests/flag_escaping_lint.rs
@@ -9,7 +9,7 @@
 //! "stray '\\' in program" errors because the backslash is a literal character,
 //! not a shell escape. `prepare_flags_for_exec` strips `\"` → `"`.
 //!
-//! Run with: `uv run cargo test -p fbuild-build --test flag_escaping_lint`
+//! Run with: `uv run soldr cargo test -p fbuild-build --test flag_escaping_lint`
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/fbuild-build/tests/teensy_build.rs
+++ b/crates/fbuild-build/tests/teensy_build.rs
@@ -3,7 +3,7 @@
 //! Downloads arm-gcc + Teensy cores (cached after first run), compiles a
 //! minimal blink sketch, and validates the output firmware.hex.
 //!
-//! Run with: `uv run cargo test -p fbuild-build --test teensy_build -- --ignored`
+//! Run with: `uv run soldr cargo test -p fbuild-build --test teensy_build -- --ignored`
 
 use std::fs;
 use std::path::PathBuf;

--- a/crates/fbuild-config/src/bin/README.md
+++ b/crates/fbuild-config/src/bin/README.md
@@ -1,3 +1,3 @@
 # Binary Targets
 
-- **`enrich_boards.rs`** -- One-off maintenance tool that enriches stripped board JSONs with `build` and `upload` sections from PlatformIO's local platform installs (`~/.platformio/platforms/`). Extracts core, variant, f_cpu, mcu, extra_flags, VID/PID, Arduino sub-fields (ldscript, partitions), and upload protocol/speed. Run manually with `uv run cargo run -p fbuild-config --bin enrich_boards`.
+- **`enrich_boards.rs`** -- One-off maintenance tool that enriches stripped board JSONs with `build` and `upload` sections from PlatformIO's local platform installs (`~/.platformio/platforms/`). Extracts core, variant, f_cpu, mcu, extra_flags, VID/PID, Arduino sub-fields (ldscript, partitions), and upload protocol/speed. Run manually with `uv run soldr cargo run -p fbuild-config --bin enrich_boards`.

--- a/crates/fbuild-config/src/bin/enrich_boards.rs
+++ b/crates/fbuild-config/src/bin/enrich_boards.rs
@@ -8,7 +8,7 @@
 //! are committed to the repo and used as static assets at compile time.
 //!
 //! Usage:
-//!     uv run cargo run -p fbuild-config --bin enrich_boards
+//!     uv run soldr cargo run -p fbuild-config --bin enrich_boards
 
 use serde_json::{Map, Value};
 use std::collections::BTreeSet;

--- a/crates/fbuild-daemon/tests/process_containment.rs
+++ b/crates/fbuild-daemon/tests/process_containment.rs
@@ -25,7 +25,7 @@
 //!
 //! Run explicitly with:
 //! ```bash
-//! uv run cargo test -p fbuild-daemon --test process_containment -- --ignored
+//! uv run soldr cargo test -p fbuild-daemon --test process_containment -- --ignored
 //! ```
 
 use std::io::{BufRead, BufReader};

--- a/crates/fbuild-deploy/src/esp32.rs
+++ b/crates/fbuild-deploy/src/esp32.rs
@@ -1755,7 +1755,7 @@ Verification successful (digest matched).\n";
     // These tests are `#[ignore]` so they never run in CI.  To exercise
     // them on a local bench, set the env vars described below and run:
     //
-    //   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real -- --ignored --nocapture
+    //   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real -- --ignored --nocapture
     //
     // Each test reads **two** environment variables:
     //
@@ -1893,7 +1893,7 @@ Verification successful (digest matched).\n";
     ///
     /// ```text
     /// ESP32_PORT=COM5 ESP32_FIRMWARE=C:\path\to\firmware.bin \
-    ///   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32 -- --ignored --nocapture
+    ///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32 -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "requires real ESP32 board — set ESP32_PORT and ESP32_FIRMWARE"]
@@ -1905,7 +1905,7 @@ Verification successful (digest matched).\n";
     ///
     /// ```text
     /// ESP32S2_PORT=COM6 ESP32S2_FIRMWARE=C:\path\to\firmware.bin \
-    ///   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32s2 -- --ignored --nocapture
+    ///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32s2 -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "requires real ESP32-S2 board — set ESP32S2_PORT and ESP32S2_FIRMWARE"]
@@ -1920,7 +1920,7 @@ Verification successful (digest matched).\n";
     ///
     /// ```text
     /// ESP32S3_PORT=COM13 ESP32S3_FIRMWARE=C:\Users\niteris\dev\fastled\.pio\build\esp32s3\firmware.bin \
-    ///   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32s3 -- --ignored --nocapture
+    ///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32s3 -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "requires real ESP32-S3 board — set ESP32S3_PORT and ESP32S3_FIRMWARE"]
@@ -1932,7 +1932,7 @@ Verification successful (digest matched).\n";
     ///
     /// ```text
     /// ESP32C2_PORT=COM7 ESP32C2_FIRMWARE=C:\path\to\firmware.bin \
-    ///   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c2 -- --ignored --nocapture
+    ///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c2 -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "requires real ESP32-C2 board — set ESP32C2_PORT and ESP32C2_FIRMWARE"]
@@ -1944,7 +1944,7 @@ Verification successful (digest matched).\n";
     ///
     /// ```text
     /// ESP32C3_PORT=COM8 ESP32C3_FIRMWARE=C:\path\to\firmware.bin \
-    ///   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c3 -- --ignored --nocapture
+    ///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c3 -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "requires real ESP32-C3 board — set ESP32C3_PORT and ESP32C3_FIRMWARE"]
@@ -1956,7 +1956,7 @@ Verification successful (digest matched).\n";
     ///
     /// ```text
     /// ESP32C6_PORT=COM9 ESP32C6_FIRMWARE=C:\path\to\firmware.bin \
-    ///   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c6 -- --ignored --nocapture
+    ///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c6 -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "requires real ESP32-C6 board — set ESP32C6_PORT and ESP32C6_FIRMWARE"]
@@ -1968,7 +1968,7 @@ Verification successful (digest matched).\n";
     ///
     /// ```text
     /// ESP32H2_PORT=COM10 ESP32H2_FIRMWARE=C:\path\to\firmware.bin \
-    ///   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32h2 -- --ignored --nocapture
+    ///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32h2 -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "requires real ESP32-H2 board — set ESP32H2_PORT and ESP32H2_FIRMWARE"]
@@ -1983,7 +1983,7 @@ Verification successful (digest matched).\n";
     ///
     /// ```text
     /// ESP32P4_PORT=COM11 ESP32P4_FIRMWARE=C:\path\to\firmware.bin \
-    ///   uv run cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32p4 -- --ignored --nocapture
+    ///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32p4 -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "requires real ESP32-P4 board — set ESP32P4_PORT and ESP32P4_FIRMWARE"]

--- a/crates/fbuild-python/src/lib.rs
+++ b/crates/fbuild-python/src/lib.rs
@@ -1912,7 +1912,7 @@ mod tests {
     /// a stale hardcoded literal. The previous value `"2.0.0"` diverged from
     /// the workspace version and broke native-binary freshness checks.
     #[test]
-    fn python_module_version_matches_cargo_pkg_version() {
+    fn python_module_version_matches_pkg_version() {
         assert_eq!(PYTHON_MODULE_VERSION, env!("CARGO_PKG_VERSION"));
         assert_ne!(
             PYTHON_MODULE_VERSION, "2.0.0",
@@ -2007,7 +2007,7 @@ mod tests {
     /// Deliberately does not pull a crate dep — axum is already in the
     /// workspace but not in `fbuild-python`'s dep graph, and adding it
     /// just for one test would inflate the build graph for every clean
-    /// `uv run cargo check`. Raw TCP is adequate for a response we control.
+    /// `uv run soldr cargo check`. Raw TCP is adequate for a response we control.
     async fn spawn_mock_daemon(body: String) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -12,11 +12,11 @@
 
 ## DD-002: Workspace Pattern from zccache
 
-**Decision**: 11-crate Rust workspace with shared `Cargo.toml` dependencies, matching zccache's CI/trampoline/hook infrastructure.
+**Decision**: 11-crate Rust workspace with shared `Cargo.toml` dependencies, matching zccache's CI and hook infrastructure.
 
 **Context**: zccache has a proven pattern for Rust workspaces with uv-based toolchain management, agent hooks, and progressive disclosure documentation.
 
-**Rationale**: Reusing the pattern avoids reinventing CI, toolchain management, and agent workflow. The trampoline solves the Chocolatey-vs-rustup PATH conflict on Windows.
+**Rationale**: Reusing the pattern avoids reinventing CI, toolchain management, and agent workflow. soldr solves the Chocolatey-vs-rustup PATH conflict on Windows by resolving tools through rustup.
 
 ## DD-003: Axum over Actix-Web
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This document covers the developer workflow: testing, troubleshooting, and local
 
 ## Testing
 
-fbuild includes comprehensive integration tests. The Rust workspace uses `cargo test` via the `uv run` / `soldr` trampolines enforced by repo hooks.
+fbuild includes comprehensive integration tests. The Rust workspace uses `cargo test` via `soldr`, enforced by repo hooks.
 
 ```bash
 # Run unit tests only
@@ -96,12 +96,12 @@ This environment requires you to use `git-bash`.
 
 ### Linting
 
-Use the `uv run` trampolines (bare `cargo` / `rustc` are blocked by hook):
+Use `soldr` directly through the repo-local uv environment (bare `cargo` / `rustc` and `uv run cargo` shims are blocked by hook):
 
 ```bash
-uv run cargo check --workspace --all-targets
-uv run cargo clippy --workspace --all-targets -- -D warnings
-uv run cargo fmt --all
+uv run soldr cargo check --workspace --all-targets
+uv run soldr cargo clippy --workspace --all-targets -- -D warnings
+uv run soldr cargo fmt --all
 ```
 
 The legacy Python linters (`./lint.sh` with `pylint`, `flake8`, `mypy`) remain for any Python utility code under `ci/`.
@@ -124,7 +124,7 @@ The `fbuild` Python package wraps a Rust PyO3 extension built from `crates/fbuil
 
 ```bash
 # Build the extension and copy it into the Python package
-uv run cargo build --release -p fbuild-python --features extension-module
+uv run soldr cargo build --release -p fbuild-python --features extension-module
 
 # Windows
 cp target/release/_native.dll python/fbuild/_native.pyd

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,13 +8,13 @@ fbuild includes comprehensive integration tests. The Rust workspace uses `cargo 
 
 ```bash
 # Run unit tests only
-uv run test
+bash test
 
 # Run unit + stress + integration tests
-uv run test --full
+bash test --full
 
 # Run a specific test in a specific crate
-uv run test -p <crate> -- <test_name>
+bash test -p <crate> -- <test_name>
 ```
 
 For the legacy Python test suite (used only for CI parity checks against the Python fbuild reference):

--- a/docs/PERF_WARM_BUILD.md
+++ b/docs/PERF_WARM_BUILD.md
@@ -317,7 +317,7 @@ export FBUILD_DEV_MODE=1 FBUILD_PERF_LOG=1
 export PATH="target/x86_64-pc-windows-msvc/release:$PATH"
 
 # Build once (release) so the binaries match the instrumentation
-./_cargo build --release -p fbuild-cli -p fbuild-daemon
+uv run soldr cargo build --release -p fbuild-cli -p fbuild-daemon
 
 # Kill any stale daemon, then run a cold build to populate disk cache
 fbuild.exe daemon stop

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,7 @@
 - [x] CI infrastructure (lint, test, install, hooks)
 - [x] Progressive disclosure documentation
 - [x] PyO3 binding stubs (SerialMonitor, Daemon, connect_daemon)
-- [x] `uv run cargo check/test/clippy` all passing
+- [x] `uv run soldr cargo check/test/clippy` all passing
 
 ## Phase 1: Serial Manager (HIGHEST RISK)
 

--- a/install
+++ b/install
@@ -167,7 +167,7 @@ def uv_sync():
         subprocess.run(["uv", "sync"], check=False)
 
 
-def source_cargo_env():
+def source_rust_env():
     """Add .cargo/bin to PATH."""
     for candidate in [
         os.environ.get("CARGO_HOME", ""),
@@ -187,7 +187,7 @@ def source_cargo_env():
 
 def current_rust_version():
     """Get the current rustc version, or None."""
-    source_cargo_env()
+    source_rust_env()
     try:
         out = subprocess.check_output(["rustc", "--version"], text=True).strip()
         parts = out.split()
@@ -234,7 +234,7 @@ def install_rustup(plat):
 
 def verify(plat):
     """Verify the installation."""
-    source_cargo_env()
+    source_rust_env()
 
     if not shutil.which("rustc"):
         err("rustc not found on PATH after installation.")
@@ -273,7 +273,7 @@ def verify(plat):
             warn('  export PATH="$HOME/.cargo/bin:$PATH"')
 
     log("")
-    log("Done. Run: uv run cargo check --workspace")
+    log("Done. Run: uv run soldr cargo check --workspace")
     return True
 
 
@@ -299,7 +299,7 @@ def main():
         if current:
             warn(f"Current rustc: {current} (need {RUST_TOOLCHAIN})")
 
-        source_cargo_env()
+        source_rust_env()
         if shutil.which("rustup"):
             log(f"rustup found. Installing toolchain {RUST_TOOLCHAIN} ...")
             subprocess.run(
@@ -312,12 +312,12 @@ def main():
             log("rustup not found. Installing from scratch ...")
             install_rustup(plat)
 
-    source_cargo_env()
+    source_rust_env()
     if not verify(plat):
         warn("")
         warn("Restart your terminal, then run:")
         warn("  rustc --version")
-        warn("  uv run cargo check --workspace")
+        warn("  uv run soldr cargo check --workspace")
 
 
 if __name__ == "__main__":

--- a/python/README.md
+++ b/python/README.md
@@ -14,7 +14,7 @@ The `_native` extension is **not** checked into the repo — it would go stale r
 
 ```bash
 # 1. Compile the PyO3 extension
-uv run cargo build --release -p fbuild-python --features extension-module
+uv run soldr cargo build --release -p fbuild-python --features extension-module
 
 # 2. Copy into python/fbuild/ (platform-specific extension name).
 #    Rustup may place output under target/<triple>/release/ on some hosts —

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,13 +4,13 @@
 
 **Problem**: Bare `cargo` on Windows resolves to Chocolatey's ancient 1.66 instead of rustup's 1.94.
 
-**Fix**: `ci/trampoline.py` prepends `~/.cargo/bin` to PATH before invoking cargo. `tool_guard.py` hook blocks bare `cargo` commands. Always use `uv run cargo`.
+**Fix**: `soldr` resolves the rustup-managed toolchain directly, and `tool_guard.py` blocks bare `cargo` commands. Always use `uv run soldr cargo`.
 
 ## 2026-03-13: Clippy `-D warnings` Catches Everything
 
 **Pattern**: Stub code with unused fields, imports, or match arms will fail clippy with `-D warnings`. Use `#[allow(dead_code)]` at crate level for stubs, or prefix unused fields with `_`.
 
-**Rule**: Always run `uv run cargo clippy --workspace --all-targets -- -D warnings` before considering code done.
+**Rule**: Always run `uv run soldr cargo clippy --workspace --all-targets -- -D warnings` before considering code done.
 
 ## 2026-03-13: PyO3 `__exit__` Signature
 

--- a/test
+++ b/test
@@ -37,7 +37,7 @@ for arg in "${ARGS[@]}"; do
     fi
 done
 
-CMD=(uv run cargo test)
+CMD=(uv run soldr cargo test)
 
 if [ ${#CARGO_ARGS[@]} -eq 0 ]; then
     CMD+=(--workspace)


### PR DESCRIPTION
﻿## Summary

- remove the repo-local `_cargo`, `_rustc`, and `_rustfmt` shell wrappers
- remove `cargo`/`rustc`/`rustfmt`/`clippy-driver` dev-tool console shims so Rust tooling goes through `soldr` directly
- update the tool guard to reject legacy `uv run cargo`-style Rust invocations and require `soldr ...` or `uv run soldr ...`
- update docs, helper scripts, and command examples to use direct soldr commands

Closes #181.

## Testing

- `uv run python ci/hooks/test_tool_guard.py`
- `uv run soldr cargo fmt --all --check`
- `uv run soldr cargo check --workspace --all-targets`
- `bash test -p fbuild-core`

Note: `uv run test -p fbuild-core` was attempted first, but this repo does not currently expose `test` as a uv console script in this environment, so it failed before invoking the checked-in test wrapper. The checked-in `test` script was then validated directly with Bash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build, test, and check command documentation to use `soldr` for Rust tool invocation instead of direct `uv run cargo`.

* **Chores**
  * Removed legacy trampoline scripts and console entry points. Rust tooling now exclusively routes through `soldr` or `uv run soldr`.
  * Updated validation rules to enforce new Rust tool routing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->