### PR TITLE
feat(acceptance): #205 AC#6 teensy41 cold resolver <= 200 ms gate

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -18,6 +18,7 @@ on:
       - 'crates/fbuild-build/src/stm32/**'
       - 'crates/fbuild-build/tests/teensylc_acceptance.rs'
       - 'crates/fbuild-build/tests/teensy30_acceptance.rs'
+      - 'crates/fbuild-build/tests/teensy41_acceptance.rs'
       - 'crates/fbuild-build/tests/stm32_acceptance.rs'
       - '.github/workflows/acceptance-205.yml'
 
@@ -44,6 +45,9 @@ jobs:
           - gate: stm32f103c8 SPI
             test_bin: stm32_acceptance
             test_fn: stm32f103c8_blink_with_spi_auto_discovers_library_205_ac4
+          - gate: teensy41 cold resolver
+            test_bin: teensy41_acceptance
+            test_fn: teensy41_cold_library_selection_meets_205_ac6
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3

--- a/crates/fbuild-build/tests/teensy41_acceptance.rs
+++ b/crates/fbuild-build/tests/teensy41_acceptance.rs
@@ -1,0 +1,130 @@
+//! Acceptance gate for #205 AC#6: teensy41 cold library-selection budget.
+//!
+//! AC#6 verbatim from the #205 issue body:
+//!
+//! > Cold run of library selection on `teensy41` project <= 200 ms on a
+//! > typical CI runner.
+//!
+//! This test materializes a real Teensyduino install via
+//! `fbuild_packages::library::TeensyCores::ensure_installed`, enumerates its
+//! ~40 framework libraries with `get_framework_libraries`, and times a SINGLE
+//! call to the uncached resolver
+//! `fbuild_library_select::resolve(seeds, search_paths, libraries)` against a
+//! minimal teensy41 Blink fixture. The test asserts the elapsed wall-clock
+//! time is <= 200 ms — the 200 ms budget is the AC#6 contract.
+//!
+//! "Cold" means the resolver itself, NOT the cache layer: AC#6 is about the
+//! actual BFS+attribution cost of `resolve()`, the function on top of which
+//! `resolve_cached` is built. Hitting the warm cache short-circuits this work
+//! and is covered by AC#5 (the bench-fastled-examples warm threshold gate);
+//! AC#6 ensures the cold path is itself fast enough that a cache-cold project
+//! does not pay an unbounded resolution tax.
+//!
+//! Uses the stm32_acceptance.rs / teensy30_acceptance.rs inline-tempdir
+//! pattern so the committed `tests/platform/teensy41/` fixture stays untouched
+//! and no scratch artifacts land in the repo.
+//!
+//! Run with:
+//! `uv run soldr cargo test -p fbuild-build --release --test teensy41_acceptance \
+//!     -- --ignored teensy41_cold_library_selection_meets_205_ac6 --nocapture`
+//!
+//! Marked `#[ignore]` because it downloads Teensyduino on the first run
+//! (cached after) — too heavy for default `cargo test`.
+
+use std::time::Instant;
+
+use fbuild_library_select::resolve;
+use fbuild_packages::library::TeensyCores;
+use fbuild_packages::Package;
+
+#[test]
+#[ignore = "downloads Teensyduino + arm-gcc; CI-only"]
+fn teensy41_cold_library_selection_meets_205_ac6() {
+    // Inline tempdir project — same root-cause-isolation pattern as
+    // stm32_acceptance.rs / teensy30_acceptance.rs. AC#6 needs only the
+    // sketch on disk; we don't run a full build, only the resolver.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let project_dir = tmp.path();
+
+    std::fs::write(
+        project_dir.join("platformio.ini"),
+        "[env:teensy41]\n\
+         platform = teensy\n\
+         board = teensy41\n\
+         framework = arduino\n",
+    )
+    .unwrap();
+
+    let src_dir = project_dir.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    // Minimal Blink. The resolver only walks #include directives reachable
+    // from this seed, so keeping the sketch tiny mirrors the AC#6 statement
+    // "Cold run of library selection on teensy41 project" — there's no
+    // additional framework-lib reference here, the resolver still has to
+    // load + scan every Teensyduino library to decide they're NOT needed.
+    std::fs::write(
+        src_dir.join("main.ino"),
+        "#include <Arduino.h>\n\
+         void setup() { pinMode(LED_BUILTIN, OUTPUT); }\n\
+         void loop() {\n\
+           digitalWrite(LED_BUILTIN, HIGH);\n\
+           delay(500);\n\
+           digitalWrite(LED_BUILTIN, LOW);\n\
+           delay(500);\n\
+         }\n",
+    )
+    .unwrap();
+
+    // Materialize Teensyduino. Idempotent — cached across runs on the
+    // CI runner once the package has been downloaded once.
+    let teensy_cores = TeensyCores::new(project_dir);
+    let framework_dir =
+        Package::ensure_installed(&teensy_cores).expect("Teensyduino must install for AC#6 gate");
+    println!(
+        "AC#6 teensy41 framework installed at {}",
+        framework_dir.display()
+    );
+
+    // Real teensy41 framework library set (~40 libraries: SPI, Wire,
+    // OctoWS2811, FNET, Snooze, RadioHead, mbedtls, ...). Listing them is
+    // an O(libraries-dir) directory walk; that work is NOT what AC#6
+    // measures, so it happens outside the timed window below.
+    let libraries = teensy_cores.get_framework_libraries();
+    assert!(
+        !libraries.is_empty(),
+        "AC#6: TeensyCores::get_framework_libraries must return at least one \
+         library after install — got 0, which means the Teensyduino install \
+         layout has changed"
+    );
+    println!(
+        "AC#6 teensy41 framework libraries discovered: {}",
+        libraries.len()
+    );
+
+    // Seeds + search paths: match what the teensy orchestrator passes to
+    // resolve() in normal operation. The orchestrator's path
+    // (framework_libs.rs -> resolve_framework_library_sources_from_libraries)
+    // walks the project's src/include/lib roots and uses every source file
+    // as a seed. For AC#6 we just have the single Blink .ino, and the
+    // project search paths are the src/ dir.
+    let seeds = vec![src_dir.join("main.ino")];
+    let search_paths = vec![src_dir.clone(), project_dir.to_path_buf()];
+
+    // Time a SINGLE uncached resolve() — this is what AC#6 measures.
+    let start = Instant::now();
+    let selection = resolve(&seeds, &search_paths, &libraries);
+    let elapsed = start.elapsed();
+    let elapsed_ms = elapsed.as_secs_f64() * 1_000.0;
+
+    println!(
+        "AC#6 cold resolve: {:.2} ms (budget 200.00 ms), selected {} library(ies)",
+        elapsed_ms,
+        selection.required_libraries.len()
+    );
+
+    assert!(
+        elapsed_ms <= 200.0,
+        "AC#6: cold resolve must finish in <= 200 ms; got {:.2} ms",
+        elapsed_ms
+    );
+}


