### PR TITLE
Avoid duplicate native release builds

### DIFF
--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -89,11 +89,13 @@ jobs:
         shell: bash
         run: |
           if [ "${{ inputs.linux_cross }}" = "true" ]; then
-            soldr cargo zigbuild --release --target ${{ inputs.target }} -p fbuild-cli
-            soldr cargo zigbuild --release --target ${{ inputs.target }} -p fbuild-daemon
+            soldr cargo zigbuild --release --target ${{ inputs.target }} \
+              -p fbuild-cli \
+              -p fbuild-daemon
           else
-            soldr cargo build --release --target ${{ inputs.target }} -p fbuild-cli
-            soldr cargo build --release --target ${{ inputs.target }} -p fbuild-daemon
+            soldr cargo build --release --target ${{ inputs.target }} \
+              -p fbuild-cli \
+              -p fbuild-daemon
           fi
 
       # PyO3 extension — built for ALL targets, including cross-compiled.
@@ -124,9 +126,13 @@ jobs:
               --target ${{ inputs.target }} -p fbuild-python \
               --features extension-module
           elif [ "${{ runner.os }}" = "macOS" ]; then
-            soldr cargo build --release -p fbuild-python --features extension-module
+            soldr cargo build --release --target ${{ inputs.target }} \
+              -p fbuild-python \
+              --features extension-module
           else
-            soldr cargo build --release -p fbuild-python --features extension-module
+            soldr cargo build --release --target ${{ inputs.target }} \
+              -p fbuild-python \
+              --features extension-module
           fi
 
       - name: Stage artifacts
@@ -142,7 +148,7 @@ jobs:
             ARCH="${TARGET%%-*}"
             ext_src="target/${ARCH}-unknown-linux-gnu/release/lib_native.so"
             [ -f "$ext_src" ] && cp "$ext_src" staging/_native.abi3.so
-          elif [ "${{ inputs.macos_cross }}" = "true" ]; then
+          elif [ "${{ runner.os }}" = "macOS" ]; then
             ext_src="target/${{ inputs.target }}/release/lib_native.dylib"
             [ -f "$ext_src" ] && cp "$ext_src" staging/_native.abi3.so
           elif [ "${{ inputs.binary_ext }}" = ".exe" ]; then


### PR DESCRIPTION
## Summary
- Build fbuild-cli and fbuild-daemon in one Cargo invocation per native target.
- Pass the explicit native target when building the PyO3 extension on macOS and Windows.
- Stage macOS native/cross extensions from the explicit target directory.

## Investigation
The linked Windows release job built binaries with `--target x86_64-pc-windows-msvc`, then entered the Python extension step. That extension command omitted `--target` on native Windows/macOS, so Cargo used the host output tree (`target/release`) after the binaries had populated `target/<target>/release`. On Windows this causes the shared graph to compile again. The binary step also used two separate Cargo invocations for `fbuild-cli` and `fbuild-daemon`, so this PR builds those together.

## Verification
- `actionlint .github/workflows/template_native_build.yml`
- `cargo check --target x86_64-pc-windows-msvc -p fbuild-cli -p fbuild-daemon` with Rust 1.94.1 MSVC toolchain in an isolated temp target dir
- `cargo check --target x86_64-pc-windows-msvc -p fbuild-python --features extension-module` with Rust 1.94.1 MSVC toolchain in an isolated temp target dir
