### PR TITLE
chore(hooks): route lint/test/perf through soldr instead of `uv run cargo`

### DIFF
--- a/ci/lint.py
+++ b/ci/lint.py
@@ -54,13 +54,13 @@ def lint_single_file(file_path):
         return 1
 
     # Format single file
-    result = run_cmd(["uv", "run", "rustfmt", file_path])
+    result = run_cmd(["uv", "run", "soldr", "rustfmt", file_path])
     if result.returncode != 0:
         return result.returncode
 
     # Clippy on the affected crate (or workspace if unknown)
     crate = detect_crate(file_path)
-    cmd = ["uv", "run", "cargo", "clippy"]
+    cmd = ["uv", "run", "soldr", "cargo", "clippy"]
     if crate:
         cmd += ["-p", crate]
     else:
@@ -74,14 +74,14 @@ def lint_single_file(file_path):
 def lint_workspace():
     """Full workspace lint: fmt check + clippy."""
     # Format check
-    result = run_cmd(["uv", "run", "cargo", "fmt", "--all", "--check"])
+    result = run_cmd(["uv", "run", "soldr", "cargo", "fmt", "--all", "--check"])
     if result.returncode != 0:
         print("Formatting issues found. Run './lint --fix' to auto-fix.", file=sys.stderr)
         return result.returncode
 
     # Clippy
     result = run_cmd([
-        "uv", "run", "cargo", "clippy", "--workspace", "--all-targets",
+        "uv", "run", "soldr", "cargo", "clippy", "--workspace", "--all-targets",
         "--", "-D", "warnings",
     ])
     return result.returncode
@@ -93,13 +93,13 @@ def main():
     # Handle --fix flag
     if "--fix" in args:
         args.remove("--fix")
-        result = run_cmd(["uv", "run", "cargo", "fmt", "--all"])
+        result = run_cmd(["uv", "run", "soldr", "cargo", "fmt", "--all"])
         if result.returncode != 0:
             return result.returncode
         if not args:
             # After fixing fmt, run clippy
             result = run_cmd([
-                "uv", "run", "cargo", "clippy", "--workspace", "--all-targets",
+                "uv", "run", "soldr", "cargo", "clippy", "--workspace", "--all-targets",
                 "--", "-D", "warnings",
             ])
             return result.returncode

--- a/ci/test.py
+++ b/ci/test.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 
 
 def main():
-    cmd = ["uv", "run", "cargo", "test"]
+    cmd = ["uv", "run", "soldr", "cargo", "test"]
 
     args = sys.argv[1:]
     full = "--full" in args

--- a/lint
+++ b/lint
@@ -49,13 +49,13 @@ def main() -> int:
 
     # --fix mode
     if fix:
-        rc = run(["uv", "run", "cargo", "fmt", "--all"])
+        rc = run(["uv", "run", "soldr", "cargo", "fmt", "--all"])
         if rc != 0:
             return rc
         if not file_arg:
             return run(
                 [
-                    "uv", "run", "cargo", "clippy",
+                    "uv", "run", "soldr", "cargo", "clippy",
                     "--workspace", "--all-targets", "--", "-D", "warnings",
                 ]
             )
@@ -66,27 +66,27 @@ def main() -> int:
         if not os.path.isfile(file_path):
             print(f"File not found: {file_path}", file=sys.stderr)
             return 1
-        rc = run(["uv", "run", "rustfmt", file_path])
+        rc = run(["uv", "run", "soldr", "rustfmt", file_path])
         if rc != 0:
             return rc
         crate = detect_crate(file_path)
         if crate:
             return run(
                 [
-                    "uv", "run", "cargo", "clippy",
+                    "uv", "run", "soldr", "cargo", "clippy",
                     "-p", crate, "--all-targets", "--", "-D", "warnings",
                 ]
             )
         else:
             return run(
                 [
-                    "uv", "run", "cargo", "clippy",
+                    "uv", "run", "soldr", "cargo", "clippy",
                     "--workspace", "--all-targets", "--", "-D", "warnings",
                 ]
             )
 
     # Full workspace mode
-    rc = run(["uv", "run", "cargo", "fmt", "--all", "--check"])
+    rc = run(["uv", "run", "soldr", "cargo", "fmt", "--all", "--check"])
     if rc != 0:
         print(
             "Formatting issues found. Run 'uv run --script lint --fix' to auto-fix.",
@@ -95,7 +95,7 @@ def main() -> int:
         return 1
     return run(
         [
-            "uv", "run", "cargo", "clippy",
+            "uv", "run", "soldr", "cargo", "clippy",
             "--workspace", "--all-targets", "--", "-D", "warnings",
         ]
     )

--- a/perf
+++ b/perf
@@ -18,7 +18,7 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 
 def main():
     cmd = [
-        "uv", "run", "cargo", "test",
+        "uv", "run", "soldr", "cargo", "test",
         "-p", "fbuild-daemon",
         "--test", "perf_bench_test",
         "--",


### PR DESCRIPTION
## Summary

- The PostToolUse lint hook (`./lint`) and the Stop hook (`ci/lint.py` + `ci/test.py`) shell out to `uv run cargo`. On Windows that resolves to a different host triple than `soldr cargo` (`x86_64-pc-windows-gnu` vs `x86_64-pc-windows-msvc`), so the same `target/debug/` cannot be shared. Every Stop fired a target-triple mismatch cascading across 30+ crates.
- `tool_guard.py` already blocks `uv run cargo` in shell tool calls, but it doesn't catch subprocess invocations from inside Python — these four scripts slipped through.
- Routes every `cargo`/`rustfmt` call through `uv run soldr ...` so the rustup-managed msvc-host toolchain is the single source of truth for `target/debug/`.

## Test plan

- [x] `uv run --script ci/lint.py` — clean post-patch (workspace clippy `-D warnings`)
- [x] `uv run --script ci/test.py -p fbuild-library-select` — 16/16 passing
- [ ] CI green on Linux + macOS + Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)