### PR TITLE
ci: scope native release target cache

### DIFF
--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -59,6 +59,11 @@ jobs:
           build-cache: true
           target-cache: true
           cache-key-suffix: native-${{ inputs.target }}
+          target-cache-paths: |
+            target/${{ inputs.target }}/release
+            target/*-unknown-linux-gnu.2.17/release
+            target/*-unknown-linux-gnu/release
+            target/release
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
- Configure the native release build template's `setup-soldr` target cache to restore/save only release-profile target directories.
- Include the normal native target, host `target/release`, and Linux manylinux/PyO3 cargo-zigbuild target directories.

## Why
`release-auto.yml` and manual `build.yml` both route native artifact builds through `template_native_build.yml`. The template already used `setup-soldr`; this narrows target-cache paths to the outputs those release jobs actually reuse, reducing cache transfer churn while preserving the soldr build-cache and release target cache fast paths.

## Verification
- `actionlint .github/workflows/template_native_build.yml`
- `git diff --check`