### PR DESCRIPTION
Closes the last unmet acceptance criterion of #205. With this merge, all six ACs are CI-enforced and #205 can close.

## AC#6 verbatim from the #205 issue body

> 6. Cold run of library selection on `teensy41` project <= 200 ms on a typical CI runner.

## Summary

- New integration test `teensy41_cold_library_selection_meets_205_ac6` in `crates/fbuild-build/tests/teensy41_acceptance.rs` materializes a real Teensyduino install via `fbuild_packages::library::TeensyCores::ensure_installed`, lists its 92 bundled framework libraries with `get_framework_libraries`, and times a single uncached `fbuild_library_select::resolve(seeds, search_paths, libraries)` call against a teensy41 Blink fixture.
- Asserts `elapsed_ms <= 200.0` with a clear panic message; emits the timing on stdout so the CI log records it.
- Wired into `.github/workflows/acceptance-205.yml` as a fourth matrix entry; the same workflow already covers AC#1 (teensyLC), AC#2 (teensy30 AnalogOutput), and AC#4 (stm32f103c8 SPI).
- Uses the inline-tempdir pattern from `stm32_acceptance.rs` / `teensy30_acceptance.rs` — no committed fixture, no scratch artifacts in the repo.

## TDD walkthrough

### RED — assertion mechanism proven

