### PR TITLE
feat(cli): #242 fbuild ci — PlatformIO-compatible alias for compile-many

### DIFF
--- a/crates/fbuild-build/src/compile_many.rs
+++ b/crates/fbuild-build/src/compile_many.rs
@@ -105,6 +105,10 @@ pub struct CompileManyRequest {
     pub profile: BuildProfile,
     /// Verbose compiler output.
     pub verbose: bool,
+    /// `PLATFORMIO_*` env-var overlay forwarded to each per-sketch
+    /// `BuildParams.pio_env`. Empty by default. Used by `fbuild ci` to
+    /// surface `--lib` / `--project-conf` to the underlying orchestrator.
+    pub pio_env: HashMap<String, String>,
 }
 
 /// Result for a single sketch.
@@ -219,20 +223,22 @@ fn platform_for_board(board: &str) -> Result<Platform> {
 ///
 /// `jobs` controls intra-build parallelism (passed through to the
 /// orchestrator's per-build thread pool).
-fn build_one_sketch(
-    sketch: &Path,
-    env_name: &str,
-    platform: Platform,
-    profile: BuildProfile,
-    jobs: usize,
-    verbose: bool,
-    stage: Stage,
-) -> SketchResult {
+fn build_one_sketch(inputs: SketchBuildInputs) -> SketchResult {
+    let SketchBuildInputs {
+        sketch,
+        env_name,
+        platform,
+        profile,
+        jobs,
+        verbose,
+        stage,
+        pio_env,
+    } = inputs;
     let start = Instant::now();
-    let build_dir = fbuild_packages::Cache::new(sketch).get_build_dir(env_name, profile);
+    let build_dir = fbuild_packages::Cache::new(&sketch).get_build_dir(&env_name, profile);
     let params = BuildParams {
-        project_dir: sketch.to_path_buf(),
-        env_name: env_name.to_string(),
+        project_dir: sketch.clone(),
+        env_name: env_name.clone(),
         clean: false,
         profile,
         build_dir,
@@ -245,7 +251,7 @@ fn build_one_sketch(
         symbol_analysis_path: None,
         no_timestamp: true,
         src_dir: None,
-        pio_env: Default::default(),
+        pio_env: pio_env.into_iter().collect(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
     };
@@ -266,10 +272,10 @@ fn build_one_sketch(
                 build_log,
                 ..
             } = br;
-            let log_path = write_log_file(sketch, env_name, profile, build_log);
+            let log_path = write_log_file(&sketch, &env_name, profile, build_log);
             SketchResult {
-                sketch: sketch.to_path_buf(),
-                env_name: env_name.to_string(),
+                sketch,
+                env_name,
                 success,
                 firmware_path,
                 elf_path,
@@ -280,8 +286,8 @@ fn build_one_sketch(
             }
         }
         Err(e) => SketchResult {
-            sketch: sketch.to_path_buf(),
-            env_name: env_name.to_string(),
+            sketch,
+            env_name,
             success: false,
             firmware_path: None,
             elf_path: None,
@@ -324,6 +330,8 @@ pub struct SketchBuildInputs {
     pub jobs: usize,
     pub verbose: bool,
     pub stage: Stage,
+    /// `PLATFORMIO_*` env-var overlay forwarded to `BuildParams.pio_env`.
+    pub pio_env: HashMap<String, String>,
 }
 
 /// Trait used by [`compile_many_with`] to run a single sketch. Tests
@@ -340,15 +348,7 @@ pub struct OrchestratorBuilder;
 
 impl SketchBuilder for OrchestratorBuilder {
     fn build(&self, inputs: SketchBuildInputs) -> SketchResult {
-        build_one_sketch(
-            &inputs.sketch,
-            &inputs.env_name,
-            inputs.platform,
-            inputs.profile,
-            inputs.jobs,
-            inputs.verbose,
-            inputs.stage,
-        )
+        build_one_sketch(inputs)
     }
 }
 
@@ -413,6 +413,7 @@ pub fn compile_many_with(
         jobs: framework_jobs,
         verbose: req.verbose,
         stage: Stage::Stage1Framework,
+        pio_env: req.pio_env.clone(),
     });
     let stage1_secs = stage1_start.elapsed().as_secs_f64();
 
@@ -445,6 +446,7 @@ pub fn compile_many_with(
             sketch_jobs,
             req.verbose,
             builder,
+            &req.pio_env,
         )
     };
     let stage2_secs = stage2_start.elapsed().as_secs_f64();
@@ -477,6 +479,7 @@ fn run_stage2(
     sketch_jobs: usize,
     verbose: bool,
     builder: &dyn SketchBuilder,
+    pio_env: &HashMap<String, String>,
 ) -> Vec<SketchResult> {
     let total = rest.len();
     let cap = sketch_jobs.min(total).max(1);
@@ -516,6 +519,7 @@ fn run_stage2(
                         jobs: 1,
                         verbose,
                         stage: Stage::Stage2Sketch,
+                        pio_env: pio_env.clone(),
                     });
                     *results_slot[idx].lock().unwrap() = Some(res);
                 })
@@ -602,6 +606,7 @@ mod tests {
             sketch_jobs: None,
             profile: BuildProfile::Release,
             verbose: false,
+            pio_env: HashMap::new(),
         };
         assert!(compile_many(req).is_err());
     }
@@ -617,6 +622,7 @@ mod tests {
             sketch_jobs: None,
             profile: BuildProfile::Release,
             verbose: false,
+            pio_env: HashMap::new(),
         };
         assert!(compile_many(req).is_err());
     }
