### PR TITLE
fix(fbuild-deploy): repair broken intra-doc links and fmt drift

### DIFF
--- a/crates/fbuild-deploy/src/esp32.rs
+++ b/crates/fbuild-deploy/src/esp32.rs
@@ -1245,11 +1245,9 @@ impl Deployer for Esp32Deployer {
 
         #[cfg(feature = "espflash-native")]
         if self.use_native_write {
-            if let Some(result) =
-                native_write_or_fallback(port, "write-flash", || {
-                    self.try_deploy_native(firmware_path, port)
-                })
-            {
+            if let Some(result) = native_write_or_fallback(port, "write-flash", || {
+                self.try_deploy_native(firmware_path, port)
+            }) {
                 return Ok(result);
             }
         }

--- a/crates/fbuild-deploy/src/esp32_native.rs
+++ b/crates/fbuild-deploy/src/esp32_native.rs
@@ -1,6 +1,6 @@
 //! Native ESP32 `verify-flash` **and** `write-flash` implementations
 //! backed by the [`espflash`] crate. Alternatives to the default
-//! [`super::esp32::Esp32Deployer`] path, which shells out to Python
+//! [`crate::esp32::Esp32Deployer`] path, which shells out to Python
 //! `esptool`.
 //!
 //! # Why (issue #66)
@@ -16,7 +16,8 @@
 //! # Scope
 //!
 //! * `verify-flash` — three regions (bootloader / partitions /
-//!   firmware), same [`VerifyOutcome`] semantics as the esptool path.
+//!   firmware), same [`crate::esp32::VerifyOutcome`] semantics as the
+//!   esptool path.
 //! * `write-flash` — same three regions, same
 //!   [`DeploymentResult`]/[`DeployOutcome`] shape as the esptool path.
 //!   Progress callbacks from espflash are bridged into `tracing` so the
@@ -36,9 +37,9 @@
 //! # Opt-in
 //!
 //! `verify-flash` is guarded by
-//! [`super::esp32::Esp32Deployer::with_native_verify`] (daemon env:
+//! [`crate::esp32::Esp32Deployer::with_native_verify`] (daemon env:
 //! `FBUILD_USE_ESPFLASH_VERIFY`), and `write-flash` by
-//! [`super::esp32::Esp32Deployer::with_native_write`] (daemon env:
+//! [`crate::esp32::Esp32Deployer::with_native_write`] (daemon env:
 //! `FBUILD_USE_ESPFLASH_WRITE`). The two flags are independent —
 //! users can flip one without the other while the native write path
 //! accumulates bench time on every ESP32 family member.


### PR DESCRIPTION
## Summary

Fixes two CI jobs that failed at commit 2aa2e346 (Upgrade GitHub Actions to Node 24):

- **Documentation** (run [24900888165](https://github.com/FastLED/fbuild/actions/runs/24900888165)) — exit 101
- **Formatting** (run [24900888192](https://github.com/FastLED/fbuild/actions/runs/24900888192)) — exit 1

### Documentation

`soldr cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings` failed inside `fbuild-deploy` with four `rustdoc::broken-intra-doc-links` errors, all in the module-level `//!` doc header of `crates/fbuild-deploy/src/esp32_native.rs`:

```
error: unresolved link to `super::esp32::Esp32Deployer`
  = note: no item named `super` in scope
  = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`

error: unresolved link to `VerifyOutcome`
  = note: no item named `VerifyOutcome` in scope

error: unresolved link to `super::esp32::Esp32Deployer::with_native_verify`
  = note: no item named `super` in scope

error: unresolved link to `super::esp32::Esp32Deployer::with_native_write`
  = note: no item named `super` in scope

error: could not document `fbuild-deploy`
```

Under rustc 1.94.1, rustdoc does not resolve `super::` from inner doc comments (`//!`) at the top of a module file, and `VerifyOutcome` is not in scope at the module-doc resolution site (the `use crate::esp32::{..., VerifyOutcome}` lives further down in the file body). Fixed by switching to unambiguous `crate::esp32::...` paths for all four links.

### Formatting

`cargo fmt --all -- --check` complained about one block in `crates/fbuild-deploy/src/esp32.rs:1245` (the `native_write_or_fallback` early-return around `try_deploy_native`). Applied `cargo fmt`. No other files touched.

## Test plan

- [x] `cargo doc --workspace --no-deps` locally with `RUSTDOCFLAGS=-D warnings` (rustc 1.94.1) — passes
- [x] `cargo fmt --all -- --check` locally — passes
- [ ] CI Documentation job — green on this PR
- [ ] CI Formatting job — green on this PR

Diff: 2 files, 8 insertions, 9 deletions. No behavior change, docs-only + whitespace.