### PR TITLE
ci: update MSRV to Rust 1.94.1

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ CI/CD workflows for the fbuild project, covering lint, test, documentation, and 
 
 - **`check-{macos,ubuntu,windows}.yml`** -- Clippy + tests per platform
 - **`fmt.yml`** -- Rustfmt check | **`docs.yml`** -- Doc build with `-D warnings`
-- **`msrv.yml`** -- MSRV 1.75 verification | **`validate-boards.yml`** -- Board JSON validation
+- **`msrv.yml`** -- MSRV 1.94.1 verification | **`validate-boards.yml`** -- Board JSON validation
 
 ## Per-Board Builds (push/PR)
 

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,4 +1,4 @@
-name: Min Rust Version (1.75)
+name: Min Rust Version (1.94.1)
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   msrv:
-    name: Min Rust Version (1.75)
+    name: Min Rust Version (1.94.1)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -19,7 +19,7 @@ jobs:
           cache: true
           build-cache: true
           target-cache: true
-          toolchain: 1.75.0
+          toolchain: 1.94.1
 
       - name: Check MSRV
         run: soldr cargo check --workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ fbuild is a PlatformIO-compatible embedded build tool (11 crates). See @docs/CLA
 
 - **Always use `soldr` or `uv run soldr` to execute Rust commands.** Bare cargo/rustc and legacy `uv run cargo` shims are blocked by hook. soldr uses `rustup which` to pick the rustup-managed toolchain from `rust-toolchain.toml`. The standard Cargo path is `soldr cargo ...`, so repo Rust builds get soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for normal builds.
 - **Always use `uv` for Python.** Bare `python`/`pip` are blocked by hook. Use `uv run ...` or `uv pip ...`.
-- MSRV: 1.75 | Edition: 2021 | Toolchain: 1.94.1 pinned in `rust-toolchain.toml` (clippy + rustfmt)
+- MSRV: 1.94.1 | Edition: 2021 | Toolchain: 1.94.1 pinned in `rust-toolchain.toml` (clippy + rustfmt)
 - CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)
 - Every directory with files must have a README.md (enforced by hook)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [workspace.package]
 version = "2.2.1"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fastled/fbuild"
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -90,7 +90,7 @@ This environment requires you to use `git-bash`.
 
 ### Toolchain
 
-- MSRV: 1.75 | Edition: 2021
+- MSRV: 1.94.1 | Edition: 2021
 - Toolchain: 1.94.1 pinned in `rust-toolchain.toml` (clippy + rustfmt)
 - CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)
 


### PR DESCRIPTION
## Summary
- Update the declared workspace MSRV from Rust 1.75 to 1.94.1.
- Update the MSRV workflow job name/toolchain and docs to match the pinned Rust toolchain.

## Investigation
The failing MSRV job was running Rust 1.75.0. It first failed while `soldr` bootstrapped managed `zccache`, because the current zccache dependency graph includes crates using edition 2024, which Cargo 1.75 cannot parse. After bypassing that locally, the workspace dependency graph itself also contained crates requiring newer Rust, including `running-process-core` with `rust-version = 1.85` and other transitive dependencies requiring Rust 1.8x. Since this repo already pins `rust-toolchain.toml` to 1.94.1, this PR makes 1.94.1 the explicit MSRV.

## Verification
- `RUSTUP_TOOLCHAIN=1.94.1 uv run soldr cargo check --workspace`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Rust version (MSRV) to 1.94.1 across project configuration and documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->