### PR TITLE
Use setup-soldr in CI workers

### DIFF
--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -16,27 +16,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/checkout@v6
+      - name: Setup soldr
+        id: setup-soldr
+        uses: zackees/setup-soldr@v0
         with:
-          repository: zackees/soldr
-          ref: v0.7.4
-          path: soldr
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - name: Install soldr bootstrap
-        shell: bash
-        run: python -m pip install soldr==0.7.4
-      - name: Build soldr from source
-        shell: bash
-        working-directory: soldr
-        run: soldr cargo build --package soldr-cli --release --locked
-      - name: Add soldr to PATH
-        shell: bash
-        run: echo "${{ github.workspace }}/soldr/target/release" >> "$GITHUB_PATH"
+          cache: true
+          build-cache: true
+          target-cache: true
 
       - name: Check
         shell: bash

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -16,14 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup soldr
+        id: setup-soldr
+        uses: zackees/setup-soldr@v0
         with:
-          components: clippy, rustfmt
-      - name: Install soldr 0.7.4
-        shell: bash
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          cache: true
+          build-cache: true
+          target-cache: true
 
       - name: Check
         run: soldr cargo check --workspace --all-targets

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -16,27 +16,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/checkout@v6
+      - name: Setup soldr
+        id: setup-soldr
+        uses: zackees/setup-soldr@v0
         with:
-          repository: zackees/soldr
-          ref: v0.7.4
-          path: soldr
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-      - name: Install soldr bootstrap
-        shell: bash
-        run: python -m pip install soldr==0.7.4
-      - name: Build soldr from source
-        shell: bash
-        working-directory: soldr
-        run: soldr cargo build --package soldr-cli --release --locked
-      - name: Add soldr to PATH
-        shell: bash
-        run: echo "${{ github.workspace }}/soldr/target/release" >> "$GITHUB_PATH"
+          cache: true
+          build-cache: true
+          target-cache: true
 
       - name: Check
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,12 +14,13 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install soldr 0.7.4
-        shell: bash
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Setup soldr
+        id: setup-soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          build-cache: true
+          target-cache: true
 
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -12,13 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup soldr
+        id: setup-soldr
+        uses: zackees/setup-soldr@v0
         with:
-          components: rustfmt
-      - name: Install soldr 0.7.4
-        shell: bash
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          cache: true
+          build-cache: true
+          target-cache: false
       - name: Check formatting
         run: soldr cargo fmt --all -- --check

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -12,12 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.75.0
-      - name: Install soldr 0.7.4
-        shell: bash
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Setup soldr
+        id: setup-soldr
+        uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          build-cache: true
+          target-cache: true
+          toolchain: 1.75.0
 
       - name: Check MSRV
         run: soldr cargo check --workspace

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -32,17 +32,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup soldr
+        id: setup-soldr
+        uses: zackees/setup-soldr@v0
         with:
-          toolchain: 1.94.1
-          components: clippy, rustfmt
-
-      - name: Install soldr 0.7.4
-        shell: bash
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/zackees/soldr/v0.7.4/install.sh | bash -s -- --version 0.7.4
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          cache: true
+          build-cache: true
+          target-cache: true
+          cache-key-suffix: board-${{ inputs.env-name }}
 
       - name: Restore fbuild toolchains
         uses: actions/cache/restore@v5

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -51,34 +51,18 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
 
-      - uses: actions/checkout@v6
+      - name: Setup soldr
+        id: setup-soldr
+        uses: zackees/setup-soldr@v0
         with:
-          repository: zackees/soldr
-          ref: v0.7.4
-          path: soldr
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.94.1
-          components: clippy, rustfmt
-          targets: ${{ inputs.target }}
+          cache: true
+          build-cache: true
+          target-cache: true
+          cache-key-suffix: native-${{ inputs.target }}
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-
-      - name: Install soldr bootstrap
-        shell: bash
-        run: python -m pip install soldr==0.7.4
-
-      - name: Build soldr from source
-        shell: bash
-        working-directory: soldr
-        run: soldr cargo build --package soldr-cli --release --locked
-
-      - name: Add soldr to PATH
-        shell: bash
-        run: echo "${{ github.workspace }}/soldr/target/release" >> "$GITHUB_PATH"
 
       # rust-toolchain.toml pins 1.94.1 which overrides the above;
       # ensure the target stdlib is installed for the pinned toolchain too


### PR DESCRIPTION
﻿## Summary

- replace manual soldr/rustup setup in Rust worker workflows with `zackees/setup-soldr@v0`
- remove source-building soldr from macOS/Windows check workers and native build template
- enable setup-soldr cache, zccache build-cache, and Cargo target-cache where useful
- keep fbuild's embedded toolchain/build artifact caches in `template_build.yml`
- keep explicit `rustup target add` steps in native builds for cross-target stdlibs

Closes #183.

## Testing

- `git diff --check`
- `actionlint`