Temporarily tightened the threshold to `0.001 ms` and ran:

```
uv run soldr cargo test -p fbuild-build --release --test teensy41_acceptance \
    -- --ignored teensy41_cold_library_selection_meets_205_ac6 --nocapture
```

Output:
```
AC#6 teensy41 framework installed at C:\Users\niteris\.fbuild\prod\cache\platforms\dl-framework-arduinoteensy-1.160.0\1b0675c97b0fd8d7\1.160.0
AC#6 teensy41 framework libraries discovered: 92
AC#6 cold resolve: 11.09 ms (budget 200.00 ms), selected 0 library(ies)
thread 'teensy41_cold_library_selection_meets_205_ac6' panicked at crates\fbuild-build\tests\teensy41_acceptance.rs:126:5:
AC#6: cold resolve must finish in <= 200 ms; got 11.09 ms
test teensy41_cold_library_selection_meets_205_ac6 ... FAILED
```

Panic format matches the spec; the assertion mechanism works.

### GREEN — restored threshold passes

Restored the threshold to `200.0` and reran the same command:

```
AC#6 teensy41 framework installed at C:\Users\niteris\.fbuild\prod\cache\platforms\dl-framework-arduinoteensy-1.160.0\1b0675c97b0fd8d7\1.160.0
AC#6 teensy41 framework libraries discovered: 92
AC#6 cold resolve: 11.36 ms (budget 200.00 ms), selected 0 library(ies)
test teensy41_cold_library_selection_meets_205_ac6 ... ok
```

**Measured cold time: 11.36 ms — ~17.6x headroom under the 200 ms budget.** Plenty of margin for slower CI runners and growth in the Teensyduino library set.

## Files changed

| File | LOC | Purpose |
|------|-----|---------|
| `crates/fbuild-build/tests/teensy41_acceptance.rs` | +130 | New integration test for AC#6 |
| `.github/workflows/acceptance-205.yml` | +4 | Add `teensy41 cold resolver` matrix entry + path filter |

## #205 AC status after this PR

| AC | Contract | Gate test | Status |
|----|----------|-----------|--------|
| AC#1 | teensyLC `.bss <= 3 KB` + no FNET/Snooze/RadioHead/mbedtls | `teensylc_blink_meets_205_acceptance_criteria` | CI-enforced |
| AC#2 | teensy30 AnalogOutput `.dmabuffers <= 1 KB` | `teensy30_analog_output_meets_205_ac2` | CI-enforced |
| AC#3 | Pass-2 reconciliation logic | unit tests in `library-select` | CI-enforced |
| AC#4 | stm32f103c8 auto-discovers SPI | `stm32f103c8_blink_with_spi_auto_discovers_library_205_ac4` | CI-enforced |
| AC#5 | Warm cache hit <= 50 ms (bench-fastled-examples) | `bench-fastled-examples` Phase 7 | CI-enforced |
| AC#6 | Cold resolve on teensy41 <= 200 ms | `teensy41_cold_library_selection_meets_205_ac6` (this PR) | CI-enforced after merge |

Closes #205

## Test plan

- [ ] `bench-205.yml` / `acceptance-205.yml` runs on this PR and the new `teensy41 cold resolver` matrix entry passes on Ubuntu CI
- [ ] Pre-existing acceptance gates (teensyLC, teensy30, stm32) remain green
- [ ] Clippy `-D warnings` clean on `fbuild-build` (verified locally)

Generated with [Claude Code](https://claude.com/claude-code)