### PR TITLE
fix(ci): unblock Formatting + Documentation on main

### DIFF
--- a/crates/fbuild-build/src/compile_database/tests/generate.rs
+++ b/crates/fbuild-build/src/compile_database/tests/generate.rs
@@ -305,8 +305,7 @@ fn test_generate_entries_windows_backslash_paths() {
 fn test_generate_entries_no_response_file_in_args() {
     // Even with many include flags, generate_entries should produce
     // individual -I flags, never @file references (those are for GCC only).
-    let include_flags: Vec<String> =
-        (0..300).map(|i| format!("-I/sdk/include/{}", i)).collect();
+    let include_flags: Vec<String> = (0..300).map(|i| format!("-I/sdk/include/{}", i)).collect();
 
     let entries = generate_entries(
         Path::new("/usr/bin/gcc"),

--- a/crates/fbuild-build/src/compile_database/tests/serialization_and_write.rs
+++ b/crates/fbuild-build/src/compile_database/tests/serialization_and_write.rs
@@ -178,8 +178,7 @@ fn test_write_and_copy_identical_content() {
 
     db.write_and_copy(&build_dir, &project_dir).unwrap();
 
-    let build_content =
-        std::fs::read_to_string(build_dir.join("compile_commands.json")).unwrap();
+    let build_content = std::fs::read_to_string(build_dir.join("compile_commands.json")).unwrap();
     let project_content =
         std::fs::read_to_string(project_dir.join("compile_commands.json")).unwrap();
     assert_eq!(build_content, project_content);

--- a/crates/fbuild-build/src/esp32/orchestrator/build.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator/build.rs
@@ -16,9 +16,7 @@ use super::cdc::warn_if_cdc_on_boot;
 use super::embed_stage::stage_embed_files;
 use super::fingerprint::Esp32FingerprintMetadata;
 use super::framework_libs::compile_framework_builtin_libs;
-use super::helpers::{
-    apply_overlay_flags, compile_db_is_current, profile_label,
-};
+use super::helpers::{apply_overlay_flags, compile_db_is_current, profile_label};
 use super::local_libs::compile_local_libraries;
 use super::packages::resolve_pioarduino_packages;
 use super::Esp32Orchestrator;

--- a/crates/fbuild-build/src/esp32/orchestrator/framework_libs.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator/framework_libs.rs
@@ -14,9 +14,9 @@ use super::helpers::{
     apply_overlay_flags, framework_failure_marker, framework_signature,
     record_failed_framework_lib, should_skip_failed_framework_lib,
 };
+use crate::compiler::Compiler as _;
 use crate::flag_overlay::LanguageExtraFlags;
 use crate::BuildParams;
-use crate::compiler::Compiler as _;
 
 /// Compile every Arduino built-in library shipped with the ESP32 framework.
 /// Library archives are appended to `library_archives`.

--- a/crates/fbuild-build/src/esp32/orchestrator/local_libs.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator/local_libs.rs
@@ -6,8 +6,8 @@ use fbuild_core::Result;
 
 use super::super::esp32_compiler::Esp32Compiler;
 use super::helpers::apply_overlay_flags;
-use crate::flag_overlay::LanguageExtraFlags;
 use crate::compiler::Compiler as _;
+use crate::flag_overlay::LanguageExtraFlags;
 
 /// Walk `project_dir/lib/*` and compile each subdirectory as a library archive.
 /// Archives are appended to `library_archives`.
@@ -46,9 +46,8 @@ pub(super) fn compile_local_libraries(
             .to_string_lossy()
             .to_string();
 
-        let lib_info = fbuild_packages::library::library_info::InstalledLibrary::new(
-            &lib_path, &lib_name,
-        );
+        let lib_info =
+            fbuild_packages::library::library_info::InstalledLibrary::new(&lib_path, &lib_name);
         let lib_sources = lib_info.get_source_files();
         if lib_sources.is_empty() {
             continue;
@@ -65,8 +64,7 @@ pub(super) fn compile_local_libraries(
         let local_ar_path = toolchain.get_ar_path();
         let local_gcc_ar_path = toolchain.get_gcc_ar_path();
         let local_c_flags = apply_overlay_flags(&compiler.c_flags(), src_overlay, "dummy.c");
-        let local_cpp_flags =
-            apply_overlay_flags(&compiler.cpp_flags(), src_overlay, "dummy.cpp");
+        let local_cpp_flags = apply_overlay_flags(&compiler.cpp_flags(), src_overlay, "dummy.cpp");
         let local_lib_ar_path = crate::pipeline::pick_archiver(
             &local_ar_path,
             &local_gcc_ar_path,

--- a/crates/fbuild-build/src/stm32/orchestrator/mod.rs
+++ b/crates/fbuild-build/src/stm32/orchestrator/mod.rs
@@ -13,10 +13,12 @@
 //! 10. Convert to hex + report size
 //!
 //! Module layout (refactored to keep each .rs file under the 1000-LOC gate):
-//! - [`arduino_mbed`] — Arduino mbed-core build path (GIGA, PORTENTA, ...)
-//! - [`framework_props`] — STM32duino `boards.txt` parser
-//! - [`includes`] — include-path/define helpers and small shared utilities
-//! - [`variant_files`] — variant_*.{h,cpp} / PeripheralPins_*.c selection
+//! - `arduino_mbed` — Arduino mbed-core build path (GIGA, PORTENTA, ...)
+//! - `framework_props` — STM32duino `boards.txt` parser
+//! - `includes` — include-path/define helpers and small shared utilities
+//! - `variant_files` — variant_*.{h,cpp} / PeripheralPins_*.c selection
+//!
+//! All four submodules are private internals of the STM32 orchestrator.
 
 mod arduino_mbed;
 mod framework_props;

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 
 use crate::{daemon_client, lib_select, mcp};
 
-use super::args::{rewrite_args, resolve_project_dir, Cli, Commands};
+use super::args::{resolve_project_dir, rewrite_args, Cli, Commands};
 use super::build::run_build;
 use super::clang_tools::{run_clang_tool, run_iwyu};
 use super::compile_many::{

--- a/crates/fbuild-config/src/board/mod.rs
+++ b/crates/fbuild-config/src/board/mod.rs
@@ -8,11 +8,14 @@
 //! - Include path resolution
 //!
 //! The module is split into:
-//! - [`types`] – the public [`BoardConfig`] struct and supporting types
-//! - [`loaders`] – `from_boards_txt` / `from_board_id` constructors and the
+//! - `types` – the public [`BoardConfig`] struct and supporting types
+//! - `loaders` – `from_boards_txt` / `from_board_id` constructors and the
 //!   `boards.txt` line parser
-//! - [`methods`] – accessor / derivation methods on `BoardConfig`
-//! - [`db`] – embedded JSON board database, alias resolution, default extraction
+//! - `methods` – accessor / derivation methods on `BoardConfig`
+//! - `db` – embedded JSON board database, alias resolution, default extraction
+//!
+//! The four submodules are private; only the types re-exported below
+//! form the public API.
 
 mod db;
 mod loaders;

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -356,8 +356,7 @@ fn test_esp32_effective_memory_type_tracks_effective_flash_mode() {
 
 #[test]
 fn test_esp32_effective_memory_type_preserves_opi_flash_profiles() {
-    let config =
-        BoardConfig::from_board_id("esp32-s3-devkitc-1-n32r8v", &HashMap::new()).unwrap();
+    let config = BoardConfig::from_board_id("esp32-s3-devkitc-1-n32r8v", &HashMap::new()).unwrap();
     assert_eq!(
         config.effective_esp32_memory_type("dio"),
         Some("opi_opi".to_string())

--- a/crates/fbuild-core/src/containment.rs
+++ b/crates/fbuild-core/src/containment.rs
@@ -18,10 +18,10 @@
 //! * **Linux** — each child is placed in its own new process group with
 //!   `setpgid(0, 0)` and requests `PR_SET_PDEATHSIG(SIGKILL)` so the
 //!   kernel sends SIGKILL when the daemon thread exits. Per-child groups
-//!   avoid the EPERM that
-//!   [`ContainedProcessGroup::spawn_with_containment`] hits when a
-//!   second child tries to join a stale, already-exited first child's
-//!   pgid (see issue #129).
+//!   avoid the EPERM that the pre-publication
+//!   `ContainedProcessGroup::spawn_with_containment` (since removed from
+//!   `running-process-core` 3.4) hit when a second child tried to join a
+//!   stale, already-exited first child's pgid (see issue #129).
 //! * **macOS** — `prctl` is not available. Each child gets a fresh
 //!   process group; there is no drop-time `killpg` backstop because the
 //!   global group is a `OnceLock<...>` that never drops. This is the
@@ -100,8 +100,8 @@ pub fn is_initialised() -> bool {
 ///
 /// **Windows**: spawn directly, then assign the child handle to a Job
 /// Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
-/// ([`windows_job::assign`]) — the same containment mechanism the
-/// pre-publication `running-process-core` rev used internally,
+/// (via the private `windows_job::assign` helper) — the same containment
+/// mechanism the pre-publication `running-process-core` rev used internally,
 /// reimplemented locally since the published 3.4 API no longer exposes
 /// `spawn_with_containment(_, Containment::Contained)`.
 ///

--- a/crates/fbuild-core/src/subprocess.rs
+++ b/crates/fbuild-core/src/subprocess.rs
@@ -13,7 +13,7 @@
 //!     Windows toolchain binaries.
 //!
 //! On Windows, containment is applied post-spawn by
-//! [`crate::containment::windows_job::assign`] when the daemon has
+//! `crate::containment::windows_job::assign` when the daemon has
 //! installed the global containment group; CLI binaries and unit tests
 //! run uncontained just as before. (Earlier code used a `containment:`
 //! field on `ProcessConfig` from a pre-release `running-process-core`;

--- a/crates/fbuild-daemon/src/handlers/emulator/shared.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/shared.rs
@@ -337,4 +337,3 @@ pub(crate) async fn run_qemu_process(
         exit_code: child_exit.and_then(|s| s.code()),
     })
 }
-

--- a/crates/fbuild-daemon/src/handlers/emulator/tests_outcome.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/tests_outcome.rs
@@ -30,7 +30,6 @@ fn monitor_outcome_to_emulator_maps_crash() {
 
 #[test]
 fn monitor_outcome_to_emulator_maps_timeout() {
-    let outcome =
-        monitor_outcome_to_emulator(MonitorOutcome::Timeout { expect_found: true }, None);
+    let outcome = monitor_outcome_to_emulator(MonitorOutcome::Timeout { expect_found: true }, None);
     assert_eq!(outcome, EmulatorOutcome::TimedOut { expect_found: true });
 }

--- a/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
@@ -8,8 +8,7 @@ use std::path::PathBuf;
 pub(super) fn test_process_command(lines: &[&str]) -> (PathBuf, Vec<String>) {
     #[cfg(windows)]
     {
-        let system_root =
-            std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
         let exe = PathBuf::from(system_root).join(r"System32\cmd.exe");
         let script = lines
             .iter()

--- a/crates/fbuild-deploy/src/esp32/deployer.rs
+++ b/crates/fbuild-deploy/src/esp32/deployer.rs
@@ -737,4 +737,3 @@ impl Deployer for Esp32Deployer {
         }
     }
 }
-

--- a/crates/fbuild-deploy/src/esp32/mod.rs
+++ b/crates/fbuild-deploy/src/esp32/mod.rs
@@ -9,15 +9,18 @@
 //! This file is the module entrypoint; the implementation is split
 //! across sibling files to keep each one under the LOC gate:
 //!
-//! * [`deployer`] — [`Esp32Deployer`], [`EsptoolParams`], esptool argv,
+//! * `deployer` — [`Esp32Deployer`], [`EsptoolParams`], esptool argv,
 //!   verify/write paths, and the [`crate::Deployer`] impl.
-//! * [`verify`]   — [`FlashRegion`], [`RegionVerifyResult`],
-//!   [`VerifyOutcome`], and the [`parse_verify_regions`] helper.
-//! * [`qemu`]     — QEMU flash-image assembly and argv builders.
-//! * [`image`]    — ESP image header constants, byte patching, checksum
+//! * `verify`   — `FlashRegion`, `RegionVerifyResult`, `VerifyOutcome`,
+//!   and the `parse_verify_regions` helper.
+//! * `qemu`     — QEMU flash-image assembly and argv builders.
+//! * `image`    — ESP image header constants, byte patching, checksum
 //!   and SHA-256 trailer repair, and raw binary I/O helpers.
-//! * [`parse`]    — Hex offset / flash-size string parsers shared across
+//! * `parse`    — Hex offset / flash-size string parsers shared across
 //!   the submodules.
+//!
+//! All submodules are private; only the types re-exported below form
+//! the public API.
 
 mod deployer;
 mod image;
@@ -29,6 +32,7 @@ mod verify;
 
 pub use deployer::{Esp32Deployer, EsptoolParams};
 pub use qemu::{
-    build_qemu_args, build_qemu_esp32s3_args, create_qemu_flash_image, resolve_qemu_flash_size_bytes,
+    build_qemu_args, build_qemu_esp32s3_args, create_qemu_flash_image,
+    resolve_qemu_flash_size_bytes,
 };
 pub use verify::{parse_verify_regions, FlashRegion, RegionVerifyResult, VerifyOutcome};

--- a/crates/fbuild-deploy/src/esp32/qemu.rs
+++ b/crates/fbuild-deploy/src/esp32/qemu.rs
@@ -4,9 +4,7 @@ use std::path::{Path, PathBuf};
 
 use fbuild_core::Result;
 
-use super::image::{
-    fill_with_ff, patch_qemu_esp32s3_adc_calibration, write_binary_at_offset,
-};
+use super::image::{fill_with_ff, patch_qemu_esp32s3_adc_calibration, write_binary_at_offset};
 use super::parse::{parse_flash_size_bytes, parse_hex_offset};
 
 /// Resolve the flash-image size to use for QEMU.

--- a/crates/fbuild-deploy/src/esp32/tests.rs
+++ b/crates/fbuild-deploy/src/esp32/tests.rs
@@ -7,18 +7,18 @@ use std::path::Path;
 use sha2::{Digest, Sha256};
 
 use super::deployer::{Esp32Deployer, EsptoolParams};
+use super::image::patch_bytes;
 use super::image::{
     repair_esp_image_checksum_and_hash, resolve_esp_image_file_offset, ESP_IMAGE_APPENDED_HASH_LEN,
     ESP_IMAGE_HEADER_LEN, ESP_IMAGE_HEADER_MAGIC, ESP_IMAGE_SEGMENT_HEADER_LEN,
-    ESP_ROM_CHECKSUM_INITIAL, QEMU_ADC_CALIBRATION_EXPECTED_BYTES, QEMU_ADC_CALIBRATION_PATCH_BYTES,
+    ESP_ROM_CHECKSUM_INITIAL, QEMU_ADC_CALIBRATION_EXPECTED_BYTES,
+    QEMU_ADC_CALIBRATION_PATCH_BYTES,
 };
-use super::image::patch_bytes;
 use super::qemu::{
-    build_qemu_args, build_qemu_esp32s3_args, create_qemu_flash_image, resolve_qemu_flash_size_bytes,
+    build_qemu_args, build_qemu_esp32s3_args, create_qemu_flash_image,
+    resolve_qemu_flash_size_bytes,
 };
-use super::verify::{
-    parse_verify_regions, FlashRegion, RegionVerifyResult, VerifyOutcome,
-};
+use super::verify::{parse_verify_regions, FlashRegion, RegionVerifyResult, VerifyOutcome};
 use crate::Deployer;
 
 /// Test params matching ESP32-C6 JSON config values.
@@ -199,8 +199,7 @@ fn repair_esp_image_checksum_and_hash_updates_trailers_after_patch() {
             word[..chunk.len()].copy_from_slice(chunk);
             checksum_word ^= u32::from_le_bytes(word);
         }
-        ((checksum_word >> 24) ^ (checksum_word >> 16) ^ (checksum_word >> 8) ^ checksum_word)
-            as u8
+        ((checksum_word >> 24) ^ (checksum_word >> 16) ^ (checksum_word >> 8) ^ checksum_word) as u8
     };
     let expected_hash = Sha256::digest(&image[..checksum_offset + 1]);
     assert_eq!(image[checksum_offset], expected_checksum);

--- a/crates/fbuild-deploy/src/esp32_native/tests.rs
+++ b/crates/fbuild-deploy/src/esp32_native/tests.rs
@@ -9,8 +9,7 @@ use crate::DeployOutcome;
 
 use super::progress::LoggingProgressBridge;
 use super::transport::{
-    local_md5, parse_after_reset, parse_before_reset, parse_chip, region_name,
-    render_native_stdout,
+    local_md5, parse_after_reset, parse_before_reset, parse_chip, region_name, render_native_stdout,
 };
 use super::types::NativeWriteRegion;
 use super::verify::collect_standard_regions;

--- a/crates/fbuild-deploy/src/esp32_native/write.rs
+++ b/crates/fbuild-deploy/src/esp32_native/write.rs
@@ -28,7 +28,7 @@ use super::types::NativeWriteRegion;
 ///
 /// Progress from espflash is bridged into `tracing` so the daemon's
 /// existing log broadcaster surfaces it without new API surface (see
-/// the private `LoggingProgressBridge` in [`super::progress`]).
+/// the private `LoggingProgressBridge` in `super::progress`).
 /// Structured WebSocket progress frames are a follow-up: the bridge is
 /// a drop-in replacement point for a richer callback without touching
 /// any of the call sites.

--- a/crates/fbuild-python/src/daemon_connection.rs
+++ b/crates/fbuild-python/src/daemon_connection.rs
@@ -2,9 +2,7 @@
 
 use pyo3::prelude::*;
 
-use crate::outcome::{
-    build_url, deploy_url, monitor_url, outcome_to_pydict, send_op, OpRequest,
-};
+use crate::outcome::{build_url, deploy_url, monitor_url, outcome_to_pydict, send_op, OpRequest};
 
 /// Python-visible DaemonConnection (context manager).
 #[pyclass]


### PR DESCRIPTION
## Summary

Two pre-existing failures on main since the loc-gate-refactor merge (#252) and the running-process-core 3.4 refactor (#254). Both are now blocking branch protection on every PR.

- **Formatting** — `cargo fmt --all` over the 16 files rustfmt flagged. Mechanical whitespace/trailing-comma adjustments; no semantic changes.
- **Documentation** — `rustdoc::private-intra-doc-links` (implied by `-D warnings`) rejects `[`name`]` doc-link syntax pointing at private modules. The LOC-gate split PRs created several new private submodules whose parent `mod.rs` files still link to them as if they were public. Demoted those links to backticked plain text (with a note that the submodules are private internals).

Files touched for Docs: `fbuild-config/src/board/mod.rs`, `fbuild-deploy/src/esp32/mod.rs`, `fbuild-deploy/src/esp32_native/write.rs`, `fbuild-build/src/stm32/orchestrator/mod.rs`, `fbuild-core/src/{containment,subprocess}.rs`.

## Why not just make the modules `pub`

The LOC-gate splits intentionally kept the implementation submodules private and re-exported only the public types from the parent `mod.rs`. Making the submodules `pub` would expose internal layout. Plain-text references preserve the original intent.

## Test plan

- [x] `uv run soldr cargo fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS=-D warnings uv run soldr cargo doc --workspace --no-deps` — clean (was 15 errors before)
- [ ] CI: Formatting + Documentation both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Consolidated and reformatted import statements across multiple modules for consistency.
  * Reformatted variable assignments and expressions throughout the codebase for improved readability.

* **Documentation**
  * Updated module-level documentation comments to clarify submodule responsibilities and structure.
  * Enhanced function documentation with improved formatting and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->