### PR TITLE
feat(test-matrix): #224 add SuperMini, nice!nano, nRFMicro nRF52840 boards

### DIFF
--- a/.github/workflows/build-nice_nano_nrf52840.yml
+++ b/.github/workflows/build-nice_nano_nrf52840.yml
@@ -1,0 +1,16 @@
+name: Build nice!nano nRF52840
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "nice!nano nRF52840"
+      test-dir: "tests/platform/nice_nano_nrf52840"
+      env-name: "nice_nano_nrf52840"
+      firmware-ext: "hex"

--- a/.github/workflows/build-nrfmicro_nrf52840.yml
+++ b/.github/workflows/build-nrfmicro_nrf52840.yml
@@ -1,0 +1,16 @@
+name: Build nRFMicro nRF52840
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "nRFMicro nRF52840"
+      test-dir: "tests/platform/nrfmicro_nrf52840"
+      env-name: "nrfmicro_nrf52840"
+      firmware-ext: "hex"

--- a/.github/workflows/build-supermini_nrf52840.yml
+++ b/.github/workflows/build-supermini_nrf52840.yml
@@ -1,0 +1,16 @@
+name: Build SuperMini nRF52840
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "SuperMini nRF52840"
+      test-dir: "tests/platform/supermini_nrf52840"
+      env-name: "supermini_nrf52840"
+      firmware-ext: "hex"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@
 
 ### Nordic NRF52
 [![Build nRF52840 DK](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml)
+[![Build SuperMini nRF52840](https://github.com/fastled/fbuild/actions/workflows/build-supermini_nrf52840.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-supermini_nrf52840.yml)
+[![Build nice!nano nRF52840](https://github.com/fastled/fbuild/actions/workflows/build-nice_nano_nrf52840.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nice_nano_nrf52840.yml)
+[![Build nRFMicro nRF52840](https://github.com/fastled/fbuild/actions/workflows/build-nrfmicro_nrf52840.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrfmicro_nrf52840.yml)
 
 ### Apollo3
 [![Build Apollo3 RedBoard](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml)

--- a/tests/platform/README.md
+++ b/tests/platform/README.md
@@ -29,6 +29,9 @@ PlatformIO-compatible test projects for each supported hardware platform. Each s
 | `mgm240/` | EFR32MG24 | ARM Cortex-M33 | Arduino |
 | `nano_every/` | ATmega4809 | MegaAVR | Arduino |
 | `nrf52840_dk/` | nRF52840 | ARM Cortex-M4F | Arduino |
+| `supermini_nrf52840/` | nRF52840 | ARM Cortex-M4F | Arduino |
+| `nice_nano_nrf52840/` | nRF52840 | ARM Cortex-M4F | Arduino |
+| `nrfmicro_nrf52840/` | nRF52840 | ARM Cortex-M4F | Arduino |
 | `nucleo_f429zi/` | STM32F429ZI | ARM Cortex-M4F | Arduino |
 | `nucleo_f439zi/` | STM32F439ZI | ARM Cortex-M4F | Arduino |
 | `rp2040/` | RP2040 | ARM Cortex-M0+ | Arduino |

--- a/tests/platform/nice_nano_nrf52840/README.md
+++ b/tests/platform/nice_nano_nrf52840/README.md
@@ -1,0 +1,11 @@
+# nice!nano nRF52840 Test Project
+
+Minimal blink sketch for the nice!nano v2 / ProMicro nRF52840 community board build
+validation.
+
+The board reuses the `nrf52840_dk_adafruit` PlatformIO board because no first-party
+PlatformIO board package exists for this community variant. The
+`-DTARGET_NICE_NANO_V2` build flag mirrors the define used by FastLED's FastPin
+variant block (FastLED/FastLED#2445) so the variant code path is exercised in CI.
+
+Variant header: https://github.com/pdcook/nRFMicro-Arduino-Core/blob/main/variants/nice_nano/variant.h

--- a/tests/platform/nice_nano_nrf52840/platformio.ini
+++ b/tests/platform/nice_nano_nrf52840/platformio.ini
@@ -1,0 +1,5 @@
+[env:nice_nano_nrf52840]
+platform = nordicnrf52
+board = nrf52840_dk_adafruit
+framework = arduino
+build_flags = -DTARGET_NICE_NANO_V2

--- a/tests/platform/nice_nano_nrf52840/src/README.md
+++ b/tests/platform/nice_nano_nrf52840/src/README.md
@@ -1,0 +1,3 @@
+# src
+
+Arduino sketch source for the nice!nano nRF52840 test project.

--- a/tests/platform/nice_nano_nrf52840/src/main.ino
+++ b/tests/platform/nice_nano_nrf52840/src/main.ino
@@ -1,0 +1,12 @@
+#include <Arduino.h>
+
+void setup() {
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+}

--- a/tests/platform/nrfmicro_nrf52840/README.md
+++ b/tests/platform/nrfmicro_nrf52840/README.md
@@ -1,0 +1,10 @@
+# nRFMicro nRF52840 Test Project
+
+Minimal blink sketch for the nRFMicro community board build validation.
+
+The board reuses the `nrf52840_dk_adafruit` PlatformIO board because no first-party
+PlatformIO board package exists for this community variant. The `-DTARGET_NRFMICRO`
+build flag mirrors the define used by FastLED's FastPin variant block
+(FastLED/FastLED#2445) so the variant code path is exercised in CI.
+
+Variant header: https://github.com/pdcook/nRFMicro-Arduino-Core/blob/main/variants/nRFMicro/variant.h

--- a/tests/platform/nrfmicro_nrf52840/platformio.ini
+++ b/tests/platform/nrfmicro_nrf52840/platformio.ini
@@ -1,0 +1,5 @@
+[env:nrfmicro_nrf52840]
+platform = nordicnrf52
+board = nrf52840_dk_adafruit
+framework = arduino
+build_flags = -DTARGET_NRFMICRO

--- a/tests/platform/nrfmicro_nrf52840/src/README.md
+++ b/tests/platform/nrfmicro_nrf52840/src/README.md
@@ -1,0 +1,3 @@
+# src
+
+Arduino sketch source for the nRFMicro nRF52840 test project.

--- a/tests/platform/nrfmicro_nrf52840/src/main.ino
+++ b/tests/platform/nrfmicro_nrf52840/src/main.ino
@@ -1,0 +1,12 @@
+#include <Arduino.h>
+
+void setup() {
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+}

--- a/tests/platform/supermini_nrf52840/README.md
+++ b/tests/platform/supermini_nrf52840/README.md
@@ -1,0 +1,11 @@
+# SuperMini nRF52840 Test Project
+
+Minimal blink sketch for the SuperMini nRF52840 community board build validation.
+
+The board reuses the `nrf52840_dk_adafruit` PlatformIO board because no first-party
+PlatformIO board package exists for this community variant. The
+`-DTARGET_SUPERMINI_NRF52840` build flag mirrors the define used by FastLED's
+FastPin variant block (FastLED/FastLED#2445) so the variant code path is exercised
+in CI.
+
+Variant header: https://github.com/pdcook/nRFMicro-Arduino-Core/blob/main/variants/SuperMini_nRF52840/variant.h

--- a/tests/platform/supermini_nrf52840/platformio.ini
+++ b/tests/platform/supermini_nrf52840/platformio.ini
@@ -1,0 +1,5 @@
+[env:supermini_nrf52840]
+platform = nordicnrf52
+board = nrf52840_dk_adafruit
+framework = arduino
+build_flags = -DTARGET_SUPERMINI_NRF52840

--- a/tests/platform/supermini_nrf52840/src/README.md
+++ b/tests/platform/supermini_nrf52840/src/README.md
@@ -1,0 +1,3 @@
+# src
+
+Arduino sketch source for the SuperMini nRF52840 test project.

--- a/tests/platform/supermini_nrf52840/src/main.ino
+++ b/tests/platform/supermini_nrf52840/src/main.ino
@@ -1,0 +1,12 @@
+#include <Arduino.h>
+
+void setup() {
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+}


### PR DESCRIPTION
Closes #224

## Summary

Extends fbuild's self-test matrix with three nRF52840 community boards from the [pdcook/nRFMicro-Arduino-Core](https://github.com/pdcook/nRFMicro-Arduino-Core) BSP, mirroring FastLED PR [FastLED/FastLED#2445](https://github.com/FastLED/FastLED/pull/2445):

- `supermini_nrf52840` &rarr; SuperMini nRF52840
- `nice_nano_nrf52840` &rarr; nice!nano v2 (ProMicro-pin-compatible footprint)
- `nrfmicro_nrf52840` &rarr; nRFMicro

## Approach

Each test platform reuses the existing `nrf52840_dk_adafruit` PlatformIO board (no first-party board package exists for these community variants &mdash; the same approach FastLED takes via `real_board_name="nrf52840_dk_adafruit"` in `ci/boards.py`). The matching `-DTARGET_*` build flag selects the variant block so the FastLED code path is exercised when these boards are compiled in CI.

No new board JSONs were added because all three boards share `nrf52840_dk_adafruit`'s build settings; only the `TARGET_*` define differs.

## Files

- `tests/platform/{supermini,nice_nano,nrfmicro}_nrf52840/{platformio.ini, README.md, src/main.ino, src/README.md}` &mdash; minimal blink sketches
- `.github/workflows/build-{supermini,nice_nano,nrfmicro}_nrf52840.yml` &mdash; per-board workflows calling `template_build.yml`
- `README.md` &mdash; three new badges in the **Nordic NRF52** group
- `tests/platform/README.md` &mdash; three rows in the platform table

## Test plan

- [ ] CI runs the three new build jobs (quick + release) using `template_build.yml`
- [ ] README badges render and link to their respective workflow runs
- [ ] If any build fails on a BSP/toolchain mismatch (the issue notes a pre-existing `ARDUINO_BSP_VERSION` parsing failure with GCC 15.2.1), follow up with a BSP package pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for three new nRF52840 board variants: nice!nano, nRFMicro, and SuperMini.

* **Tests**
  * Added test projects with validation sketches for each newly supported board variant.

* **Chores**
  * Added CI/CD automation workflows for build validation across the new boards.

* **Documentation**
  * Updated platform documentation with setup and configuration information for the new boards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/225)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->