### PR TITLE
test(build): #231 hermetic regression gate for #147 cache-survives-tar-extract DoD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/fbuild-build/Cargo.toml
+++ b/crates/fbuild-build/Cargo.toml
@@ -28,3 +28,4 @@ tempfile = { workspace = true }
 [dev-dependencies]
 filetime = { workspace = true }
 fbuild-test-support = { path = "../fbuild-test-support" }
+tar = { workspace = true }

--- a/crates/fbuild-build/tests/cache_survives_tar_extract.rs
+++ b/crates/fbuild-build/tests/cache_survives_tar_extract.rs
@@ -1,0 +1,193 @@
+//! Hermetic regression gate for #147 (cache must survive tar-extract / cross-runner restore).
+//!
+//! These tests pin the invariants whose union closes #147:
+//!   * `hash_watch_set_stamps` is **content-derived**, not mtime-derived.
+//!   * `relative_path_for_hash` keeps absolute workspace paths out of the hash.
+//!   * `build_rebuild_signature` substitutes `compiler_identity` for the raw compiler path.
+//!
+//! If any of these regresses, this suite turns RED with a clear signal (instead of the
+//! bench-fastled-examples warm-rebuild gate going slow on the next AC run).
+
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use filetime::{set_file_mtime, FileTime};
+use tar::{Archive, Builder};
+use tempfile::TempDir;
+
+use fbuild_build::build_fingerprint::hash_watch_set_stamps;
+use fbuild_build::compiler::build_rebuild_signature;
+use fbuild_build::zccache::FingerprintWatch;
+
+const SOURCES: &[(&str, &str)] = &[
+    (
+        "src/main.cpp",
+        "#include <Arduino.h>\n#include \"foo.h\"\nvoid setup() { foo(); }\nvoid loop() {}\n",
+    ),
+    (
+        "src/foo.cpp",
+        "#include \"foo.h\"\nvoid foo() { /* deterministic */ }\n",
+    ),
+    ("src/foo.h", "#pragma once\nvoid foo();\n"),
+];
+
+fn populate_project(root: &Path) {
+    for (rel, body) in SOURCES {
+        let dest = root.join(rel);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(dest, body).unwrap();
+    }
+}
+
+fn make_watch(cache_dir: &Path, root: &Path) -> FingerprintWatch {
+    FingerprintWatch {
+        cache_file: cache_dir.join("fingerprint"),
+        root: root.to_path_buf(),
+        extensions: vec!["cpp".to_string(), "h".to_string()],
+        excludes: vec![],
+    }
+}
+
+fn tar_directory(root: &Path) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    builder.append_dir_all("proj", root).unwrap();
+    builder.into_inner().unwrap()
+}
+
+fn untar_into(bytes: &[u8], dest: &Path) {
+    fs::create_dir_all(dest).unwrap();
+    let mut archive = Archive::new(Cursor::new(bytes));
+    archive.set_preserve_mtime(false);
+    archive.unpack(dest).unwrap();
+}
+
+/// Force every regular file under `root` to a known mtime distinct from the source tree.
+/// Models what a CI tar-extract / cross-runner restore looks like in practice: mtimes
+/// either come back as "now" or are stamped with the cache restore time, never matching
+/// the original build mtimes. If a future change re-introduces mtime into the watch hash,
+/// this guarantees the two hashes diverge instead of accidentally matching.
+fn stomp_mtimes(root: &Path, mtime: FileTime) {
+    for entry in walkdir::WalkDir::new(root).into_iter().flatten() {
+        if entry.file_type().is_file() {
+            set_file_mtime(entry.path(), mtime).unwrap();
+        }
+    }
+}
+
+fn file_mtime(path: &Path) -> SystemTime {
+    fs::metadata(path).unwrap().modified().unwrap()
+}
+
+#[test]
+fn fingerprint_survives_tar_roundtrip() {
+    let proj_a = TempDir::new().unwrap();
+    let cache_a = TempDir::new().unwrap();
+    populate_project(proj_a.path());
+    let watch_a = make_watch(cache_a.path(), proj_a.path());
+    let hash_a = hash_watch_set_stamps(std::slice::from_ref(&watch_a)).unwrap();
+
+    let tarball = tar_directory(proj_a.path());
+    let unpack_root = TempDir::new().unwrap();
+    untar_into(&tarball, unpack_root.path());
+    let proj_b = unpack_root.path().join("proj");
+
+    let stomped = FileTime::from_unix_time(1_577_836_800, 0); // 2020-01-01 UTC
+    stomp_mtimes(&proj_b, stomped);
+
+    let mtime_a = file_mtime(&proj_a.path().join("src/main.cpp"));
+    let mtime_b = file_mtime(&proj_b.join("src/main.cpp"));
+    assert_ne!(
+        mtime_a, mtime_b,
+        "test setup invariant: extracted tree must have different mtimes than source \
+         (otherwise we cannot prove mtime is excluded from the hash)"
+    );
+
+    let cache_b = TempDir::new().unwrap();
+    let watch_b = make_watch(cache_b.path(), &proj_b);
+    let hash_b = hash_watch_set_stamps(std::slice::from_ref(&watch_b)).unwrap();
+
+    assert_eq!(
+        hash_a, hash_b,
+        "watch-set hash regressed: mtime or some other non-content input leaked into the hash. \
+         See crates/fbuild-build/src/build_fingerprint/mod.rs::hash_watch_set_stamps_inner."
+    );
+}
+
+#[test]
+fn fingerprint_survives_workspace_relocation() {
+    let proj_a = TempDir::new().unwrap();
+    let cache_a = TempDir::new().unwrap();
+    populate_project(proj_a.path());
+    let watch_a = make_watch(cache_a.path(), proj_a.path());
+    let hash_a = hash_watch_set_stamps(std::slice::from_ref(&watch_a)).unwrap();
+
+    let tarball = tar_directory(proj_a.path());
+
+    let different_parent = TempDir::new().unwrap();
+    let unpack_root = different_parent
+        .path()
+        .join("nested")
+        .join("run-c")
+        .join("deeper");
+    fs::create_dir_all(&unpack_root).unwrap();
+    untar_into(&tarball, &unpack_root);
+    let proj_c = unpack_root.join("proj");
+
+    stomp_mtimes(&proj_c, FileTime::from_unix_time(1_609_459_200, 0)); // 2021-01-01 UTC
+
+    assert_ne!(
+        proj_a.path().parent(),
+        proj_c.parent(),
+        "test setup invariant: extracted project must live under a different parent path"
+    );
+
+    let cache_c = TempDir::new().unwrap();
+    let watch_c = make_watch(cache_c.path(), &proj_c);
+    let hash_c = hash_watch_set_stamps(std::slice::from_ref(&watch_c)).unwrap();
+
+    assert_eq!(
+        hash_a, hash_c,
+        "watch-set hash regressed: absolute workspace path leaked into the hash. \
+         See crates/fbuild-build/src/build_fingerprint/mod.rs::relative_path_for_hash."
+    );
+}
+
+#[test]
+fn compiler_signature_survives_toolchain_path_change() {
+    let toolchain_a = TempDir::new().unwrap();
+    let toolchain_b = TempDir::new().unwrap();
+
+    let compiler_filename = if cfg!(windows) { "gcc.exe" } else { "gcc" };
+    let path_a: PathBuf = toolchain_a.path().join(compiler_filename);
+    let path_b: PathBuf = toolchain_b.path().join(compiler_filename);
+    assert_ne!(
+        path_a, path_b,
+        "test setup invariant: the two compiler paths must differ as absolute path strings"
+    );
+
+    let flags = vec!["-O2".to_string(), "-DFOO=1".to_string()];
+    let pre_flags = vec!["-Wall".to_string()];
+    let extra_flags = vec!["-I/some/include".to_string()];
+
+    let sig_a = build_rebuild_signature(&path_a, &flags, &pre_flags, &extra_flags);
+    let sig_b = build_rebuild_signature(&path_b, &flags, &pre_flags, &extra_flags);
+
+    assert_eq!(
+        sig_a, sig_b,
+        "build_rebuild_signature regressed: absolute compiler path leaked into the signature. \
+         See crates/fbuild-build/src/compiler.rs::compiler_identity."
+    );
+
+    let alt_filename = if cfg!(windows) { "clang.exe" } else { "clang" };
+    let path_c = toolchain_a.path().join(alt_filename);
+    let sig_c = build_rebuild_signature(&path_c, &flags, &pre_flags, &extra_flags);
+    assert_ne!(
+        sig_a, sig_c,
+        "build_rebuild_signature collapsed two different compilers to the same signature; \
+         compiler_identity must still distinguish on file stem."
+    );
+}


