### PR TITLE
Support Digistump dtiny AVR framework

### DIFF
--- a/crates/fbuild-packages/assets/avr_frameworks.json
+++ b/crates/fbuild-packages/assets/avr_frameworks.json
@@ -25,6 +25,24 @@
       "checksum": null,
       "validation_path": "cores/tinymodern/Arduino.h"
     },
+    "dtiny": {
+      "name": "digistump-avr-core",
+      "github": "ArminJo/DigistumpArduino",
+      "version": "1.7.2",
+      "tag_prefix": "",
+      "checksum": null,
+      "validation_path": "cores/tiny/Arduino.h",
+      "core_dir": "tiny"
+    },
+    "pro": {
+      "name": "digistump-avr-core",
+      "github": "ArminJo/DigistumpArduino",
+      "version": "1.7.2",
+      "tag_prefix": "",
+      "checksum": null,
+      "validation_path": "cores/pro/Arduino.h",
+      "core_dir": "pro"
+    },
     "MiniCore": {
       "name": "minicore",
       "github": "MCUdude/MiniCore",

--- a/crates/fbuild-packages/src/library/avr_framework.rs
+++ b/crates/fbuild-packages/src/library/avr_framework.rs
@@ -372,4 +372,29 @@ mod tests {
         assert_eq!(entry.name, "arduino-megaavr-core");
         assert_eq!(entry.core_dir.as_deref(), Some("arduino"));
     }
+
+    #[test]
+    fn test_digispark_dtiny_registered() {
+        let registry = load_registry();
+        assert!(
+            registry.contains_key("dtiny"),
+            "dtiny must be registered for Digistump/Digispark boards"
+        );
+    }
+
+    #[test]
+    fn test_digispark_dtiny_lookup() {
+        let entry = lookup_entry("dtiny").unwrap();
+        assert!(entry.github.contains("DigistumpArduino"));
+        assert_eq!(entry.name, "digistump-avr-core");
+        assert_eq!(entry.core_dir.as_deref(), Some("tiny"));
+    }
+
+    #[test]
+    fn test_digispark_pro_lookup() {
+        let entry = lookup_entry("pro").unwrap();
+        assert!(entry.github.contains("DigistumpArduino"));
+        assert_eq!(entry.name, "digistump-avr-core");
+        assert_eq!(entry.core_dir.as_deref(), Some("pro"));
+    }
 }


### PR DESCRIPTION
## Summary

- register the Digistump/Digispark AVR framework for `dtiny`
- map `dtiny` to the package's `cores/tiny` directory
- register the sibling `pro` Digistump core from the same PlatformIO mapping
- add regression coverage for the missing `dtiny` lookup from #189

## TDD Notes

Red:

```text
uv run soldr cargo test -p fbuild-packages dtiny
```

failed with:

```text
no AVR framework registered for core 'dtiny'
```

Green:

```text
uv run soldr cargo test -p fbuild-packages dtiny
uv run soldr cargo test -p fbuild-packages
uv run soldr cargo test -p fbuild-build avr::orchestrator::tests
uv run soldr cargo fmt --all -- --check
```

Also verified a disposable temp `digispark-tiny` project builds successfully with:

```text
uv run soldr cargo run -p fbuild-cli -- build <temp-project> -e digispark-tiny --release --verbose
```

The temp project was removed after the run.

Fixes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new AVR Arduino frameworks (`dtiny` and `pro`) powered by the Digistump Arduino core. Both frameworks are now fully registered and configured with appropriate core directory paths.

* **Tests**
  * Added unit tests to ensure proper framework detection and validation of configuration parameters, including verification of core directory assignments for the newly added frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->