### PR TITLE
perf(library-select): #236 parallel BFS walker + scan memoization + tracing spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,9 @@ name = "fbuild-header-scan"
 version = "2.2.3"
 dependencies = [
  "criterion",
+ "rayon",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -1013,6 +1015,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tracing",
+ "tracing-test",
  "walkdir",
  "zccache-artifact",
 ]
@@ -3358,6 +3361,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 shell-words = "1"
 bincode = "1"
 zccache-artifact = "1.4.0"
+rayon = "1"
+tracing-test = "0.2"
 
 # Process containment: all subprocess spawns the daemon performs (compilers,
 # esptool, qemu, simavr, node, npm, …) and any grandchildren they fork must

--- a/crates/fbuild-header-scan/Cargo.toml
+++ b/crates/fbuild-header-scan/Cargo.toml
@@ -7,6 +7,8 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+rayon = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/fbuild-header-scan/src/lib.rs
+++ b/crates/fbuild-header-scan/src/lib.rs
@@ -10,7 +10,7 @@ mod scanner;
 mod walker;
 
 pub use scanner::{scan, IncludeKind, IncludeRef, Span};
-pub use walker::{walk, WalkResult};
+pub use walker::{walk, walk_with_state, WalkResult, WalkState};
 
 /// Bumped whenever the scanner output shape changes. Mixed into cache keys so a
 /// scanner change invalidates memoized library-selection results.

--- a/crates/fbuild-header-scan/src/walker.rs
+++ b/crates/fbuild-header-scan/src/walker.rs
@@ -5,18 +5,71 @@
 //! plus the set of include strings that could not be resolved. The walker is
 //! BFS over a visited set so cycles, diamonds, and arbitrary depth all
 //! terminate correctly.
+//!
+//! Two public entry points:
+//! * [`walk`] -- one-shot convenience wrapper that allocates a fresh
+//!   [`WalkState`] internally. `WalkResult::reached` is the full set of files
+//!   reached from `seeds`.
+//! * [`walk_with_state`] -- accepts a caller-owned [`WalkState`] so multiple
+//!   walks can share a scan cache and a `visited` set across calls (used by
+//!   `fbuild-library-select` to avoid re-reading files between LDF passes).
+//!   `WalkResult::reached` is the *delta* of canonical paths newly discovered
+//!   in this call; the union of deltas across calls equals the full set.
 
-use std::collections::{BTreeSet, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
+
+use rayon::prelude::*;
 
 use crate::scanner::{scan, IncludeKind, IncludeRef};
 
 /// Result of a walk. `reached` and `unresolved` are sorted for deterministic
 /// cache keys.
+///
+/// For [`walk`] (fresh-state wrapper) `reached` is the full set of files
+/// transitively reached from the seeds. For [`walk_with_state`] the same
+/// fields contain only the *delta* added in this call -- files already
+/// present in the shared `WalkState::visited` set are not re-emitted.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct WalkResult {
     pub reached: Vec<PathBuf>,
     pub unresolved: Vec<String>,
+}
+
+/// State that can be shared across multiple [`walk_with_state`] calls so the
+/// include-scan results are memoized and each on-disk file is read at most
+/// once for the lifetime of the state.
+///
+/// Used by `fbuild-library-select::resolve_with_stats` to share scan results
+/// across LDF passes -- pass 1 reads every file once, pass 2 re-seeds with
+/// library `.cpp` files but reuses the cached scans for everything already
+/// reached.
+#[derive(Debug, Default)]
+pub struct WalkState {
+    /// Canonical paths the walker has already enqueued/visited.
+    visited: HashSet<PathBuf>,
+    /// Canonical path -> parsed include list. Populated lazily on first read.
+    /// Missing entries mean either "not yet read" or "read failed" -- they are
+    /// indistinguishable here, matching the existing `let Ok(...) else
+    /// { continue }` semantics of the original walker.
+    scan_cache: HashMap<PathBuf, Vec<IncludeRef>>,
+    /// Number of successful `std::fs::read_to_string` invocations across the
+    /// lifetime of this state. Each unique file is counted exactly once
+    /// because subsequent walks hit `scan_cache` instead.
+    files_read: usize,
+}
+
+impl WalkState {
+    /// Create an empty state. No files have been scanned, nothing is visited.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of files physically read from disk so far. Used by
+    /// `resolve_with_stats` to assert the no-re-read contract in tests.
+    pub fn files_read(&self) -> usize {
+        self.files_read
+    }
 }
 
 /// Walk the include graph starting from `seeds` over `search_paths`.