@@ -636,6 +642,7 @@ mod tests {
             sketch_jobs: None,
             profile: BuildProfile::Release,
             verbose: false,
+            pio_env: HashMap::new(),
         };
         assert!(compile_many(req).is_err());
     }

--- a/crates/fbuild-build/tests/compile_many_two_stage.rs
+++ b/crates/fbuild-build/tests/compile_many_two_stage.rs
@@ -162,6 +162,7 @@ fn make_request(
         sketch_jobs: Some(sketch_jobs),
         profile: BuildProfile::Release,
         verbose: false,
+        pio_env: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/fbuild-cli/README.md
+++ b/crates/fbuild-cli/README.md
@@ -1,6 +1,6 @@
 # fbuild-cli
 
-Clap-based CLI for fbuild. Thin HTTP client that delegates all work to the daemon. Subcommands: build, deploy, test-emu, monitor, reset, purge, daemon, device, show, mcp, clang-tidy, iwyu, clang-query.
+Clap-based CLI for fbuild. Thin HTTP client that delegates all work to the daemon. Subcommands: build, deploy, test-emu, monitor, reset, purge, daemon, device, show, mcp, clang-tidy, iwyu, clang-query, compile-many, ci.
 
 ## Key Types
 
@@ -25,3 +25,30 @@ Clap-based CLI for fbuild. Thin HTTP client that delegates all work to the daemo
 - `device` -- list/status/lease/release/preempt connected devices
 - `show` -- display daemon logs
 - `mcp` -- start MCP server for AI assistants
+- `compile-many` -- two-stage compile of many sketches against the same board (FastLED/fbuild#238, PR #241)
+- `ci` -- PlatformIO-compatible CI command (drop-in for `pio ci`, FastLED/fbuild#242)
+
+## `fbuild ci` -- PlatformIO-compatible CI command
+
+`fbuild ci` is a drop-in replacement for [`pio ci`](https://docs.platformio.org/en/latest/core/userguide/cmd_ci.html) that delegates to the two-stage `compile-many` primitive shipped in PR [#241](https://github.com/FastLED/fbuild/pull/241). It lets existing CI workflows swap `s/pio ci/fbuild ci/` without other changes. Tracking issue: [#242](https://github.com/FastLED/fbuild/issues/242).
+
+### Flag mapping
+
+| `fbuild ci` flag | `pio ci` equivalent | Behavior |
+|---|---|---|
+| `--board <b>` / `-b <b>` | `--board` / `-b` | Required. Board id (e.g. `uno`, `teensy41`). |
+| `--lib <path>` / `-l <path>` (repeatable) | `--lib` / `-l` | Mapped to `PLATFORMIO_LIB_EXTRA_DIRS`; joined with `;` on Windows, `:` elsewhere. |
+| `--project-conf <path>` / `-c <path>` | `--project-conf` / `-c` | Mapped to `PLATFORMIO_PROJECT_CONFIG`. Canonicalized when possible. |
+| `--keep-build-dir` | `--keep-build-dir` | Accepted for compatibility; no-op (fbuild always keeps build dirs under `.fbuild/build/...`). |
+| `--build-dir <path>` | `--build-dir` | Accepted for compatibility; not yet honored. Emits a warning when set. |
+| `--framework-jobs` / `--sketch-jobs` / `--quick` / `--release` / `--verbose` (-v) | n/a | fbuild-native; see `compile-many`. |
+| positional sketches | positional | Each entry may be a project dir or a `.ino` file (its parent dir is used). |
+
+### Example
+
+```bash
+fbuild ci --board uno --lib ./libs --lib ./more -c custom.ini \
+  examples/Blink/Blink.ino examples/Fire2012/Fire2012.ino
+```
+
+Exits 0 when every sketch builds, non-zero on any failure.

--- a/crates/fbuild-cli/src/main.rs
+++ b/crates/fbuild-cli/src/main.rs
@@ -333,6 +333,51 @@ enum Commands {
         #[arg(required = true)]
         sketches: Vec<String>,
     },
+    /// PlatformIO-compatible CI command (FastLED/fbuild#242). Drop-in
+    /// replacement for `pio ci` that delegates to the `compile-many`
+    /// two-stage primitive (FastLED/fbuild#241).
+    Ci {
+        /// Board id (e.g. "uno", "teensy41"). Matches `pio ci --board`.
+        #[arg(short = 'b', long)]
+        board: String,
+        /// Extra library search directory (repeatable). Mapped to the
+        /// `PLATFORMIO_LIB_EXTRA_DIRS` env var, ';' separated on Windows
+        /// and ':' separated elsewhere. Matches `pio ci --lib`.
+        #[arg(short = 'l', long = "lib")]
+        libs: Vec<String>,
+        /// Path to a `platformio.ini` to use instead of the per-sketch
+        /// one. Mapped to `PLATFORMIO_PROJECT_CONFIG`. Matches
+        /// `pio ci --project-conf`.
+        #[arg(short = 'c', long = "project-conf")]
+        project_conf: Option<String>,
+        /// Accepted for compatibility with `pio ci`; build directories
+        /// are always kept under `.fbuild/build/...` (no-op).
+        #[arg(long)]
+        keep_build_dir: bool,
+        /// Accepted for compatibility with `pio ci`. Not yet honored;
+        /// emits a warning when set.
+        #[arg(long)]
+        build_dir: Option<String>,
+        /// Parallelism for stage 1 (framework + library compile).
+        #[arg(long)]
+        framework_jobs: Option<usize>,
+        /// Parallelism for stage 2 (per-sketch compile + link).
+        #[arg(long)]
+        sketch_jobs: Option<usize>,
+        /// Build profile.
+        #[arg(long, group = "ci_profile")]
+        quick: bool,
+        #[arg(long, group = "ci_profile")]
+        release: bool,
+        /// Verbose compiler output.
+        #[arg(short, long)]
+        verbose: bool,
+        /// Sketches to build. Each entry is either a project directory
+        /// containing `platformio.ini` or a `.ino` file whose parent
+        /// directory is the project. Matches `pio ci` positional args.
+        #[arg(required = true)]
+        sketches: Vec<String>,
+    },
 }
 
 /// Subcommands for `fbuild lnk`.
@@ -474,6 +519,7 @@ const KNOWN_SUBCOMMANDS: &[&str] = &[
     "test-emu",
     "lib-select",
     "compile-many",
+    "ci",
 ];
 
 /// Rewrite `fbuild <dir> <subcommand> ...` → `fbuild <subcommand> <dir> ...`
@@ -499,8 +545,30 @@ fn rewrite_args() -> Vec<String> {
     args
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
+    // Trampoline through a larger-stack thread: Windows' default 1 MB main-thread
+    // stack is not enough for clap's `--help` formatting across fbuild's full
+    // subcommand tree on debug builds (would crash with STATUS_STACK_OVERFLOW
+    // before parse_from even returns).
+    let handle = std::thread::Builder::new()
+        .name("fbuild-main".into())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(async_main_entry)
+        .expect("failed to spawn main thread");
+    if handle.join().is_err() {
+        std::process::exit(1);
+    }
+}
+
+fn async_main_entry() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+    rt.block_on(async_main());
+}
+
+async fn async_main() {
     let cli = Cli::parse_from(rewrite_args());
 
     tracing_subscriber::fmt()
@@ -798,7 +866,7 @@ async fn main() {
             verbose,
             sketches,
         }) => {
-            run_compile_many(
+            run_compile_many(CompileManyArgs {
                 board,
                 framework_jobs,
                 sketch_jobs,
@@ -806,7 +874,41 @@ async fn main() {
                 release,
                 verbose,
                 sketches,
-            )
+                pio_env: std::collections::HashMap::new(),
+            })
+            .await
+        }
+        Some(Commands::Ci {
+            board,
+            libs,
+            project_conf,
+            keep_build_dir: _keep_build_dir,
+            build_dir,
+            framework_jobs,
+            sketch_jobs,
+            quick,
+            release,
+            verbose,
+            sketches,
+        }) => {
+            if let Some(bd) = &build_dir {
+                eprintln!(
+                    "warning: --build-dir {} is accepted for pio ci compatibility but not yet honored; outputs go to .fbuild/build/...",
+                    bd
+                );
+            }
+            let normalized = normalize_ci_sketches(&sketches);
+            let pio_env = build_ci_pio_env(&libs, project_conf.as_deref());
+            run_compile_many(CompileManyArgs {
+                board,
+                framework_jobs,
+                sketch_jobs,
+                quick,
+                release,
+                verbose,
+                sketches: normalized,
+                pio_env,
+            })
             .await
         }
         None => {
@@ -1226,6 +1328,74 @@ async fn run_build(
     Ok(())
 }
 
+/// Separator used to join `PLATFORMIO_LIB_EXTRA_DIRS` entries.
+///
+/// PlatformIO follows `PATH`-style conventions: ';' on Windows, ':' elsewhere.
+/// Centralized here so the CLI handler and the unit tests agree.
+fn ci_lib_extra_dirs_sep() -> &'static str {
+    if cfg!(windows) {
+        ";"
+    } else {
+        ":"
+    }
+}
+
+/// Map a single `pio ci` positional argument to a project directory.
+///
+/// `pio ci` lets callers point at either a sketch dir or directly at the
+/// `.ino` file. fbuild's `compile-many` only takes project dirs, so a `.ino`
+/// path is rewritten to its parent. Case-insensitive on the extension so
+/// `Blink.INO` works on Windows where casing isn't preserved.
+fn normalize_ci_sketch_entry(entry: &str) -> String {
+    let path = std::path::Path::new(entry);
+    let is_ino = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("ino"))
+        .unwrap_or(false);
+    if is_ino {
+        if let Some(parent) = path.parent() {
+            let p = parent.to_string_lossy().to_string();
+            if p.is_empty() {
+                return ".".to_string();
+            }
+            return p;
+        }
+    }
+    entry.to_string()
+}
+
+/// Normalize every `pio ci` positional argument.
+fn normalize_ci_sketches(entries: &[String]) -> Vec<String> {
+    entries
+        .iter()
+        .map(|e| normalize_ci_sketch_entry(e))
+        .collect()
+}
+
+/// Build the `PLATFORMIO_*` env overlay for `fbuild ci` from `--lib` and
+/// `--project-conf`. Returns an empty map when neither flag was set.
+fn build_ci_pio_env(
+    libs: &[String],
+    project_conf: Option<&str>,
+) -> std::collections::HashMap<String, String> {
+    let mut env = std::collections::HashMap::new();
+    if !libs.is_empty() {
+        env.insert(
+            "PLATFORMIO_LIB_EXTRA_DIRS".to_string(),
+            libs.join(ci_lib_extra_dirs_sep()),
+        );
+    }
+    if let Some(conf) = project_conf {
+        let canonical = std::fs::canonicalize(conf)
+            .ok()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| conf.to_string());
+        env.insert("PLATFORMIO_PROJECT_CONFIG".to_string(), canonical);
+    }
+    env
+}
+
 /// Handler for `fbuild compile-many` (FastLED/fbuild#238).
 ///
 /// Runs the two-stage compile-many primitive in-process via the existing
@@ -1234,7 +1404,7 @@ async fn run_build(
 /// one framework build" — so all stage-1 + stage-2 work happens in this
 /// process, parallelism is driven by the `compile_many` thread pool, and
 /// no per-sketch daemon round-trip is incurred.
-async fn run_compile_many(
+struct CompileManyArgs {
     board: String,
     framework_jobs: Option<usize>,
     sketch_jobs: Option<usize>,
@@ -1242,8 +1412,22 @@ async fn run_compile_many(
     release: bool,
     verbose: bool,
     sketches: Vec<String>,
-) -> fbuild_core::Result<()> {
+    pio_env: std::collections::HashMap<String, String>,
+}
+
+async fn run_compile_many(args: CompileManyArgs) -> fbuild_core::Result<()> {
     use fbuild_build::compile_many::{compile_many, CompileManyRequest, Stage};
+
+    let CompileManyArgs {
+        board,
+        framework_jobs,
+        sketch_jobs,
+        quick,
+        release,
+        verbose,
+        sketches,
+        pio_env,
+    } = args;
 
     let profile = if release {
         fbuild_core::BuildProfile::Release
@@ -1265,6 +1449,7 @@ async fn run_compile_many(
         sketch_jobs,
         profile,
         verbose,
+        pio_env,
     };
 
     let effective_framework = req
@@ -3357,5 +3542,146 @@ async fn run_lnk(
             );
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod ci_tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn normalize_ino_path_strips_to_parent_dir() {
+        let entry = "examples/Blink/Blink.ino";
+        let got = normalize_ci_sketch_entry(entry);
+        assert_eq!(
+            got,
+            std::path::Path::new("examples/Blink").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn normalize_ino_path_is_case_insensitive() {
+        let entry = "examples/Blink/Blink.INO";
+        let got = normalize_ci_sketch_entry(entry);
+        assert_eq!(
+            got,
+            std::path::Path::new("examples/Blink").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn normalize_passes_through_project_dirs() {
+        let entry = "examples/Blink";
+        assert_eq!(normalize_ci_sketch_entry(entry), "examples/Blink");
+    }
+
+    #[test]
+    fn normalize_bare_ino_becomes_dot() {
+        let entry = "Blink.ino";
+        assert_eq!(normalize_ci_sketch_entry(entry), ".");
+    }
+
+    #[test]
+    fn normalize_batch_preserves_order() {
+        let entries = vec![
+            "examples/Blink/Blink.ino".to_string(),
+            "examples/Fire2012".to_string(),
+        ];
+        let got = normalize_ci_sketches(&entries);
+        assert_eq!(got.len(), 2);
+        assert_eq!(
+            got[0],
+            std::path::Path::new("examples/Blink").to_string_lossy()
+        );
+        assert_eq!(got[1], "examples/Fire2012");
+    }
+
+    #[test]
+    fn build_pio_env_joins_libs_with_platform_separator() {
+        let libs = vec!["a".to_string(), "b".to_string()];
+        let env = build_ci_pio_env(&libs, None);
+        let expected = if cfg!(windows) { "a;b" } else { "a:b" };
+        assert_eq!(
+            env.get("PLATFORMIO_LIB_EXTRA_DIRS").map(String::as_str),
+            Some(expected)
+        );
+        assert!(!env.contains_key("PLATFORMIO_PROJECT_CONFIG"));
+    }
+
+    #[test]
+    fn build_pio_env_omits_libs_key_when_empty() {
+        let env = build_ci_pio_env(&[], None);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn build_pio_env_falls_back_to_as_given_when_canonicalize_fails() {
+        let bogus = "/this/path/does/not/exist/conf.ini";
+        let env = build_ci_pio_env(&[], Some(bogus));
+        assert_eq!(
+            env.get("PLATFORMIO_PROJECT_CONFIG").map(String::as_str),
+            Some(bogus)
+        );
+    }
+
+    #[test]
+    fn ci_subcommand_round_trips_through_clap() {
+        let argv = [
+            "fbuild",
+            "ci",
+            "--board",
+            "uno",
+            "--lib",
+            "./libs",
+            "--lib",
+            "./more",
+            "-c",
+            "custom.ini",
+            "examples/Blink/Blink.ino",
+        ];
+        let cli = Cli::try_parse_from(argv).expect("parse");
+        match cli.command {
+            Some(Commands::Ci {
+                board,
+                libs,
+                project_conf,
+                sketches,
+                ..
+            }) => {
+                assert_eq!(board, "uno");
+                assert_eq!(libs, vec!["./libs".to_string(), "./more".to_string()]);
+                assert_eq!(project_conf.as_deref(), Some("custom.ini"));
+                assert_eq!(sketches, vec!["examples/Blink/Blink.ino".to_string()]);
+            }
+            _ => panic!("expected Ci subcommand"),
+        }
+    }
+
+    #[test]
+    fn ci_short_board_flag_b_is_accepted() {
+        let argv = ["fbuild", "ci", "-b", "uno", "examples/Blink"];
+        let cli = Cli::try_parse_from(argv).expect("parse");
+        match cli.command {
+            Some(Commands::Ci {
+                board, sketches, ..
+            }) => {
+                assert_eq!(board, "uno");
+                assert_eq!(sketches, vec!["examples/Blink".to_string()]);
+            }
+            _ => panic!("expected Ci subcommand"),
+        }
+    }
+
+    #[test]
+    fn ci_requires_at_least_one_sketch() {
+        let argv = ["fbuild", "ci", "--board", "uno"];
+        assert!(Cli::try_parse_from(argv).is_err());
+    }
+
+    #[test]
+    fn ci_quick_and_release_are_mutually_exclusive() {
+        let argv = ["fbuild", "ci", "-b", "uno", "--quick", "--release", "."];
+        assert!(Cli::try_parse_from(argv).is_err());
     }
 }

--- a/crates/fbuild-cli/tests/README.md
+++ b/crates/fbuild-cli/tests/README.md
@@ -8,3 +8,10 @@ and message contracts are covered end-to-end.
   HTTP daemon on an ephemeral loopback port, points the CLI at it via
   `FBUILD_DEV_MODE=1` + `FBUILD_DAEMON_PORT`, and asserts the CLI exits
   non-zero when the daemon returns a structured failure response.
+- **`ci_command.rs`** -- regression for FastLED/fbuild#242. Spawns the
+  compiled `fbuild` binary and asserts that `ci --help` documents the
+  PlatformIO-compatible flags (`--board`, `--lib`, `--project-conf`,
+  `--keep-build-dir`, `--build-dir`) and that missing required args
+  produce usage errors. The inline parse tests in `main.rs::ci_tests`
+  cover positive-parse + mutual-exclusion contracts at unit-test speed.
+  No toolchain or daemon is invoked.

--- a/crates/fbuild-cli/tests/ci_command.rs
+++ b/crates/fbuild-cli/tests/ci_command.rs
@@ -1,0 +1,75 @@
+//! Integration tests for the `fbuild ci` subcommand (FastLED/fbuild#242).
+//!
+//! These spawn the compiled `fbuild` binary and assert the clap surface:
+//! `--help` documents the PIO-compatible flags and required-arg validation
+//! produces usage errors. The inline parse tests in `main.rs::ci_tests`
+//! cover positive-parse + mutual-exclusion contracts at unit-test speed.
+
+use std::process::Command;
+
+#[test]
+fn ci_help_lists_pio_compat_flags() {
+    let bin = env!("CARGO_BIN_EXE_fbuild");
+    // allow-direct-spawn: integration test driver invoking the compiled fbuild binary.
+    let output = Command::new(bin)
+        .args(["ci", "--help"])
+        .output()
+        .expect("spawn fbuild");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "ci --help should exit 0\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    for needle in [
+        "--board",
+        "--lib",
+        "--project-conf",
+        "--keep-build-dir",
+        "--build-dir",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "help should document {}. got:\n{}",
+            needle,
+            stdout
+        );
+    }
+}
+
+#[test]
+fn ci_without_board_is_a_usage_error() {
+    let bin = env!("CARGO_BIN_EXE_fbuild");
+    // allow-direct-spawn: integration test driver.
+    let output = Command::new(bin)
+        .args(["ci", "examples/Blink/Blink.ino"])
+        .output()
+        .expect("spawn fbuild");
+
+    assert!(
+        !output.status.success(),
+        "ci without --board must exit non-zero.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn ci_without_sketches_is_a_usage_error() {
+    let bin = env!("CARGO_BIN_EXE_fbuild");
+    // allow-direct-spawn: integration test driver.
+    let output = Command::new(bin)
+        .args(["ci", "--board", "uno"])
+        .output()
+        .expect("spawn fbuild");
+
+    assert!(
+        !output.status.success(),
+        "ci with no positional sketches must exit non-zero.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}


### PR DESCRIPTION
## Summary

Adds `fbuild ci` as a drop-in replacement for `pio ci`. The new subcommand delegates to the two-stage `compile-many` primitive (#241) and exposes the PlatformIO-compatible flag surface so existing CI workflows can swap `s/pio ci/fbuild ci/` without other changes.

## Flag mapping

| `fbuild ci` flag | `pio ci` equivalent | Behavior |
|---|---|---|
| `--board <b>` / `-b <b>` | `--board` / `-b` | Required. Board id (e.g. `uno`, `teensy41`). |
| `--lib <path>` / `-l <path>` (repeatable) | `--lib` / `-l` | Mapped to `PLATFORMIO_LIB_EXTRA_DIRS`; joined with `;` on Windows, `:` elsewhere. |
| `--project-conf <path>` / `-c <path>` | `--project-conf` / `-c` | Mapped to `PLATFORMIO_PROJECT_CONFIG`. Canonicalized when possible, otherwise passed through as-given. |
| `--keep-build-dir` | `--keep-build-dir` | Accepted for compatibility; no-op (fbuild always keeps build dirs under `.fbuild/build/...`). |
| `--build-dir <path>` | `--build-dir` | Accepted for compatibility; emits a warning and falls back to the default location (not yet honored). |
| `--framework-jobs` / `--sketch-jobs` / `--quick` / `--release` / `-v` | n/a | fbuild-native; same semantics as `compile-many`. |
| positional sketches | positional | `.ino` files are rewritten to their parent dir; project dirs pass through unchanged. |

## How it threads through

`CompileManyRequest` gains a `pio_env: HashMap<String, String>` overlay that propagates into every per-sketch `BuildParams.pio_env`, so `--lib` / `--project-conf` reach the platform orchestrators via the existing `PLATFORMIO_*` env-var contract that `fbuild-config` already handles.

Both `fbuild ci` and `fbuild compile-many` remain exposed and share the underlying handler.

## Stack-overflow fix

The new `Ci` enum variant pushes clap's `--help` formatting past Windows' 1 MB default main-thread stack on debug builds (would crash with `STATUS_STACK_OVERFLOW` before `parse_from` returns). `main()` now trampolines through an 8 MB `std::thread`, restoring `--help` on debug Windows and not regressing release builds.

## Test plan

- [x] `uv run soldr cargo check --workspace --all-targets` passes
- [x] `uv run soldr cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `uv run soldr cargo fmt --all -- --check` clean
- [x] `uv run soldr cargo test -p fbuild-cli` — 11 new inline `ci_tests` (path normalization, env-var building, clap round-trip, short flag, required-arg + mutual-exclusion rejection) plus 3 spawn-the-binary integration tests (`ci_help_lists_pio_compat_flags`, `ci_without_board_is_a_usage_error`, `ci_without_sketches_is_a_usage_error`) all pass
- [x] `uv run soldr cargo test -p fbuild-build --test compile_many_two_stage` still green
- [x] Manual: `fbuild ci --help` renders on debug + release Windows builds
- [ ] Manual end-to-end build of a FastLED-style library on `uno` to confirm `--lib` / `--project-conf` plumbing — covered by follow-up consumer in FastLED/FastLED#2470

Closes #242.