### PR DESCRIPTION
## Summary

Closes #231. Adds the hermetic regression gate called out in the issue: a three-case integration test that pins the invariants whose union closed #147.

- `fingerprint_survives_tar_roundtrip` — tar a project, extract into a fresh location, stomp mtimes, assert `hash_watch_set_stamps` returns the same hash. Catches any future change that re-introduces mtime into the watch hash.
- `fingerprint_survives_workspace_relocation` — extract under a different parent directory; assert the hash is unchanged. Pins the `relative_path_for_hash` invariant against absolute-path leakage.
- `compiler_signature_survives_toolchain_path_change` — two compiler paths with the same filename produce identical `build_rebuild_signature`s; a third with a different filename produces a distinct one. Pins the `compiler_identity` substitution at `compiler.rs:307`.

Together with commit 2e8bc4c (AC#5 ≤ 50 ms warm threshold in `bench-fastled-examples`), this gives #147 both an empirical speed gate and a hermetic correctness gate.

The tests pass on `main` today — the fixes are already in tree. Their job is to turn RED instead of silently going slow on the next AC run if anyone re-introduces mtime or absolute paths into the fingerprint contract.

## Test plan

- [x] `uv run --script ci/test.py -p fbuild-build --test cache_survives_tar_extract` — all 3 pass locally
- [x] `uv run --script ci/test.py -p fbuild-build` — full crate suite passes (acceptance tests `ignored` as expected for CI-only)
- [x] `uv run soldr cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added regression tests to ensure build cache fingerprinting remains stable across project extraction, relocation to different directories, and varying toolchain paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->