### PR TITLE
docs(library-selection): apply CodeRabbit follow-ups from PR #208

### DIFF
--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -48,6 +48,8 @@ fbuild-test-support (test utilities) ──────────────�
 
 **HTTP API boundary:** CLI sends JSON requests to daemon over HTTP. Build output streams via WebSocket. Serial monitor data streams via `/ws/serial-monitor`. All endpoints match the Python FastAPI daemon's contract.
 
+**Diagnostic subcommand exception:** A small, growing set of `fbuild-cli` subcommands (`clang-tidy`, `clang-query`, `iwyu`, `mcp`, `lnk`, `lib-select`) run in-process and intentionally bypass the daemon. They are read-only diagnostics that don't need build orchestration, so a round-trip through the HTTP API would only add latency. The "thin HTTP client" rule still applies to every command that touches the build pipeline (`build`, `deploy`, `monitor`, `test-emu`, etc.).
+
 **PyO3 consumer contract:** FastLED imports `SerialMonitor` as a Python context manager with `read_lines()`, `write()`, `write_json_rpc()`. The `fbuild-python` crate must preserve this API exactly.
 
 ## Current Status

--- a/crates/fbuild-build/tests/teensylc_acceptance.rs
+++ b/crates/fbuild-build/tests/teensylc_acceptance.rs
@@ -73,8 +73,7 @@ fn teensylc_blink_meets_205_acceptance_criteria() {
     }
     for required in ["setup", "loop"] {
         assert!(
-            probe.has_symbol(required).expect("symbol query")
-                || probe.has_symbol_containing(required).expect("symbol query"),
+            probe.has_symbol(required).expect("symbol query"),
             "A-11: required symbol '{required}' missing from ELF"
         );
     }

--- a/docs/architecture/library-selection.md
+++ b/docs/architecture/library-selection.md
@@ -1,8 +1,9 @@
 # Library selection (LDF-style)
 
 > Status: foundation phases (0–3 + Phase 5 framework_libs delegation) landed
-> in PR #207. Phase 4 (zccache memoization) tracked at zackees/zccache#130.
-> Phase 6 acceptance gates and Phase 7 perf gates are follow-ups in #205.
+> in PR #207. Phase 6 acceptance gates and Phase 8.a `lib-select` CLI landed
+> in PR #208. Phase 4 (zccache memoization) tracked at zackees/zccache#130.
+> Phase 7 perf gates and Phase 8.b cleanup remain follow-ups in `#205`.
 
 ## Why
 
@@ -127,20 +128,21 @@ keys safe.
 - Resolver tests in `crates/fbuild-library-select/src/lib.rs` including
   the #204 regression guard, sort-stability, missing-include-dir
   tolerance, and same-basename-different-library disambiguation.
-- Acceptance tests for AC#1 (teensyLC), AC#4 (stm32 SPI auto-discovery)
-  land in Phase 6 via `fbuild-test-support`'s `MiniFramework`,
-  `ElfProbe`, and `CompileDb` utilities.
+- Acceptance gates for AC#1 (teensyLC) and AC#4 (stm32 SPI
+  auto-discovery) live in `crates/fbuild-build/tests/`
+  (`teensylc_acceptance.rs`, `stm32_acceptance.rs`). They are
+  `#[ignore]`'d by default and run by CI with `--ignored`. They use
+  `fbuild-test-support`'s `ElfProbe` and `CompileDb` utilities to probe
+  the produced firmware.
 
 ## Future work
 
 - **Phase 4** — zccache K/V memoization. Gated on zackees/zccache#130
   shipping a versioned `KvStore` API and a 1.4.0 release; see
   `tasks/zccache-kv-design.md`.
-- **Phase 6** — wire ELF + compile-DB probes through `fbuild-test-support`
-  into per-board acceptance tests, gating CI on AC#1..#4 from #205.
 - **Phase 7** — perf gates wired into `bench/fastled-examples`.
-- **Phase 8** — `fbuild lib-select --explain` CLI subcommand and final
-  deletion of `framework_libs.rs` helpers.
+- **Phase 8.b** — final deletion of any dead helpers in `framework_libs.rs`
+  once Phase 4 cache lands.
 
 ## References
 


### PR DESCRIPTION
Addresses the five inline CodeRabbit findings on PR #208 (now merged). No runtime changes.

## Changes

- **\`teensylc_acceptance.rs\`** — drop substring fallback for \`setup\` / \`loop\` symbol probes. Exact \`has_symbol\` is sufficient and avoids false positives on mangled C++ names like \`_ZN6Stream8setupXxx\`. (CR-1)
- **\`crates/CLAUDE.md\`** — add "Diagnostic subcommand exception" pattern documenting that \`clang-tidy\` / \`clang-query\` / \`iwyu\` / \`mcp\` / \`lnk\` / \`lib-select\` intentionally bypass the daemon. (CR-3)
- **\`docs/architecture/library-selection.md\`** — refresh the status block and "Future work" list now that #208 has merged; rewrite the Tests section to reference the real \`tests/*_acceptance.rs\` files instead of describing them as future work. (CR-4, CR-5)

## CR-2 — false positive

CodeRabbit flagged \`use fbuild_packages::Framework;\` in \`crates/fbuild-cli/src/lib_select.rs\` as unused. Verified locally: the \`Framework\` trait is needed for \`get_libraries_dir()\` method-call dispatch on the 12 framework objects the file constructs. Removing it produces \`E0599\` errors. **Kept**.

## Verification

- \`uv run soldr cargo clippy --workspace --all-targets -- -D warnings\` — green.
- Workspace check / fmt / doc all green (no Rust changes outside the test edit).

Refs: #205, #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural documentation and project roadmap reflecting completion of recent phases and current development status.

* **Tests**
  * Strengthened acceptance test assertions for improved validation rigor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->