### PR TITLE
fix(build): #234 use @response file for teensy link on Windows

### DIFF
--- a/crates/fbuild-build/src/teensy/teensy_linker.rs
+++ b/crates/fbuild-build/src/teensy/teensy_linker.rs
@@ -101,8 +101,23 @@ impl Linker for TeensyLinker {
             tracing::info!("link: {}", args.join(" "));
         }
 
-        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        let result = run_command(&args_ref, None, None, None)?;
+        // On Windows, use a response file to avoid command-line length limits
+        // (teensy41 produces ~500 .o files; see issue #234).
+        let result = if cfg!(windows) && args.len() > 50 {
+            let temp_dir = output_dir.join("tmp");
+            std::fs::create_dir_all(&temp_dir)?;
+            let rsp_content: Vec<String> = args[1..].iter().map(|a| a.replace('\\', "/")).collect();
+            let rsp_path = fbuild_core::response_file::write_response_file(
+                &rsp_content,
+                &temp_dir,
+                "teensy_link",
+            )?;
+            let rsp_arg = format!("@{}", rsp_path.display());
+            run_command(&[args[0].as_str(), &rsp_arg], None, None, None)?
+        } else {
+            let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+            run_command(&args_ref, None, None, None)?
+        };
 
         if !result.success() {
             return Err(fbuild_core::FbuildError::BuildFailed(format!(


### PR DESCRIPTION
## Summary

Closes #234.

- Teensy boards (notably `teensy41` with ~500 `.o` files) exceeded Windows' ~32 KB `CreateProcessW` cmdline limit at link time, failing with `io error: The filename or extension is too long. (os error 206)`.
- Linux (~128 KB) and macOS (~256 KB) absorbed the same cmdline, so CI (Ubuntu) was green while Windows developers were blocked.
- `ArmLinker` (STM32/RP2040/NRF52) and `Esp32Linker` already use GCC `@response` files for the link step on Windows. `TeensyLinker` was the outlier.
- This PR mirrors the existing `ArmLinker` pattern in `crates/fbuild-build/src/teensy/teensy_linker.rs`: when `cfg!(windows) && args.len() > 50`, write the linker args to `output_dir/tmp/fbuild_teensy_link_<hash>.rsp` via the shared `fbuild_core::response_file::write_response_file`, then invoke `arm-none-eabi-gcc @<rsp>`. Linux/macOS keep the direct invocation.

No new utilities, no behavior change for small sketches, no change to the existing Teensy integration test (`crates/fbuild-build/tests/teensy_build.rs`).

## Test plan

- [x] `uv run soldr cargo fmt --all`
- [x] `uv run soldr cargo check --workspace --all-targets`
- [x] `uv run soldr cargo clippy -p fbuild-build --all-targets -- -D warnings`
- [x] `uv run soldr cargo test -p fbuild-build --lib` (499 passed)
- [ ] Manual Windows repro: `bash compile teensy41 --examples Blink` against a FastLED checkout produces `firmware.elf` and a `.fbuild/build/teensy41/release/tmp/fbuild_teensy_link_*.rsp` file. (Best verified post-merge in CI/local Windows; companion FastLED PR for the section-conflict compile error is still needed to actually reach the link step on that branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows build failures when linker argument lists exceed typical command-line limits. The build system now automatically uses a response file mechanism to handle complex linking scenarios, ensuring reliable compilation on Windows platforms regardless of project complexity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/235)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->