### PR TITLE
ci(check-ubuntu): install uv so subprocess lint step can run

### DIFF
--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
         uses: zackees/setup-soldr@v0


### PR DESCRIPTION
## Summary
- The `Lint subprocess spawns` step added to `check-ubuntu.yml` in #200 invokes `uv run python ci/find_direct_subprocess.py --fail`, but the job never installs uv. Main broke on the merge of #200 with `uv: command not found` (exit 127).
- Fix: add `- uses: astral-sh/setup-uv@v3` before the step, matching how the sibling `lint-subprocess.yml` workflow sets up uv.

Failing run: https://github.com/FastLED/fbuild/actions/runs/24905357266

## Test plan
- [ ] CI `Check (ubuntu-latest)` passes on this PR (previously failed at the lint step).
- [ ] `Lint subprocess spawns` workflow remains green (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)