### PR TITLE
feat(library-selection): #205 Phase 4 zccache K/V memoization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,13 +990,17 @@ dependencies = [
 name = "fbuild-library-select"
 version = "2.2.3"
 dependencies = [
+ "bincode",
+ "blake3",
  "criterion",
  "fbuild-header-scan",
  "fbuild-packages",
  "fbuild-test-support",
+ "serde",
  "tempfile",
  "tracing",
  "walkdir",
+ "zccache-artifact",
 ]
 
 [[package]]
@@ -1849,6 +1862,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,6 +2430,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3690,6 +3721,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -3996,6 +4036,48 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zccache-artifact"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4144e1348f83ab3ec55c039e199b0f16dc7afa3d6c0af475debc00023adce425"
+dependencies = [
+ "bincode",
+ "blake3",
+ "redb",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "zccache-core",
+ "zccache-hash",
+]
+
+[[package]]
+name = "zccache-core"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "694f8a8a46b8552415458eca9a39a0bb36ed28fb0d152374a1f83761abef8222"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "zccache-hash"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb7ff97b2722055babfb6037757f4d6de41f8e4b838491e31d1eb3f367c318b"
+dependencies = [
+ "blake3",
+ "memmap2",
+ "serde",
+ "zccache-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ mimalloc = "0.1"
 object = { version = "0.36", default-features = false, features = ["read", "std", "elf", "write"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 shell-words = "1"
+bincode = "1"
+zccache-artifact = "1.4.0"
 
 # Process containment: all subprocess spawns the daemon performs (compilers,
 # esptool, qemu, simavr, node, npm, …) and any grandchildren they fork must

--- a/crates/fbuild-library-select/Cargo.toml
+++ b/crates/fbuild-library-select/Cargo.toml
@@ -11,6 +11,10 @@ fbuild-header-scan = { path = "../fbuild-header-scan" }
 fbuild-packages = { path = "../fbuild-packages" }
 tracing = { workspace = true }
 walkdir = { workspace = true }
+serde = { workspace = true }
+bincode = { workspace = true }
+blake3 = { workspace = true }
+zccache-artifact = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/fbuild-library-select/src/cache.rs
+++ b/crates/fbuild-library-select/src/cache.rs
@@ -1,0 +1,420 @@
+//! zccache K/V memoization for the [`crate::resolve`] function.
+//!
+//! The resolver is a pure function of (project sources, search paths, library
+//! set, toolchain triple, framework version, scanner/LDF semantics). Computing
+//! it costs ~tens of ms cold; restoring from a cache hit is sub-ms. On a warm
+//! CI build this should round-trip through `zccache_artifact::KvStore` instead
+//! of re-walking the framework `libraries/` tree.
+//!
+//! ## Cache key (Q9 from #205)
+//!
+//! `blake3(` of the following, concatenated with framing tags:
+//!   - sorted seed-path + content-hash pairs,
+//!   - sorted (lib_name, canonical_header_hash) pairs,
+//!   - the ordered search-path list (verbatim — order is observable),
+//!   - toolchain_triple,
+//!   - framework_install_path,
+//!   - framework_version,
+//!   - [`SCANNER_VERSION`],
+//!   - [`LDF_MODE_VERSION`].
+//!
+//! Bumping `SCANNER_VERSION` invalidates every cached entry whose include
+//! grammar may have changed. Bumping `LDF_MODE_VERSION` invalidates every
+//! entry whose 2-pass resolver semantics may have changed. Both are blunt
+//! and intentional — partial migration of a malformed cache is worse than
+//! a one-time recompute.
+
+use std::path::{Path, PathBuf};
+
+use fbuild_packages::library::FrameworkLibrary;
+use zccache_artifact::{Key, KvError, KvStore};
+
+use crate::{resolve, Selection};
+
+/// Bump when the scanner's lexical grammar changes in a way that could change
+/// which `#include` directives it emits for the same source.
+pub const SCANNER_VERSION: u32 = 1;
+
+/// Bump when the resolver's 2-pass LDF semantics change (seed expansion,
+/// attribution, convergence rule, etc.).
+pub const LDF_MODE_VERSION: u32 = 1;
+
+/// zccache namespace for this cache. Reserved per the zccache#130 design note.
+pub const NAMESPACE: &str = "library-selection";
+
+/// Inputs that vary independently of the (seeds, search_paths, libraries)
+/// triple and must contribute to the cache key — toolchain + framework
+/// identity. Held separately so the resolver call site (orchestrator) can
+/// supply them once per build.
+#[derive(Debug, Clone)]
+pub struct CacheKeyInputs<'a> {
+    /// Toolchain triple, e.g. `avr-unknown-none` or `xtensa-esp32-elf`.
+    pub toolchain_triple: &'a str,
+    /// On-disk install root of the framework (e.g. the Teensyduino root).
+    pub framework_install_path: &'a Path,
+    /// Framework version identifier (release string parsed from whatever
+    /// version file the framework carries — `package.json`, `platform.txt`,
+    /// or a `framework-name@version` line).
+    pub framework_version: &'a str,
+}
+
+/// Result of [`resolve_cached`]. `from_cache` distinguishes hit from miss so
+/// the caller can attribute build-time / log accordingly.
+#[derive(Debug, Clone)]
+pub struct CachedSelection {
+    pub selection: Selection,
+    pub key: Key,
+    pub from_cache: bool,
+}
+
+/// Compute the cache key for a (seeds, search_paths, libraries, inputs)
+/// tuple. Pure function — no I/O beyond reading file bodies for hashing.
+///
+/// Errors only on filesystem failures while reading seeds or canonical
+/// library headers; in either case we fall back to *not* hashing the
+/// missing file and continue (a missing seed is the resolver's problem,
+/// not the cache key's). Non-existence is recorded as the empty hash.
+#[must_use]
+pub fn cache_key(
+    seeds: &[PathBuf],
+    search_paths: &[PathBuf],
+    libraries: &[FrameworkLibrary],
+    inputs: &CacheKeyInputs<'_>,
+) -> Key {
+    let mut h = blake3::Hasher::new();
+
+    h.update(b"fbuild.library-select.v1\n");
+    h.update(&SCANNER_VERSION.to_le_bytes());
+    h.update(&LDF_MODE_VERSION.to_le_bytes());
+
+    h.update(b"toolchain:");
+    h.update(inputs.toolchain_triple.as_bytes());
+    h.update(b"\n");
+
+    h.update(b"framework_path:");
+    h.update(inputs.framework_install_path.to_string_lossy().as_bytes());
+    h.update(b"\n");
+
+    h.update(b"framework_version:");
+    h.update(inputs.framework_version.as_bytes());
+    h.update(b"\n");
+
+    // Seeds: sorted by path, each contributes (canonical_path, content_hash).
+    let mut seed_pairs: Vec<(String, [u8; 32])> = seeds
+        .iter()
+        .map(|p| {
+            let canon = std::fs::canonicalize(p).unwrap_or_else(|_| p.clone());
+            let bytes = std::fs::read(&canon).unwrap_or_default();
+            (
+                canon.to_string_lossy().into_owned(),
+                *blake3::hash(&bytes).as_bytes(),
+            )
+        })
+        .collect();
+    seed_pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    h.update(b"seeds:");
+    h.update(&(seed_pairs.len() as u64).to_le_bytes());
+    for (path, content) in &seed_pairs {
+        h.update(&(path.len() as u64).to_le_bytes());
+        h.update(path.as_bytes());
+        h.update(content);
+    }
+
+    // Search paths: ORDER MATTERS (PIO resolves earlier paths first), so we
+    // hash them in the order supplied — do not sort.
+    h.update(b"search_paths:");
+    h.update(&(search_paths.len() as u64).to_le_bytes());
+    for p in search_paths {
+        let s = p.to_string_lossy();
+        h.update(&(s.len() as u64).to_le_bytes());
+        h.update(s.as_bytes());
+    }
+
+    // Libraries: sorted by name. Content hash of the canonical header
+    // (`<lib>/<src>/<name>.h` or first include_dir hit) catches the common
+    // case of a lib's API header changing without bumping the framework
+    // version. We deliberately do NOT hash every source file — Teensyduino
+    // alone is ~500 files and PIO LDF doesn't either.
+    let mut lib_pairs: Vec<(String, [u8; 32])> = libraries
+        .iter()
+        .map(|lib| (lib.name.clone(), canonical_header_hash(lib)))
+        .collect();
+    lib_pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    h.update(b"libraries:");
+    h.update(&(lib_pairs.len() as u64).to_le_bytes());
+    for (name, content) in &lib_pairs {
+        h.update(&(name.len() as u64).to_le_bytes());
+        h.update(name.as_bytes());
+        h.update(content);
+    }
+
+    Key::from_hash(h.finalize())
+}
+
+fn canonical_header_hash(lib: &FrameworkLibrary) -> [u8; 32] {
+    // Try `<include_dir>/<lib_name>.h` for each of the lib's include dirs.
+    // First hit wins; falls back to a hash of the empty string if the lib
+    // doesn't expose its name as a header (rare — usually a pure
+    // implementation-only lib).
+    for dir in &lib.include_dirs {
+        let candidate = dir.join(format!("{}.h", lib.name));
+        if let Ok(bytes) = std::fs::read(&candidate) {
+            return *blake3::hash(&bytes).as_bytes();
+        }
+    }
+    *blake3::hash(b"").as_bytes()
+}
+
+/// Resolve with cache. On miss, computes the selection, stores it, and
+/// returns it with `from_cache = false`. On hit, deserializes the stored
+/// `Selection` and returns it with `from_cache = true`.
+///
+/// Cache lookups that fail decoding (corrupt entry, schema drift) fall
+/// through to recomputation rather than propagating — a stale cache must
+/// never poison a build. The tainted entry is overwritten by the fresh
+/// computation's `put`.
+///
+/// Errors propagate only from the underlying [`KvStore`] backend
+/// (filesystem, redb commit). Construction-time validation of the
+/// namespace is impossible to fail because [`NAMESPACE`] is a const.
+pub fn resolve_cached(
+    seeds: &[PathBuf],
+    search_paths: &[PathBuf],
+    libraries: &[FrameworkLibrary],
+    inputs: &CacheKeyInputs<'_>,
+    store: &KvStore,
+) -> Result<CachedSelection, KvError> {
+    let key = cache_key(seeds, search_paths, libraries, inputs);
+
+    if let Some(bytes) = store.get(NAMESPACE, &key)? {
+        match bincode::deserialize::<Selection>(&bytes) {
+            Ok(selection) => {
+                return Ok(CachedSelection {
+                    selection,
+                    key,
+                    from_cache: true,
+                });
+            }
+            Err(err) => {
+                tracing::warn!(
+                    key = %key.to_hex(),
+                    error = %err,
+                    "library-select cache: corrupt entry; recomputing"
+                );
+            }
+        }
+    }
+
+    let selection = resolve(seeds, search_paths, libraries);
+    // serde's `PathBuf` Serialize impl errors when a path component is not
+    // valid UTF-8 (legal on Unix, possible on Windows via canonicalize edge
+    // cases). Treat that as a cache write miss — degraded performance is
+    // strictly better than poisoning the build with a panic.
+    match bincode::serialize(&selection) {
+        Ok(bytes) => {
+            store.put(NAMESPACE, &key, &bytes)?;
+        }
+        Err(err) => {
+            tracing::warn!(
+                key = %key.to_hex(),
+                error = %err,
+                "library-select cache: failed to serialize selection \
+                 (likely non-UTF-8 path); skipping cache write"
+            );
+        }
+    }
+
+    Ok(CachedSelection {
+        selection,
+        key,
+        from_cache: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn lib(tmp: &Path, name: &str) -> FrameworkLibrary {
+        let dir = tmp.join("libraries").join(name);
+        let src = dir.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        FrameworkLibrary {
+            name: name.to_string(),
+            dir,
+            include_dirs: vec![src],
+            source_files: Vec::new(),
+        }
+    }
+
+    fn fixture_inputs<'a>(framework_root: &'a Path) -> CacheKeyInputs<'a> {
+        CacheKeyInputs {
+            toolchain_triple: "avr-unknown-none",
+            framework_install_path: framework_root,
+            framework_version: "1.59.0",
+        }
+    }
+
+    fn build_simple_project() -> (TempDir, Vec<PathBuf>, Vec<PathBuf>, Vec<FrameworkLibrary>) {
+        let tmp = TempDir::new().unwrap();
+        let project_src = tmp.path().join("project").join("src");
+        write(&project_src.join("main.cpp"), "#include <SPI.h>\n");
+
+        let mut spi = lib(tmp.path(), "SPI");
+        write(
+            &spi.include_dirs[0].join("SPI.h"),
+            "// canonical SPI header",
+        );
+        let spi_cpp = spi.include_dirs[0].join("SPI.cpp");
+        write(&spi_cpp, "");
+        spi.source_files.push(spi_cpp);
+
+        let seeds = vec![project_src.join("main.cpp")];
+        let search_paths = vec![project_src];
+        (tmp, seeds, search_paths, vec![spi])
+    }
+
+    #[test]
+    fn c01_cache_miss_then_hit() {
+        let (tmp, seeds, search_paths, libs) = build_simple_project();
+        let kv = KvStore::open(tmp.path().join("kv")).unwrap();
+        let inputs = fixture_inputs(tmp.path());
+
+        let first = resolve_cached(&seeds, &search_paths, &libs, &inputs, &kv).unwrap();
+        assert!(!first.from_cache, "first call should miss");
+        assert_eq!(first.selection.required_libraries, vec!["SPI".to_string()]);
+
+        let second = resolve_cached(&seeds, &search_paths, &libs, &inputs, &kv).unwrap();
+        assert!(second.from_cache, "second call should hit");
+        assert_eq!(first.selection, second.selection);
+        assert_eq!(first.key.as_bytes(), second.key.as_bytes());
+    }
+
+    #[test]
+    fn c02_seed_content_change_invalidates_key() {
+        let (tmp, seeds, search_paths, libs) = build_simple_project();
+        let inputs = fixture_inputs(tmp.path());
+        let key_before = cache_key(&seeds, &search_paths, &libs, &inputs);
+
+        // Touch the seed body. Even though the include set is identical,
+        // the cache key must change so a downstream "did the source actually
+        // change" check is the source of truth, not the cached resolver
+        // result. (Otherwise a syntactic-only edit could mask a real change.)
+        write(&seeds[0], "#include <SPI.h>\n// extra comment\n");
+        let key_after = cache_key(&seeds, &search_paths, &libs, &inputs);
+        assert_ne!(key_before.as_bytes(), key_after.as_bytes());
+    }
+
+    #[test]
+    fn c03_toolchain_change_invalidates_key() {
+        let (tmp, seeds, search_paths, libs) = build_simple_project();
+        let a = CacheKeyInputs {
+            toolchain_triple: "avr-unknown-none",
+            framework_install_path: tmp.path(),
+            framework_version: "1.59.0",
+        };
+        let b = CacheKeyInputs {
+            toolchain_triple: "xtensa-esp32-elf",
+            framework_install_path: tmp.path(),
+            framework_version: "1.59.0",
+        };
+        assert_ne!(
+            cache_key(&seeds, &search_paths, &libs, &a).as_bytes(),
+            cache_key(&seeds, &search_paths, &libs, &b).as_bytes()
+        );
+    }
+
+    #[test]
+    fn c04_framework_version_change_invalidates_key() {
+        let (tmp, seeds, search_paths, libs) = build_simple_project();
+        let a = fixture_inputs(tmp.path());
+        let b = CacheKeyInputs {
+            toolchain_triple: a.toolchain_triple,
+            framework_install_path: a.framework_install_path,
+            framework_version: "1.60.0",
+        };
+        assert_ne!(
+            cache_key(&seeds, &search_paths, &libs, &a).as_bytes(),
+            cache_key(&seeds, &search_paths, &libs, &b).as_bytes()
+        );
+    }
+
+    #[test]
+    fn c05_library_input_order_does_not_affect_key() {
+        let tmp = TempDir::new().unwrap();
+        let project_src = tmp.path().join("project").join("src");
+        write(&project_src.join("main.cpp"), "#include <SPI.h>\n");
+
+        let mut spi = lib(tmp.path(), "SPI");
+        write(&spi.include_dirs[0].join("SPI.h"), "spi");
+        spi.source_files.push(spi.include_dirs[0].join("SPI.cpp"));
+        write(&spi.source_files[0], "");
+
+        let mut wire = lib(tmp.path(), "Wire");
+        write(&wire.include_dirs[0].join("Wire.h"), "wire");
+        wire.source_files
+            .push(wire.include_dirs[0].join("Wire.cpp"));
+        write(&wire.source_files[0], "");
+
+        let seeds = vec![project_src.join("main.cpp")];
+        let search_paths = vec![project_src];
+        let inputs = fixture_inputs(tmp.path());
+
+        let k1 = cache_key(&seeds, &search_paths, &[spi.clone(), wire.clone()], &inputs);
+        let k2 = cache_key(&seeds, &search_paths, &[wire, spi], &inputs);
+        assert_eq!(
+            k1.as_bytes(),
+            k2.as_bytes(),
+            "library input order must be normalized"
+        );
+    }
+
+    #[test]
+    fn c06_search_path_order_does_affect_key() {
+        // PIO resolves earlier search paths first, so the key must reflect
+        // ordering. (If this test fails after a refactor, it's because
+        // `cache_key` accidentally sorted search_paths — don't.)
+        let (tmp, seeds, search_paths, libs) = build_simple_project();
+        let inputs = fixture_inputs(tmp.path());
+
+        let mut reversed = search_paths.clone();
+        reversed.push(tmp.path().join("extra"));
+        let mut also_reversed = reversed.clone();
+        also_reversed.reverse();
+
+        assert_ne!(
+            cache_key(&seeds, &reversed, &libs, &inputs).as_bytes(),
+            cache_key(&seeds, &also_reversed, &libs, &inputs).as_bytes()
+        );
+    }
+
+    #[test]
+    fn c07_corrupt_entry_falls_through_to_recompute() {
+        let (tmp, seeds, search_paths, libs) = build_simple_project();
+        let kv = KvStore::open(tmp.path().join("kv")).unwrap();
+        let inputs = fixture_inputs(tmp.path());
+
+        let key = cache_key(&seeds, &search_paths, &libs, &inputs);
+        // Plant garbage bytes under the cache key. resolve_cached must NOT
+        // propagate the bincode error — it must fall through, recompute,
+        // and overwrite.
+        kv.put(NAMESPACE, &key, b"not a valid bincoded Selection")
+            .unwrap();
+
+        let res = resolve_cached(&seeds, &search_paths, &libs, &inputs, &kv).unwrap();
+        assert!(!res.from_cache, "corrupt entry must trigger recompute");
+        assert_eq!(res.selection.required_libraries, vec!["SPI".to_string()]);
+
+        // And the corrupted bytes were replaced with valid bincode.
+        let again = resolve_cached(&seeds, &search_paths, &libs, &inputs, &kv).unwrap();
+        assert!(again.from_cache);
+    }
+}

--- a/crates/fbuild-library-select/src/lib.rs
+++ b/crates/fbuild-library-select/src/lib.rs
@@ -22,9 +22,14 @@ use std::path::{Path, PathBuf};
 
 use fbuild_header_scan::walk;
 use fbuild_packages::library::FrameworkLibrary;
+use serde::{Deserialize, Serialize};
+
+pub mod cache;
+
+pub use cache::{cache_key, resolve_cached, CacheKeyInputs, CachedSelection};
 
 /// Resolved library selection plus the transitive include closure.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Selection {
     /// Canonicalized paths of every file reached by the walker.
     pub included_files: Vec<PathBuf>,


### PR DESCRIPTION
## Summary

- Adds `crates/fbuild-library-select/src/cache.rs` — `resolve_cached(...)` wraps `crate::resolve` in a blake3-keyed `zccache_artifact::KvStore` lookup.
- Cache key composition matches Q9 from #205: sorted `(canonical_path, blake3(content))` for seeds; sorted `(lib_name, blake3(canonical header))` for libraries; ordered search-path list (PIO order matters); toolchain triple, framework install path + version; `SCANNER_VERSION` + `LDF_MODE_VERSION` for invalidation.
- Workspace bump to `zccache-artifact = "1.4.0"` (released from `~/dev/zccache` as part of the Phase 4 coordination, Tasks 1–3).
- Corrupt entries fall through to recompute and overwrite — a stale cache must never poison a build.

## Test plan

- [x] `uv run --script ci/test.py -p fbuild-library-select` — 16/16 passing
  - 9 resolver tests: 2-pass LDF + path-prefix attribution
  - 7 cache tests (`c01_cache_miss_then_hit`, `c02_seed_content_change_invalidates_key`, `c03_toolchain_change_invalidates_key`, `c04_framework_version_change_invalidates_key`, `c05_library_input_order_does_not_affect_key`, `c06_search_path_order_does_affect_key`, `c07_corrupt_entry_falls_through_to_recompute`)
- [x] `uv run --script ci/lint.py` — clean (workspace clippy `-D warnings`)
- [ ] CI green on the linked workflow run

Refs: #205 Phase 4. Closes Phase 4 of the issue's revised DAG; Phase 7 perf gates (#210) and Phase 8.b cleanup remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added caching layer for library selection to improve build performance when configurations remain unchanged. Cache automatically validates and refreshes when toolchain, framework, or build parameters change.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->