### PR TITLE
bench iter8b: cache fastled/.venv to cut warm uv_sync from 22s to <5s

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -234,6 +234,7 @@ jobs:
           paths=()
           for p in "$HOME/.fbuild" "$HOME/.fastled/global_cache" \
                    "$GITHUB_WORKSPACE/fastled/.build/pio/${BENCH_BOARD}" \
+                   "$GITHUB_WORKSPACE/fastled/.venv" \
                    "${ZCCACHE_CACHE_DIR}"; do
             if [ -d "$p" ]; then paths+=("$p"); fi
           done
@@ -241,7 +242,11 @@ jobs:
             echo "no cache dirs to pack" >&2
             exit 1
           fi
-          tar --use-compress-program='zstd -T0 -3' -cPf "$BENCH_CACHE_TARBALL" "${paths[@]}"
+          # --dereference: follow Python interpreter symlinks in fastled/.venv so
+          # the restored venv carries its own bin/python copy and survives across
+          # runs where actions/setup-python may pick a different interpreter path
+          # (see #239).
+          tar --dereference --use-compress-program='zstd -T0 -3' -cPf "$BENCH_CACHE_TARBALL" "${paths[@]}"
           t1=$(date +%s.%N)
           printf 'pack_cache\t%.3f\n' "$(awk "BEGIN{print $t1-$t0}")" >> "$BENCH_TIMINGS"
           ls -lh "$BENCH_CACHE_TARBALL"


### PR DESCRIPTION
## Summary

Adds `fastled/.venv` to the warm-cache tarball packed by the benchmark workflow.

**Hypothesis (from #239):** `uv_sync` is the second-largest phase in iter7 timings, costing ~22s on every warm run because the cache tarball does NOT pack the resolved virtual environment. Packing `fastled/.venv` lets `uv sync` short-circuit when the lockfile matches, dropping the phase to sub-second.

| phase | iter7 cold | iter7 warm | iter8b expected |
|---|---:|---:|---:|
| uv_sync | 22.34s | 22.35s | ~3s |

## Diff

One file (`.github/workflows/benchmark.yml`):

- Add `$GITHUB_WORKSPACE/fastled/.venv` to the `paths` array in the "Phase - pack cache tarball" step.
- Add `--dereference` to the `tar` invocation so the Python interpreter symlinks inside `.venv` materialize as real files, defending against `actions/setup-python` picking a different interpreter path between runs.

The "Phase - warm restore from prior artifact" step already uses `tar -xPf` with absolute paths, so it restores `.venv` to the expected `fastled/.venv` location without modification.

## Acceptance gates (validated by next bench-workflow run after merge)

- [ ] Warm `uv_sync` ≤ 5s
- [ ] No new failure mode in the compile phase from a stale venv
- [ ] Tarball compressed size ≤ 200 MB (issue estimates 100–150 MB)
- [ ] Cold-run timings unchanged

Closes #239