@@ -26,35 +79,95 @@ pub struct WalkResult {
 /// A file is added to `reached` exactly once. Files outside `search_paths`
 /// are still reached if they are seeds or `"..."`-resolved relative to a
 /// seed/visited file.
+///
+/// Allocates a fresh [`WalkState`] internally, so `WalkResult::reached`
+/// contains every file transitively reached from `seeds`.
 pub fn walk(seeds: &[PathBuf], search_paths: &[PathBuf]) -> WalkResult {
+    let mut state = WalkState::new();
+    walk_with_state(seeds, search_paths, &mut state)
+}
+
+/// Walk the include graph using a caller-owned [`WalkState`] so the scan cache
+/// and visited set persist across calls.
+///
+/// `WalkResult::reached` contains only the *delta* of canonical paths newly
+/// reached in this call. Files already in `state.visited` from a previous
+/// call are not re-emitted (and not re-read).
+///
+/// The BFS proceeds in waves: each wave reads all not-yet-cached files in
+/// parallel via rayon, then resolves every `#include` in every cached scan
+/// result to enqueue the next wave.
+#[tracing::instrument(
+    name = "ldf_walk",
+    skip_all,
+    fields(seeds = seeds.len(), search_paths = search_paths.len())
+)]
+pub fn walk_with_state(
+    seeds: &[PathBuf],
+    search_paths: &[PathBuf],
+    state: &mut WalkState,
+) -> WalkResult {
+    tracing::debug!(
+        seeds = seeds.len(),
+        search_paths = search_paths.len(),
+        "ldf_walk"
+    );
     let mut reached: BTreeSet<PathBuf> = BTreeSet::new();
     let mut unresolved: BTreeSet<String> = BTreeSet::new();
-    let mut visited: HashSet<PathBuf> = HashSet::new();
-    let mut queue: VecDeque<PathBuf> = VecDeque::new();
+    let mut frontier: VecDeque<PathBuf> = VecDeque::new();
 
     for seed in seeds {
         let canon = canon(seed);
-        if visited.insert(canon.clone()) {
-            queue.push_back(canon.clone());
+        if state.visited.insert(canon.clone()) {
+            frontier.push_back(canon.clone());
             reached.insert(canon);
         }
     }
 
-    while let Some(file) = queue.pop_front() {
-        let Ok(text) = std::fs::read_to_string(&file) else {
-            continue;
-        };
-        for inc in scan(&text) {
-            match resolve(&inc, &file, search_paths) {
-                Some(resolved) => {
-                    let canon = canon(&resolved);
-                    if visited.insert(canon.clone()) {
-                        reached.insert(canon.clone());
-                        queue.push_back(canon);
+    while !frontier.is_empty() {
+        // Read all not-yet-cached files in the current wave in parallel.
+        let to_read: Vec<PathBuf> = frontier
+            .iter()
+            .filter(|p| !state.scan_cache.contains_key(*p))
+            .cloned()
+            .collect();
+
+        if !to_read.is_empty() {
+            let scanned: Vec<(PathBuf, Vec<IncludeRef>)> = to_read
+                .par_iter()
+                .filter_map(|p| {
+                    let text = std::fs::read_to_string(p).ok()?;
+                    Some((p.clone(), scan(&text)))
+                })
+                .collect();
+
+            for (path, includes) in scanned {
+                state.scan_cache.insert(path, includes);
+                state.files_read += 1;
+            }
+        }
+
+        // Resolve includes for every file in the frontier and build the next
+        // wave from any newly discovered canonical paths.
+        let current: Vec<PathBuf> = frontier.drain(..).collect();
+        for file in &current {
+            let Some(includes) = state.scan_cache.get(file).cloned() else {
+                // Read failed (file is a directory, permission denied, etc.).
+                // Match the existing behavior: silently skip.
+                continue;
+            };
+            for inc in &includes {
+                match resolve_include(inc, file, search_paths) {
+                    Some(resolved) => {
+                        let canon = canon(&resolved);
+                        if state.visited.insert(canon.clone()) {
+                            reached.insert(canon.clone());
+                            frontier.push_back(canon);
+                        }
                     }
-                }
-                None => {
-                    unresolved.insert(inc.path.clone());
+                    None => {
+                        unresolved.insert(inc.path.clone());
+                    }
                 }
             }
         }
@@ -66,7 +179,7 @@ pub fn walk(seeds: &[PathBuf], search_paths: &[PathBuf]) -> WalkResult {
     }
 }
 
-fn resolve(inc: &IncludeRef, from: &Path, search_paths: &[PathBuf]) -> Option<PathBuf> {
+fn resolve_include(inc: &IncludeRef, from: &Path, search_paths: &[PathBuf]) -> Option<PathBuf> {
     if inc.kind == IncludeKind::Quoted {
         if let Some(parent) = from.parent() {
             let candidate = parent.join(&inc.path);

--- a/crates/fbuild-library-select/Cargo.toml
+++ b/crates/fbuild-library-select/Cargo.toml
@@ -20,6 +20,7 @@ zccache-artifact = { workspace = true }
 tempfile = { workspace = true }
 criterion = { workspace = true }
 fbuild-test-support = { path = "../fbuild-test-support" }
+tracing-test = { workspace = true, features = ["no-env-filter"] }
 
 [[bench]]
 name = "resolve_cold"

--- a/crates/fbuild-library-select/src/lib.rs
+++ b/crates/fbuild-library-select/src/lib.rs
@@ -20,13 +20,25 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use fbuild_header_scan::walk;
+use fbuild_header_scan::{walk_with_state, WalkState};
 use fbuild_packages::library::FrameworkLibrary;
 use serde::{Deserialize, Serialize};
 
 pub mod cache;
 
 pub use cache::{cache_key, resolve_cached, CacheKeyInputs, CachedSelection};
+
+/// Stats emitted by [`resolve_with_stats`] for performance assertions and
+/// daemon-side observability. `files_read` is the total number of physical
+/// `std::fs::read_to_string` invocations across all LDF passes within a
+/// single `resolve` call; `passes` is the total pass count (Pass 1 plus
+/// every reconciliation iteration that ran, including the final
+/// no-change iteration that proved convergence).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResolveStats {
+    pub files_read: usize,
+    pub passes: usize,
+}
 
 /// Resolved library selection plus the transitive include closure.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -59,9 +71,27 @@ pub fn resolve(
     project_search_paths: &[PathBuf],
     libraries: &[FrameworkLibrary],
 ) -> Selection {
+    resolve_with_stats(seeds, project_search_paths, libraries).0
+}
+
+/// Same contract as [`resolve`] but also returns [`ResolveStats`] so callers
+/// can observe the number of physical file reads and LDF passes performed.
+///
+/// Internally this is the single implementation; [`resolve`] simply discards
+/// the stats. A shared [`WalkState`] is threaded through every pass so that
+/// any file scanned by Pass 1 is reused (not re-read) by Pass 2's
+/// reconciliation walk. Each pass is wrapped in an `ldf_pass` tracing span;
+/// the walker emits its own `ldf_walk` span per BFS invocation.
+pub fn resolve_with_stats(
+    seeds: &[PathBuf],
+    project_search_paths: &[PathBuf],
+    libraries: &[FrameworkLibrary],
+) -> (Selection, ResolveStats) {
     let mut selected: BTreeSet<usize> = BTreeSet::new();
     let mut all_included: BTreeSet<PathBuf> = BTreeSet::new();
     let mut all_unresolved: BTreeSet<String> = BTreeSet::new();
+    let mut state = WalkState::new();
+    let mut pass_count: usize = 0;
 
     let canon_lib_dirs: Vec<Vec<PathBuf>> = libraries
         .iter()
@@ -83,31 +113,43 @@ pub fn resolve(
     }
 
     // Pass 1: BFS from project seeds.
-    let res = walk(seeds, &full_search_paths);
-    for p in &res.reached {
-        all_included.insert(p.clone());
-    }
-    for u in &res.unresolved {
-        all_unresolved.insert(u.clone());
-    }
-    for (idx, dirs) in canon_lib_dirs.iter().enumerate() {
-        if res.reached.iter().any(|p| path_in_any(p, dirs)) {
-            selected.insert(idx);
+    {
+        let _span = tracing::info_span!("ldf_pass", pass = 1u32).entered();
+        pass_count += 1;
+        tracing::info!(pass = 1u32, "ldf_pass");
+        let res = walk_with_state(seeds, &full_search_paths, &mut state);
+        for p in &res.reached {
+            all_included.insert(p.clone());
+        }
+        for u in &res.unresolved {
+            all_unresolved.insert(u.clone());
+        }
+        for (idx, dirs) in canon_lib_dirs.iter().enumerate() {
+            if res.reached.iter().any(|p| path_in_any(p, dirs)) {
+                selected.insert(idx);
+            }
         }
     }
 
-    // Pass 2: reconciliation. Re-walk with each selected library's full source
-    // set as seeds, in case a lib-to-lib dep is only visible through a `.cpp`
-    // (not a header). Keeps iterating until the selection stabilizes, which for
-    // realistic Arduino-library graphs is 1–2 rounds.
+    // Pass 2+: reconciliation. Re-walk with each selected library's full
+    // source set as seeds, in case a lib-to-lib dep is only visible through a
+    // `.cpp` (not a header). Keeps iterating until the selection stabilizes,
+    // which for realistic Arduino-library graphs is 1–2 rounds. With the
+    // shared `WalkState`, `res.reached` is the *delta* of newly-discovered
+    // files for this pass -- the prefix-match check still works correctly
+    // because a library can only become newly-selected via a path reached for
+    // the first time in this pass.
     loop {
+        pass_count += 1;
+        let _span = tracing::info_span!("ldf_pass", pass = pass_count as u32).entered();
+        tracing::info!(pass = pass_count as u32, "ldf_pass");
         let mut recon_seeds: Vec<PathBuf> = seeds.to_vec();
         for idx in &selected {
             for src in &libraries[*idx].source_files {
                 recon_seeds.push(src.clone());
             }
         }
-        let res = walk(&recon_seeds, &full_search_paths);
+        let res = walk_with_state(&recon_seeds, &full_search_paths, &mut state);
         for p in &res.reached {
             all_included.insert(p.clone());
         }
@@ -147,13 +189,18 @@ pub fn resolve(
     required_libraries.sort();
     required_libraries.dedup();
 
-    Selection {
+    let selection = Selection {
         included_files: all_included.into_iter().collect(),
         required_libraries,
         source_files: source_files.into_iter().collect(),
         include_dirs: include_dirs.into_keys().collect(),
         unresolved: all_unresolved.into_iter().collect(),
-    }
+    };
+    let stats = ResolveStats {
+        files_read: state.files_read(),
+        passes: pass_count,
+    };
+    (selection, stats)
 }
 
 fn canon(p: &Path) -> PathBuf {

--- a/crates/fbuild-library-select/tests/README.md
+++ b/crates/fbuild-library-select/tests/README.md
@@ -1,0 +1,8 @@
+# `fbuild-library-select` integration tests
+
+Tests that exercise the public `resolve()` / `resolve_with_stats()` API end-to-end
+on tempfile-built mini-frameworks. Unit tests live under `src/`.
+
+- `perf_tdd.rs` — gates for #236 (parallel walker + scan memoization + tracing
+  spans). Asserts each reachable file is read exactly once across all passes
+  and that `ldf_pass` / `ldf_walk` spans are emitted.

--- a/crates/fbuild-library-select/tests/perf_tdd.rs
+++ b/crates/fbuild-library-select/tests/perf_tdd.rs
@@ -1,0 +1,122 @@
+//! TDD gates for issue #236 (parallel walker + scan memoization + tracing).
+//!
+//! These tests target the public API contracts that #236 introduces:
+//!
+//! 1. `resolve_with_stats()` exposes a `files_read` counter so we can assert
+//!    that Pass 2's re-walk reuses Pass 1's scan cache instead of re-reading
+//!    every file. Contract: each reachable file is read exactly once across
+//!    all passes within a single `resolve()` call.
+//!
+//! 2. `resolve()` emits `ldf_pass` and `ldf_walk` tracing spans so per-pass
+//!    timing is visible in the daemon log without external profilers.
+
+use std::fs;
+use std::path::Path;
+
+use fbuild_library_select::{resolve, resolve_with_stats};
+use fbuild_packages::library::FrameworkLibrary;
+use tempfile::TempDir;
+use tracing_test::traced_test;
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn make_lib(tmp: &Path, name: &str) -> FrameworkLibrary {
+    let dir = tmp.join("libraries").join(name);
+    let src = dir.join("src");
+    fs::create_dir_all(&src).unwrap();
+    FrameworkLibrary {
+        name: name.to_string(),
+        dir,
+        include_dirs: vec![src],
+        source_files: Vec::new(),
+    }
+}
+
+/// Scenario that forces ≥ 2 passes of LDF reconciliation:
+///   project/main.cpp → <SPI.h>                    (pass 1 selects SPI)
+///   libs/SPI/src/SPI.h                            (silent — pass 1 stops)
+///   libs/SPI/src/SPI.cpp → <Wire.h>               (pass 2 selects Wire)
+///   libs/Wire/src/Wire.{h,cpp}                    (pass 3 converges)
+///
+/// Without memoization, every pass re-reads main.cpp + SPI.h. With the
+/// `WalkState`-shared scan cache, each file is read exactly once.
+#[test]
+fn pass2_reuses_pass1_scan_results_no_re_reads() {
+    let tmp = TempDir::new().unwrap();
+    let project_src = tmp.path().join("project").join("src");
+    let main = project_src.join("main.cpp");
+    write(&main, "#include <SPI.h>\n");
+
+    let mut spi = make_lib(tmp.path(), "SPI");
+    write(&spi.include_dirs[0].join("SPI.h"), "// silent\n");
+    let spi_cpp = spi.include_dirs[0].join("SPI.cpp");
+    write(&spi_cpp, "#include <Wire.h>\n");
+    spi.source_files.push(spi_cpp);
+
+    let mut wire = make_lib(tmp.path(), "Wire");
+    write(&wire.include_dirs[0].join("Wire.h"), "// empty\n");
+    let wire_cpp = wire.include_dirs[0].join("Wire.cpp");
+    write(&wire_cpp, "// empty\n");
+    wire.source_files.push(wire_cpp);
+
+    let seeds = vec![main];
+    let (selection, stats) = resolve_with_stats(&seeds, &[project_src], &[spi, wire]);
+
+    assert_eq!(
+        selection.required_libraries,
+        vec!["SPI".to_string(), "Wire".to_string()],
+        "two-pass reconciliation must select both SPI and Wire"
+    );
+    assert!(
+        stats.passes >= 2,
+        "scenario must require at least 2 passes (got passes={})",
+        stats.passes
+    );
+
+    // The contract: each reachable file is physically read exactly once
+    // across all passes inside a single `resolve()` call. files_read counts
+    // std::fs::read_to_string invocations; included_files contains every
+    // unique reached file. With memoization they are equal.
+    assert_eq!(
+        stats.files_read,
+        selection.included_files.len(),
+        "each reachable file must be read exactly once across all passes \
+         (files_read={}, included_files.len()={})",
+        stats.files_read,
+        selection.included_files.len()
+    );
+}
+
+/// `resolve()` must wrap its walks in tracing spans so per-pass timing is
+/// observable. The walker also emits its own `ldf_walk` span around each
+/// BFS invocation.
+#[traced_test]
+#[test]
+fn resolve_emits_ldf_pass_and_ldf_walk_spans() {
+    let tmp = TempDir::new().unwrap();
+    let project_src = tmp.path().join("project").join("src");
+    write(&project_src.join("main.cpp"), "#include <SPI.h>\n");
+
+    let mut spi = make_lib(tmp.path(), "SPI");
+    write(&spi.include_dirs[0].join("SPI.h"), "");
+    let spi_cpp = spi.include_dirs[0].join("SPI.cpp");
+    write(&spi_cpp, "");
+    spi.source_files.push(spi_cpp);
+
+    let seeds = vec![project_src.join("main.cpp")];
+    let _ = resolve(&seeds, &[project_src], &[spi]);
+
+    assert!(
+        logs_contain("ldf_pass"),
+        "expected ldf_pass span/event in tracing capture",
+    );
+    assert!(
+        logs_contain("ldf_walk"),
+        "expected ldf_walk span/event in tracing capture",
+    );
+}


### PR DESCRIPTION
## Summary

Closes #236 (proposals A, B, C).

The LDF resolver shipped under #205 was correct, but the cold scan left real performance on the table:
- The walker was single-threaded BFS — one `std::fs::read_to_string` at a time.
- Pass 2's reconciliation walk re-read every file Pass 1 already touched, because the `visited` set was local to each `walk()` invocation.
- No `tracing` spans, so per-pass regressions were invisible without external profiling.

This PR closes all three.

### TDD process (RED → GREEN)

Two failing tests went in first (`crates/fbuild-library-select/tests/perf_tdd.rs`):

- `pass2_reuses_pass1_scan_results_no_re_reads` — builds a scenario where Wire is only reachable through SPI.cpp (forces a 2-pass reconciliation), then asserts `files_read == included_files.len()`. Without memoization this assertion fails by a factor of ~2×.
- `resolve_emits_ldf_pass_and_ldf_walk_spans` — uses `tracing-test::traced_test` to confirm both span names appear in the captured log.

Both tests failed to compile against `main` (no `resolve_with_stats`, no `WalkState`) — that's the RED gate. The implementation that follows makes them pass.

### Implementation

**`fbuild-header-scan`**

- New `WalkState { visited, scan_cache, files_read }` and `walk_with_state(seeds, search_paths, &mut state)`.
- BFS proceeds in waves: each wave reads not-yet-cached files in parallel via `rayon::par_iter().filter_map(...).collect()`, merges them serially into the scan cache + bumps `files_read`, then resolves every include and queues the next wave.
- `walk()` stays a thin wrapper around a fresh state for one-shot callers — all 8 existing walker tests pass unchanged.
- `walk_with_state` carries a `#[tracing::instrument(name = \"ldf_walk\", ...)]` attribute.

**`fbuild-library-select`**

- New `ResolveStats { files_read, passes }` and `resolve_with_stats()`. `resolve()` now delegates to `resolve_with_stats(...).0`.
- A single `WalkState` is threaded through Pass 1 and the reconciliation loop. Each pass runs inside an `info_span!(\"ldf_pass\", pass = N)`.
- Library-attribution against the per-pass delta is equivalent to the old full-set check, because a library can only become newly-selected via a path reached for the *first* time in this pass — paths reached in earlier passes already had their lib-attribution chance.

### Measured performance

`uv run soldr cargo bench -p fbuild-library-select -- --quick`:

| Bench | Δ time | Δ throughput |
|---|---|---|
| `resolve/cold_30_libs_chain_5` | **-35.4 %** (3.27 ms) | **+54.8 %** |
| `resolve/warm_30_libs_chain_5` | **-26.7 %** (1.17 ms) | **+36.5 %** |

Cold-resolve gain is dominated by parallel file reads + the deduplicated Pass 1/Pass 2 scans; warm-resolve gain comes from the faster cache-key construction path that benefits from the same memoization.

### Test plan

- [x] `uv run soldr cargo test -p fbuild-library-select --test perf_tdd` (2 passed — the new TDD gates)
- [x] `uv run soldr cargo test -p fbuild-header-scan -p fbuild-library-select` (51 + 19 passed — full existing coverage)
- [x] `uv run soldr cargo test -p fbuild-build --lib` (499 passed — orchestrator consumers)
- [x] `uv run soldr cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `uv run soldr cargo fmt --all` (clean)
- [x] `uv run soldr cargo bench -p fbuild-library-select -- --quick` (35% / 27% improvements documented above)
- [ ] Production cold-scan measurement on a real teensy41 FastLED project (best done by hand or in a follow-up after merge — would also let us tune AC#1 `≤ 100 ms` from #236).

### Out of scope (deferred to follow-up issues)

- **Proposal D** — header-name precompute index for the search-path scan.
- **Proposal E** — CI gates that fail PRs on `resolve_cold` / `scan_throughput` regressions (the benches exist; only the workflow wiring is missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stateful header scanning API with memoized file caching for improved performance across multiple passes.
  * Introduced resolver statistics reporting to track file reads and pass counts.

* **Documentation**
  * Added test documentation for integration test scope and performance gates.

* **Tests**
  * Added performance and contract verification tests for multi-pass resolution and tracing observability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/237)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->