### PR TITLE
chore(dev-tools): drop soldr dep; require global soldr install (#251)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ fbuild is a PlatformIO-compatible embedded build tool (11 crates). See @docs/CLA
 
 ## Essential Rules
 
-- **Always use `soldr` or `uv run soldr` to execute Rust commands.** Bare cargo/rustc and legacy `uv run cargo` shims are blocked by hook. soldr uses `rustup which` to pick the rustup-managed toolchain from `rust-toolchain.toml`. The standard Cargo path is `soldr cargo ...`, so repo Rust builds get soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for normal builds.
+- **Always use a globally-installed `soldr` to execute Rust commands.** Bare cargo/rustc and legacy `uv run cargo` shims are blocked by hook. soldr uses `rustup which` to pick the rustup-managed toolchain from `rust-toolchain.toml`. The standard Cargo path is `soldr cargo ...`, so repo Rust builds get soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for normal builds. Install soldr globally via `uv tool install soldr` (or see https://github.com/zackees/soldr).
 - **Always use `uv` for Python.** Bare `python`/`pip` are blocked by hook. Use `uv run ...` or `uv pip ...`.
 - MSRV: 1.94.1 | Edition: 2021 | Toolchain: 1.94.1 pinned in `rust-toolchain.toml` (clippy + rustfmt)
 - CI: Linux, macOS, Windows. All warnings denied (`RUSTFLAGS="-D warnings"`)
@@ -16,24 +16,22 @@ fbuild is a PlatformIO-compatible embedded build tool (11 crates). See @docs/CLA
 uv run test                 # unit tests only
 uv run test --full          # unit + stress + integration tests
 uv run test -p <crate> -- <test_name>
-uv run soldr cargo check --workspace --all-targets
-uv run soldr cargo clippy --workspace --all-targets -- -D warnings
-uv run soldr cargo fmt --all
-RUSTDOCFLAGS="-D warnings" uv run soldr cargo doc --workspace --no-deps
-
-# Public deploy API conventions
-uv run soldr cargo run -p fbuild-cli -- deploy tests/platform/uno -e uno --to emu
-uv run soldr cargo run -p fbuild-cli -- deploy tests/platform/uno -e uno --to emu --monitor
-uv run soldr cargo run -p fbuild-cli -- deploy tests/platform/esp32dev -e esp32dev-qemu --to emu --emulator qemu
-
-# test-emu: build + run in emulator (CI-friendly, exits with emulator exit code)
-uv run soldr cargo run -p fbuild-cli -- test-emu tests/platform/uno -e uno
-uv run soldr cargo run -p fbuild-cli -- test-emu tests/platform/esp32s3 -e esp32s3 --timeout 10
-uv run soldr cargo run -p fbuild-cli -- test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
-
-# Direct soldr commands (alternative to uv run soldr)
 soldr cargo check --workspace --all-targets
 soldr cargo clippy --workspace --all-targets -- -D warnings
+soldr cargo fmt --all
+RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps
+
+# Public deploy API conventions
+soldr cargo run -p fbuild-cli -- deploy tests/platform/uno -e uno --to emu
+soldr cargo run -p fbuild-cli -- deploy tests/platform/uno -e uno --to emu --monitor
+soldr cargo run -p fbuild-cli -- deploy tests/platform/esp32dev -e esp32dev-qemu --to emu --emulator qemu
+
+# test-emu: build + run in emulator (CI-friendly, exits with emulator exit code)
+soldr cargo run -p fbuild-cli -- test-emu tests/platform/uno -e uno
+soldr cargo run -p fbuild-cli -- test-emu tests/platform/esp32s3 -e esp32s3 --timeout 10
+soldr cargo run -p fbuild-cli -- test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
+
+# Per-file rustfmt
 soldr rustfmt --check <file.rs>
 
 # Board definition management
@@ -43,7 +41,7 @@ uv run python ci/board_sources.py --search QUERY       # search all external sou
 uv run python ci/board_sources.py --compare            # find boards missing from fbuild
 uv run python ci/board_sources.py --list-arduino       # list Arduino package index boards
 uv run python ci/board_sources.py --list-zephyr        # list Zephyr boards
-uv run soldr cargo run -p fbuild-config --bin enrich_boards  # enrich from local PlatformIO
+soldr cargo run -p fbuild-config --bin enrich_boards  # enrich from local PlatformIO
 ```
 
 ## Distribution
@@ -69,7 +67,7 @@ uv run python ci/zccache_setup.py  # writes rustc-wrapper = "zccache"
 All hooks are Python scripts in `ci/hooks/`, invoked via `uv run`:
 
 - **UserPromptSubmit**: `ci/hooks/board_context.py` detects board-related prompts and injects skill guidance (board lookup workflow, external source URLs, relevant commands)
-- **PreToolUse**: `ci/hooks/tool_guard.py` blocks bare Rust commands and legacy `uv run cargo` shims (must use `soldr` or `uv run soldr`) and bare `python`/`pip` (must use `uv`) across supported shell tools, not just Bash
+- **PreToolUse**: `ci/hooks/tool_guard.py` blocks bare Rust commands and any `uv run` invocation of `soldr`/`cargo` (must use a globally-installed `soldr` directly) and bare `python`/`pip` (must use `uv`) across supported shell tools, not just Bash
 - **PostToolUse**: `ci/hooks/lint.py` auto-formats + runs clippy on edited .rs files
 - **PostToolUse**: `ci/hooks/readme_guard.py` errors if directory lacks README.md
 - **SessionStart**: `ci/hooks/check-on-start.py` captures git fingerprint

--- a/CODEX.md
+++ b/CODEX.md
@@ -4,35 +4,31 @@ Codex working notes for this repo. Start with [CLAUDE.md](./CLAUDE.md) for the f
 
 ## Mandatory command rules
 
-- Always run Rust tooling through `soldr` or `uv run soldr`.
+- Always run Rust tooling through a globally-installed `soldr`.
 - Never run bare `cargo`, `rustc`, `rustfmt`, `clippy-driver`, `python`, or `pip`.
+- Never run `uv run soldr ...` — soldr is no longer installed into the
+  repo-local uv environment (see issue #251). Install soldr globally
+  (e.g. `uv tool install soldr` or the install script at
+  https://github.com/zackees/soldr) and call it directly.
 - Approved Rust forms in this repo are:
   - `soldr cargo ...`
   - `soldr rustc ...`
   - `soldr rustfmt ...`
-  - `uv run soldr cargo ...`
-  - `uv run soldr rustc ...`
-  - `uv run soldr rustfmt ...`
 
 ## Why
 
 - Repo hooks enforce this.
 - [soldr](https://github.com/zackees/soldr) resolves each tool via `rustup which` so the rustup-managed toolchain is always used instead of a stale system or Chocolatey install.
-- `uv run soldr ...` works because `ci/dev-tools` installs `soldr` into the repo-local uv environment.
 - The normal Cargo path is `soldr cargo ...`, so repo Rust builds use soldr's managed zccache path by default; do not add repo-specific `RUSTC_WRAPPER` wiring for standard builds.
 - If you bypass them, you can hit wrong-toolchain errors.
 
 ## Use these
 
 ```powershell
-uv run soldr cargo check --workspace --all-targets
-uv run soldr cargo test -p fbuild-build -- --ignored
-uv run soldr cargo clippy --workspace --all-targets -- -D warnings
-uv run soldr cargo fmt --all
-
 soldr cargo check --workspace --all-targets
 soldr cargo test -p fbuild-build -- --ignored
 soldr cargo clippy --workspace --all-targets -- -D warnings
+soldr cargo fmt --all
 soldr rustfmt --check crates/fbuild-build/src/compiler.rs
 
 uv run test
@@ -46,11 +42,13 @@ uv run test -p fbuild-build -- some_test_name
 uv run python ci/zccache_setup.py
 ```
 
-This configures `rustc-wrapper = "zccache"` for local wrapper-mode experiments. Standard builds should use `soldr` or `uv run soldr` above.
+This configures `rustc-wrapper = "zccache"` for local wrapper-mode experiments. Standard builds should use `soldr` above.
 
-## Fallback
+## If `soldr` is missing
 
-- Use `uv run soldr ...` when `soldr` is not on PATH but the repo-local uv environment is available.
+- Install globally with `uv tool install soldr` or follow
+  https://github.com/zackees/soldr.
+- Then re-run the failing command.
 
 ## If a command fails
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -12,9 +12,9 @@ Per-crate criterion benches live alongside their crate, e.g.:
 Run those with:
 
 ```bash
-uv run soldr cargo bench -p fbuild-library-select --bench resolve_cold
-uv run soldr cargo bench -p fbuild-library-select --bench resolve_warm
-uv run soldr cargo bench -p fbuild-header-scan  --bench scan_throughput
+soldr cargo bench -p fbuild-library-select --bench resolve_cold
+soldr cargo bench -p fbuild-library-select --bench resolve_warm
+soldr cargo bench -p fbuild-header-scan  --bench scan_throughput
 ```
 
 ## Subdirectories
@@ -23,7 +23,7 @@ uv run soldr cargo bench -p fbuild-header-scan  --bench scan_throughput
   warm-cache library-selection matrix (`FastLED/fbuild#205` AC#5, P-01).
   Discovers examples under `$FASTLED_DIR` (default `~/dev/fastled`),
   runs the resolver cold + warm per example, and reports timings.
-  Run with `uv run soldr cargo run --release -p fbuild-bench-fastled-examples`.
+  Run with `soldr cargo run --release -p fbuild-bench-fastled-examples`.
   The synthetic warm-path baseline lives in
   `crates/fbuild-library-select/benches/resolve_warm.rs`.
 

--- a/bench/fastled-examples/README.md
+++ b/bench/fastled-examples/README.md
@@ -33,16 +33,16 @@ silent fallback would mask configuration mistakes.
 
 ```bash
 FASTLED_DIR=/path/to/fastled \
-  uv run soldr cargo run --release -p fbuild-bench-fastled-examples
+  soldr cargo run --release -p fbuild-bench-fastled-examples
 
 # Emit a JSON report alongside stdout
 FASTLED_DIR=/path/to/fastled \
-  uv run soldr cargo run --release -p fbuild-bench-fastled-examples \
+  soldr cargo run --release -p fbuild-bench-fastled-examples \
   -- --json bench/fastled-examples/report.json
 
 # Enforce AC#5 (≤ 50 ms warm per example). Exits 1 on breach.
 FASTLED_DIR=/path/to/fastled \
-  uv run soldr cargo run --release -p fbuild-bench-fastled-examples \
+  soldr cargo run --release -p fbuild-bench-fastled-examples \
   -- --max-warm-ms 50
 ```
 

--- a/ci/dev-tools/README.md
+++ b/ci/dev-tools/README.md
@@ -1,9 +1,9 @@
 # Dev Tools
 
-Pip-installable package that provides repo-local development helpers and the `soldr` dependency.
+Pip-installable package that provides repo-local development helper entry points.
 
-Rust tooling should be invoked directly through [soldr](https://github.com/zackees/soldr), either as `soldr cargo ...` when soldr is on PATH or `uv run soldr cargo ...` through this repo-local environment. soldr uses `rustup which` to pick the right toolchain. The standard Cargo path is `soldr cargo ...`, so soldr's managed zccache path is enabled by default for repo Rust builds without repo-specific `RUSTC_WRAPPER` wiring.
+Rust tooling is invoked through a **globally-installed** [soldr](https://github.com/zackees/soldr) (e.g. `uv tool install soldr`); `soldr` is no longer pulled into the repo-local `uv` environment as a dependency. soldr uses `rustup which` to pick the right toolchain. The standard Cargo path is `soldr cargo ...`, so soldr's managed zccache path is enabled by default for repo Rust builds without repo-specific `RUSTC_WRAPPER` wiring.
 
 ## Contents
 
-- **`pyproject.toml`** -- Declares the `soldr>=0.7.4` dependency and defines helper entry points: `run_fbuild`, `run_fbuild_daemon`, `publish`
+- **`pyproject.toml`** -- Empty dependency list (soldr is global; see issue #251) and helper entry points: `run_fbuild`, `run_fbuild_daemon`, `publish`

--- a/ci/dev-tools/pyproject.toml
+++ b/ci/dev-tools/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "fbuild-dev-tools"
 version = "0.0.0"
-description = "Repo-local fbuild development helpers"
+description = "Repo-local fbuild development helpers (soldr must be installed globally; see https://github.com/zackees/soldr)"
 requires-python = ">=3.10"
-dependencies = ["soldr>=0.7.4"]
+dependencies = []
 
 [project.scripts]
 run_fbuild = "ci.trampoline:run_fbuild"

--- a/ci/hooks/README.md
+++ b/ci/hooks/README.md
@@ -5,7 +5,7 @@ Python scripts invoked by Claude Code lifecycle hooks, configured in `.claude/se
 ## Contents
 
 - **`board_context.py`** -- UserPromptSubmit: detects board-related prompts (board names, MCU keywords, board error patterns) and injects guidance about the `/board-support` skill, relevant commands, and external board registries
-- **`tool_guard.py`** -- PreToolUse: blocks bare `cargo`/`rustc`/`rustfmt`, legacy `uv run cargo`-style shims, and bare `python`/`pip` commands across shell tool variants such as Bash and PowerShell, requiring `soldr ...` or `uv run soldr ...` for Rust tooling and `uv run` / `uv pip` for Python tooling
+- **`tool_guard.py`** -- PreToolUse: blocks bare `cargo`/`rustc`/`rustfmt`, legacy `uv run cargo`-style shims, `uv run soldr ...` (since soldr is no longer a venv dep — issue #251), and bare `python`/`pip` commands across shell tool variants such as Bash and PowerShell. Requires a globally-installed `soldr ...` for Rust tooling and `uv run` / `uv pip` for Python tooling.
 - **`lint.py`** -- PostToolUse: runs per-file rustfmt + clippy on edited `.rs` files
 - **`readme_guard.py`** -- PostToolUse: ensures every directory containing edited files has a `README.md`
 - **`check-on-start.py`** -- SessionStart: captures a git fingerprint so the stop hook can detect changes

--- a/ci/hooks/board_context.py
+++ b/ci/hooks/board_context.py
@@ -74,7 +74,7 @@ step-by-step guidance for diagnosing board issues.
 - **Validate against PlatformIO**: `uv run python ci/validate_boards.py`
 - **Search external sources**: `uv run python ci/board_sources.py --search QUERY`
 - **Compare coverage**: `uv run python ci/board_sources.py --compare`
-- **Enrich from PlatformIO**: `uv run soldr cargo run -p fbuild-config --bin enrich_boards`
+- **Enrich from PlatformIO**: `soldr cargo run -p fbuild-config --bin enrich_boards`
 
 ### External board registries (for boards not in PlatformIO):
 - Arduino package indices: `uv run python ci/board_sources.py --list-arduino`

--- a/ci/hooks/test_tool_guard.py
+++ b/ci/hooks/test_tool_guard.py
@@ -30,13 +30,28 @@ class ToolGuardTests(unittest.TestCase):
                 self.assertIsNotNone(result)
                 self.assertEqual(result[0], "cargo")
 
+    def test_blocks_uv_run_soldr(self):
+        """`uv run soldr ...` is no longer allowed — soldr was removed from
+        the repo-local uv env in issue #251. Users must call the global
+        `soldr` binary directly.
+        """
+        commands = (
+            "uv run soldr cargo test",
+            "uv run -- soldr cargo build",
+            "uv run --offline soldr rustfmt --check src/lib.rs",
+            "uv run --project . soldr cargo check",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                result = check_command(command)
+                self.assertIsNotNone(result, f"expected deny for: {command}")
+                self.assertEqual(result[0], "soldr")
+
     def test_allows_soldr_wrapped_rust_tool(self):
         self.assertIsNone(check_command("soldr cargo test"))
         self.assertIsNone(check_command("soldr --no-cache cargo build"))
         self.assertIsNone(check_command("soldr rustc --version"))
         self.assertIsNone(check_command("soldr rustfmt --check src/lib.rs"))
-        self.assertIsNone(check_command("uv run soldr cargo test"))
-        self.assertIsNone(check_command("uv run soldr rustfmt --check src/lib.rs"))
 
     def test_blocks_bare_python(self):
         result = check_command("python ci/script.py")

--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """PreToolUse hook: blocks bare Rust commands and bare python/pip.
 
-All cargo/rustc/rustfmt must go through soldr (ensures correct toolchain).
+All cargo/rustc/rustfmt must go through a globally-installed `soldr`
+(ensures correct toolchain). The historical `uv run soldr ...` path is
+also blocked — `soldr` was removed from `ci/dev-tools` as of issue #251
+and is no longer available in the repo-local uv env.
 All python must go through uv (ensures correct environment).
 
 Exit codes:
@@ -16,9 +19,15 @@ import sys
 RUST_TOOLS = {"cargo", "rustc", "rustfmt", "clippy-driver", "cargo-clippy", "cargo-fmt"}
 PYTHON_TOOLS = {"python", "python3", "pip", "pip3"}
 
-SOLDR_PREFIXES = ("soldr ", "uv run soldr ")
+# Only the bare, global `soldr` is allowed for Rust tooling.
+SOLDR_PREFIXES = ("soldr ",)
 UV_RUN_PREFIX = "uv run "
 UV_PIP_PREFIX = "uv pip "
+# `uv run` targets that are forbidden because they belong to the
+# global-soldr path: `cargo` / `rustc` / etc. (the console-script shims
+# from a venv-installed Rust toolchain) and `soldr` itself (since
+# soldr is no longer a venv dependency — see issue #251).
+UV_RUN_FORBIDDEN_TARGETS = RUST_TOOLS | {"soldr"}
 UV_RUN_FLAGS_WITH_VALUES = {
     "--config-setting",
     "--directory",
@@ -107,13 +116,23 @@ def check_command(command):
 
         if seg.startswith(UV_RUN_PREFIX):
             parts = seg.split()
-            # `uv run soldr ...` was handled above. Block the old `uv run cargo`
-            # console-script shim path so Rust tooling has one canonical entry.
+            # Block both `uv run cargo ...` (the old venv-shim path) and
+            # `uv run soldr ...` (no longer valid since #251 removed
+            # soldr from the repo-local uv env).
             run_target = uv_run_target(parts)
-            if run_target in RUST_TOOLS:
+            if run_target in UV_RUN_FORBIDDEN_TARGETS:
+                if run_target == "soldr":
+                    return (
+                        "soldr",
+                        "Use a globally-installed `soldr ...` instead of "
+                        "`uv run soldr ...`. soldr was removed from the "
+                        "repo-local uv env in issue #251. Install via "
+                        "`uv tool install soldr` (or see "
+                        "https://github.com/zackees/soldr).",
+                    )
                 return (
                     run_target,
-                    f"Use `uv run soldr {run_target} ...` instead of "
+                    f"Use `soldr {run_target} ...` instead of "
                     f"`uv run {run_target} ...`. soldr resolves the checked-in "
                     f"Rust toolchain directly via rustup.",
                 )
@@ -122,10 +141,9 @@ def check_command(command):
         if first_word in RUST_TOOLS:
             return (
                 first_word,
-                f"Use `soldr {first_word} ...` or "
-                f"`uv run soldr {first_word} ...` instead of bare "
-                f"`{first_word}`. soldr resolves the checked-in Rust toolchain "
-                f"directly via rustup.",
+                f"Use `soldr {first_word} ...` instead of bare "
+                f"`{first_word}`. soldr (installed globally) resolves the "
+                f"checked-in Rust toolchain directly via rustup.",
             )
 
         if first_word in PYTHON_TOOLS:

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -54,13 +54,13 @@ def lint_single_file(file_path):
         return 1
 
     # Format single file
-    result = run_cmd(["uv", "run", "soldr", "rustfmt", file_path])
+    result = run_cmd(["soldr", "rustfmt", file_path])
     if result.returncode != 0:
         return result.returncode
 
     # Clippy on the affected crate (or workspace if unknown)
     crate = detect_crate(file_path)
-    cmd = ["uv", "run", "soldr", "cargo", "clippy"]
+    cmd = ["soldr", "cargo", "clippy"]
     if crate:
         cmd += ["-p", crate]
     else:
@@ -74,14 +74,14 @@ def lint_single_file(file_path):
 def lint_workspace():
     """Full workspace lint: fmt check + clippy."""
     # Format check
-    result = run_cmd(["uv", "run", "soldr", "cargo", "fmt", "--all", "--check"])
+    result = run_cmd(["soldr", "cargo", "fmt", "--all", "--check"])
     if result.returncode != 0:
         print("Formatting issues found. Run './lint --fix' to auto-fix.", file=sys.stderr)
         return result.returncode
 
     # Clippy
     result = run_cmd([
-        "uv", "run", "soldr", "cargo", "clippy", "--workspace", "--all-targets",
+        "soldr", "cargo", "clippy", "--workspace", "--all-targets",
         "--", "-D", "warnings",
     ])
     return result.returncode
@@ -93,13 +93,13 @@ def main():
     # Handle --fix flag
     if "--fix" in args:
         args.remove("--fix")
-        result = run_cmd(["uv", "run", "soldr", "cargo", "fmt", "--all"])
+        result = run_cmd(["soldr", "cargo", "fmt", "--all"])
         if result.returncode != 0:
             return result.returncode
         if not args:
             # After fixing fmt, run clippy
             result = run_cmd([
-                "uv", "run", "soldr", "cargo", "clippy", "--workspace", "--all-targets",
+                "soldr", "cargo", "clippy", "--workspace", "--all-targets",
                 "--", "-D", "warnings",
             ])
             return result.returncode

--- a/ci/measure_baseline_205.py
+++ b/ci/measure_baseline_205.py
@@ -9,7 +9,7 @@ concrete to anchor "+1%" or "<= 250" claims to.
 
 For each target it:
 
-1. Builds the fixture project via ``uv run soldr cargo run -p fbuild-cli --
+1. Builds the fixture project via ``soldr cargo run -p fbuild-cli --
    build <project> -e <env>`` plus a separate ``-t compiledb`` invocation to
    produce ``compile_commands.json``.
 2. Counts distinct ``file`` entries in the resulting compile_commands.json.
@@ -501,7 +501,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=REPO_ROOT).stdout.strip()
         or "unknown"
     )
-    cargo_proc = _run(["uv", "run", "soldr", "cargo", "--version"], cwd=REPO_ROOT, timeout=120)
+    cargo_proc = _run(["soldr", "cargo", "--version"], cwd=REPO_ROOT, timeout=120)
     cargo_version = cargo_proc.stdout.strip() or "unknown"
 
     out_path = (REPO_ROOT / args.out).resolve()

--- a/ci/test.py
+++ b/ci/test.py
@@ -19,7 +19,7 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 
 
 def main():
-    cmd = ["uv", "run", "soldr", "cargo", "test"]
+    cmd = ["soldr", "cargo", "test"]
 
     args = sys.argv[1:]
     full = "--full" in args

--- a/ci/trampoline.py
+++ b/ci/trampoline.py
@@ -1,8 +1,10 @@
 """Repo-local development command helpers.
 
-Rust tooling should be invoked with `soldr ...` or `uv run soldr ...`
-directly. This module only keeps helper entry points that run fbuild
-workspace binaries through soldr-managed Cargo.
+Rust tooling is invoked with a globally-installed `soldr` directly
+(see issue #251 — `soldr` is no longer pulled into the repo-local uv
+environment as a dependency of `fbuild-dev-tools`). This module only
+keeps helper entry points that run fbuild workspace binaries through
+soldr-managed Cargo.
 
 Why soldr:
 - soldr resolves each tool via `rustup which`, which respects
@@ -22,8 +24,11 @@ def _soldr_prefix():
     """Return the argv prefix that runs soldr."""
     if not shutil.which("soldr"):
         print(
-            "error: `soldr` not found on PATH. Run ./install (or `uv sync`) "
-            "to install fbuild-dev-tools, which pulls soldr in as a dependency.",
+            "error: `soldr` not found on PATH. `soldr` is required globally "
+            "for this repo. Install it via one of:\n"
+            "  uv tool install soldr\n"
+            "  curl -fsSL https://raw.githubusercontent.com/zackees/soldr/main/install.sh | bash\n"
+            "See https://github.com/zackees/soldr for other install options.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/ci/validate_boards.py
+++ b/ci/validate_boards.py
@@ -410,7 +410,7 @@ def main() -> int:
             for diff in diffs:
                 print(f"    {diff}")
             print()
-        print("To fix: run 'uv run soldr cargo run -p fbuild-config --bin enrich_boards' and commit the changes.")
+        print("To fix: run 'soldr cargo run -p fbuild-config --bin enrich_boards' and commit the changes.")
         return 1
 
     print("All checked boards match PlatformIO definitions.")

--- a/crates/fbuild-build/tests/README.md
+++ b/crates/fbuild-build/tests/README.md
@@ -2,4 +2,4 @@
 
 Tests that download real toolchains and compile real sketches. Marked `#[ignore]` so they don't run during normal `uv run test`.
 
-Run with: `uv run soldr cargo test -p fbuild-build -- --ignored`
+Run with: `soldr cargo test -p fbuild-build -- --ignored`

--- a/crates/fbuild-build/tests/avr_build.rs
+++ b/crates/fbuild-build/tests/avr_build.rs
@@ -3,7 +3,7 @@
 //! Downloads avr-gcc + Arduino core (cached after first run), compiles a
 //! minimal blink sketch, and validates the output firmware.hex.
 //!
-//! Run with: `uv run soldr cargo test -p fbuild-build --test avr_build -- --ignored`
+//! Run with: `soldr cargo test -p fbuild-build --test avr_build -- --ignored`
 
 use std::fs;
 use std::io::Cursor;

--- a/crates/fbuild-build/tests/eh_frame_strip_esp32.rs
+++ b/crates/fbuild-build/tests/eh_frame_strip_esp32.rs
@@ -6,7 +6,7 @@
 //! of MB on first run) and is not headless-CI-friendly. Run with:
 //!
 //! ```
-//! uv run soldr cargo test -p fbuild-build --test eh_frame_strip_esp32 -- --ignored
+//! soldr cargo test -p fbuild-build --test eh_frame_strip_esp32 -- --ignored
 //! ```
 //!
 //! The orchestrator invocation pattern mirrors

--- a/crates/fbuild-build/tests/esp32_build.rs
+++ b/crates/fbuild-build/tests/esp32_build.rs
@@ -3,7 +3,7 @@
 //! Downloads esp32 toolchain + framework (cached after first run), compiles a
 //! minimal blink sketch, and validates the output firmware.bin.
 //!
-//! Run with: `uv run soldr cargo test -p fbuild-build --test esp32_build -- --ignored`
+//! Run with: `soldr cargo test -p fbuild-build --test esp32_build -- --ignored`
 
 use std::fs;
 use std::path::PathBuf;

--- a/crates/fbuild-build/tests/flag_escaping_lint.rs
+++ b/crates/fbuild-build/tests/flag_escaping_lint.rs
@@ -9,7 +9,7 @@
 //! "stray '\\' in program" errors because the backslash is a literal character,
 //! not a shell escape. `prepare_flags_for_exec` strips `\"` → `"`.
 //!
-//! Run with: `uv run soldr cargo test -p fbuild-build --test flag_escaping_lint`
+//! Run with: `soldr cargo test -p fbuild-build --test flag_escaping_lint`
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/fbuild-build/tests/stm32_acceptance.rs
+++ b/crates/fbuild-build/tests/stm32_acceptance.rs
@@ -6,7 +6,7 @@
 //! by fbuild's library-selection layer.
 //!
 //! Run with:
-//! `uv run soldr cargo test -p fbuild-build --test stm32_acceptance -- --ignored`
+//! `soldr cargo test -p fbuild-build --test stm32_acceptance -- --ignored`
 //!
 //! Marked `#[ignore]` because it downloads the ARM GCC toolchain plus the
 //! STM32duino cores (cached after first run) and performs a full firmware

--- a/crates/fbuild-build/tests/teensy30_acceptance.rs
+++ b/crates/fbuild-build/tests/teensy30_acceptance.rs
@@ -21,7 +21,7 @@
 //! `compile_commands.json` or `.fbuild/` is ever left behind in the repo.
 //!
 //! Run with:
-//! `uv run soldr cargo test -p fbuild-build --test teensy30_acceptance -- --ignored`
+//! `soldr cargo test -p fbuild-build --test teensy30_acceptance -- --ignored`
 //!
 //! Marked `#[ignore]` because it downloads Teensyduino + arm-gcc on the
 //! first run (cached after) and performs a full firmware build — too

--- a/crates/fbuild-build/tests/teensy41_acceptance.rs
+++ b/crates/fbuild-build/tests/teensy41_acceptance.rs
@@ -25,7 +25,7 @@
 //! and no scratch artifacts land in the repo.
 //!
 //! Run with:
-//! `uv run soldr cargo test -p fbuild-build --release --test teensy41_acceptance \
+//! `soldr cargo test -p fbuild-build --release --test teensy41_acceptance \
 //!     -- --ignored teensy41_cold_library_selection_meets_205_ac6 --nocapture`
 //!
 //! Marked `#[ignore]` because it downloads Teensyduino on the first run

--- a/crates/fbuild-build/tests/teensy_build.rs
+++ b/crates/fbuild-build/tests/teensy_build.rs
@@ -3,7 +3,7 @@
 //! Downloads arm-gcc + Teensy cores (cached after first run), compiles a
 //! minimal blink sketch, and validates the output firmware.hex.
 //!
-//! Run with: `uv run soldr cargo test -p fbuild-build --test teensy_build -- --ignored`
+//! Run with: `soldr cargo test -p fbuild-build --test teensy_build -- --ignored`
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/fbuild-build/tests/teensylc_acceptance.rs
+++ b/crates/fbuild-build/tests/teensylc_acceptance.rs
@@ -14,7 +14,7 @@
 //!
 //! This test downloads Teensyduino + arm-gcc on the first run and is
 //! therefore CI-only — it is gated behind `#[ignore]` and runs via
-//! `uv run soldr cargo test -p fbuild-build --test teensylc_acceptance -- --ignored`.
+//! `soldr cargo test -p fbuild-build --test teensylc_acceptance -- --ignored`.
 
 use std::path::PathBuf;
 

--- a/crates/fbuild-config/src/bin/README.md
+++ b/crates/fbuild-config/src/bin/README.md
@@ -1,3 +1,3 @@
 # Binary Targets
 
-- **`enrich_boards.rs`** -- One-off maintenance tool that enriches stripped board JSONs with `build` and `upload` sections from PlatformIO's local platform installs (`~/.platformio/platforms/`). Extracts core, variant, f_cpu, mcu, extra_flags, VID/PID, Arduino sub-fields (ldscript, partitions), and upload protocol/speed. Run manually with `uv run soldr cargo run -p fbuild-config --bin enrich_boards`.
+- **`enrich_boards.rs`** -- One-off maintenance tool that enriches stripped board JSONs with `build` and `upload` sections from PlatformIO's local platform installs (`~/.platformio/platforms/`). Extracts core, variant, f_cpu, mcu, extra_flags, VID/PID, Arduino sub-fields (ldscript, partitions), and upload protocol/speed. Run manually with `soldr cargo run -p fbuild-config --bin enrich_boards`.

--- a/crates/fbuild-config/src/bin/enrich_boards.rs
+++ b/crates/fbuild-config/src/bin/enrich_boards.rs
@@ -8,7 +8,7 @@
 //! are committed to the repo and used as static assets at compile time.
 //!
 //! Usage:
-//!     uv run soldr cargo run -p fbuild-config --bin enrich_boards
+//!     soldr cargo run -p fbuild-config --bin enrich_boards
 
 use serde_json::{Map, Value};
 use std::collections::BTreeSet;

--- a/crates/fbuild-daemon/tests/process_containment.rs
+++ b/crates/fbuild-daemon/tests/process_containment.rs
@@ -25,7 +25,7 @@
 //!
 //! Run explicitly with:
 //! ```bash
-//! uv run soldr cargo test -p fbuild-daemon --test process_containment -- --ignored
+//! soldr cargo test -p fbuild-daemon --test process_containment -- --ignored
 //! ```
 
 use std::io::{BufRead, BufReader};

--- a/crates/fbuild-deploy/src/esp32/tests.rs
+++ b/crates/fbuild-deploy/src/esp32/tests.rs
@@ -528,7 +528,7 @@ fn verify_outcome_is_match_helper() {
 // These tests are `#[ignore]` so they never run in CI.  To exercise
 // them on a local bench, set the env vars described below and run:
 //
-//   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real -- --ignored --nocapture
+//   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real -- --ignored --nocapture
 //
 // Each test reads **two** environment variables:
 //
@@ -666,7 +666,7 @@ fn run_verify_deployment_test(
 ///
 /// ```text
 /// ESP32_PORT=COM5 ESP32_FIRMWARE=C:\path\to\firmware.bin \
-///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32 -- --ignored --nocapture
+///   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32 -- --ignored --nocapture
 /// ```
 #[test]
 #[ignore = "requires real ESP32 board — set ESP32_PORT and ESP32_FIRMWARE"]
@@ -678,7 +678,7 @@ fn try_verify_deployment_real_esp32() {
 ///
 /// ```text
 /// ESP32S2_PORT=COM6 ESP32S2_FIRMWARE=C:\path\to\firmware.bin \
-///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32s2 -- --ignored --nocapture
+///   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32s2 -- --ignored --nocapture
 /// ```
 #[test]
 #[ignore = "requires real ESP32-S2 board — set ESP32S2_PORT and ESP32S2_FIRMWARE"]
@@ -693,7 +693,7 @@ fn try_verify_deployment_real_esp32s2() {
 ///
 /// ```text
 /// ESP32S3_PORT=COM13 ESP32S3_FIRMWARE=C:\Users\niteris\dev\fastled\.pio\build\esp32s3\firmware.bin \
-///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32s3 -- --ignored --nocapture
+///   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32s3 -- --ignored --nocapture
 /// ```
 #[test]
 #[ignore = "requires real ESP32-S3 board — set ESP32S3_PORT and ESP32S3_FIRMWARE"]
@@ -705,7 +705,7 @@ fn try_verify_deployment_real_esp32s3() {
 ///
 /// ```text
 /// ESP32C2_PORT=COM7 ESP32C2_FIRMWARE=C:\path\to\firmware.bin \
-///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c2 -- --ignored --nocapture
+///   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c2 -- --ignored --nocapture
 /// ```
 #[test]
 #[ignore = "requires real ESP32-C2 board — set ESP32C2_PORT and ESP32C2_FIRMWARE"]
@@ -717,7 +717,7 @@ fn try_verify_deployment_real_esp32c2() {
 ///
 /// ```text
 /// ESP32C3_PORT=COM8 ESP32C3_FIRMWARE=C:\path\to\firmware.bin \
-///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c3 -- --ignored --nocapture
+///   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c3 -- --ignored --nocapture
 /// ```
 #[test]
 #[ignore = "requires real ESP32-C3 board — set ESP32C3_PORT and ESP32C3_FIRMWARE"]
@@ -729,7 +729,7 @@ fn try_verify_deployment_real_esp32c3() {
 ///
 /// ```text
 /// ESP32C6_PORT=COM9 ESP32C6_FIRMWARE=C:\path\to\firmware.bin \
-///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c6 -- --ignored --nocapture
+///   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32c6 -- --ignored --nocapture
 /// ```
 #[test]
 #[ignore = "requires real ESP32-C6 board — set ESP32C6_PORT and ESP32C6_FIRMWARE"]
@@ -741,7 +741,7 @@ fn try_verify_deployment_real_esp32c6() {
 ///
 /// ```text
 /// ESP32H2_PORT=COM10 ESP32H2_FIRMWARE=C:\path\to\firmware.bin \
-///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32h2 -- --ignored --nocapture
+///   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32h2 -- --ignored --nocapture
 /// ```
 #[test]
 #[ignore = "requires real ESP32-H2 board — set ESP32H2_PORT and ESP32H2_FIRMWARE"]
@@ -756,7 +756,7 @@ fn try_verify_deployment_real_esp32h2() {
 ///
 /// ```text
 /// ESP32P4_PORT=COM11 ESP32P4_FIRMWARE=C:\path\to\firmware.bin \
-///   uv run soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32p4 -- --ignored --nocapture
+///   soldr cargo test -p fbuild-deploy esp32::tests::try_verify_deployment_real_esp32p4 -- --ignored --nocapture
 /// ```
 #[test]
 #[ignore = "requires real ESP32-P4 board — set ESP32P4_PORT and ESP32P4_FIRMWARE"]

--- a/crates/fbuild-header-scan/benches/README.md
+++ b/crates/fbuild-header-scan/benches/README.md
@@ -16,5 +16,5 @@ gate (Phase 7 will wire that up in a follow-up).
 Run:
 
 ```bash
-uv run soldr cargo bench -p fbuild-header-scan --bench scan_throughput
+soldr cargo bench -p fbuild-header-scan --bench scan_throughput
 ```

--- a/crates/fbuild-library-select/benches/README.md
+++ b/crates/fbuild-library-select/benches/README.md
@@ -19,7 +19,7 @@ against it.
 Run:
 
 ```bash
-uv run soldr cargo bench -p fbuild-library-select --bench resolve_cold
+soldr cargo bench -p fbuild-library-select --bench resolve_cold
 ```
 
 ## resolve_warm
@@ -39,7 +39,7 @@ guard that runs on every CI of this crate.
 Run:
 
 ```bash
-uv run soldr cargo bench -p fbuild-library-select --bench resolve_warm
+soldr cargo bench -p fbuild-library-select --bench resolve_warm
 ```
 
 Compare against `resolve_cold`: warm should be orders of magnitude faster

--- a/crates/fbuild-library-select/benches/resolve_cold.rs
+++ b/crates/fbuild-library-select/benches/resolve_cold.rs
@@ -13,7 +13,7 @@
 //! Run with:
 //!
 //! ```text
-//! uv run soldr cargo bench -p fbuild-library-select --bench resolve_cold
+//! soldr cargo bench -p fbuild-library-select --bench resolve_cold
 //! ```
 //!
 //! Future PRs gate against the baseline number this captures.

--- a/crates/fbuild-library-select/benches/resolve_warm.rs
+++ b/crates/fbuild-library-select/benches/resolve_warm.rs
@@ -17,7 +17,7 @@
 //! Run with:
 //!
 //! ```text
-//! uv run soldr cargo bench -p fbuild-library-select --bench resolve_warm
+//! soldr cargo bench -p fbuild-library-select --bench resolve_warm
 //! ```
 //!
 //! Follows up #215 (mini bench) and #205 Phase 7 (perf budgets).

--- a/crates/fbuild-python/src/lib.rs
+++ b/crates/fbuild-python/src/lib.rs
@@ -236,7 +236,7 @@ mod tests {
     /// Deliberately does not pull a crate dep — axum is already in the
     /// workspace but not in `fbuild-python`'s dep graph, and adding it
     /// just for one test would inflate the build graph for every clean
-    /// `uv run soldr cargo check`. Raw TCP is adequate for a response we control.
+    /// `soldr cargo check`. Raw TCP is adequate for a response we control.
     async fn spawn_mock_daemon(body: String) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -99,9 +99,9 @@ This environment requires you to use `git-bash`.
 Use `soldr` directly through the repo-local uv environment (bare `cargo` / `rustc` and `uv run cargo` shims are blocked by hook):
 
 ```bash
-uv run soldr cargo check --workspace --all-targets
-uv run soldr cargo clippy --workspace --all-targets -- -D warnings
-uv run soldr cargo fmt --all
+soldr cargo check --workspace --all-targets
+soldr cargo clippy --workspace --all-targets -- -D warnings
+soldr cargo fmt --all
 ```
 
 The legacy Python linters (`./lint.sh` with `pylint`, `flake8`, `mypy`) remain for any Python utility code under `ci/`.
@@ -124,7 +124,7 @@ The `fbuild` Python package wraps a Rust PyO3 extension built from `crates/fbuil
 
 ```bash
 # Build the extension and copy it into the Python package
-uv run soldr cargo build --release -p fbuild-python --features extension-module
+soldr cargo build --release -p fbuild-python --features extension-module
 
 # Windows
 cp target/release/_native.dll python/fbuild/_native.pyd

--- a/docs/PERF_WARM_BUILD.md
+++ b/docs/PERF_WARM_BUILD.md
@@ -317,7 +317,7 @@ export FBUILD_DEV_MODE=1 FBUILD_PERF_LOG=1
 export PATH="target/x86_64-pc-windows-msvc/release:$PATH"
 
 # Build once (release) so the binaries match the instrumentation
-uv run soldr cargo build --release -p fbuild-cli -p fbuild-daemon
+soldr cargo build --release -p fbuild-cli -p fbuild-daemon
 
 # Kill any stale daemon, then run a cold build to populate disk cache
 fbuild.exe daemon stop

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,7 @@
 - [x] CI infrastructure (lint, test, install, hooks)
 - [x] Progressive disclosure documentation
 - [x] PyO3 binding stubs (SerialMonitor, Daemon, connect_daemon)
-- [x] `uv run soldr cargo check/test/clippy` all passing
+- [x] `soldr cargo check/test/clippy` all passing
 
 ## Phase 1: Serial Manager (HIGHEST RISK)
 

--- a/docs/SOLDR_BUILD_PERF.md
+++ b/docs/SOLDR_BUILD_PERF.md
@@ -12,7 +12,7 @@ daemon from this workspace.
 - Command:
 
 ```powershell
-uv run soldr cargo build --release -p fbuild-cli -p fbuild-daemon
+soldr cargo build --release -p fbuild-cli -p fbuild-daemon
 ```
 
 The benchmark used temporary target directories under `.cache/` so the normal

--- a/install
+++ b/install
@@ -167,6 +167,29 @@ def uv_sync():
         subprocess.run(["uv", "sync"], check=False)
 
 
+def install_soldr_global():
+    """Ensure `soldr` is installed globally.
+
+    Since issue #251, `soldr` is no longer pulled into the repo-local uv
+    env as a dependency of `fbuild-dev-tools`. Bootstrap it via
+    `uv tool install soldr` so subsequent `soldr cargo ...` invocations
+    work out of the box.
+    """
+    if shutil.which("soldr"):
+        log("soldr already on PATH.")
+        return
+    if not shutil.which("uv"):
+        warn("uv not on PATH; cannot install soldr globally.")
+        warn("Install soldr manually — see https://github.com/zackees/soldr")
+        return
+    log("Installing soldr globally via `uv tool install soldr` ...")
+    subprocess.run(["uv", "tool", "install", "soldr"], check=False)
+    if not shutil.which("soldr"):
+        warn("uv tool install soldr did not put `soldr` on PATH.")
+        warn("You may need to run: uv tool update-shell")
+        warn("Or install manually: see https://github.com/zackees/soldr")
+
+
 def source_rust_env():
     """Add .cargo/bin to PATH."""
     for candidate in [
@@ -273,7 +296,7 @@ def verify(plat):
             warn('  export PATH="$HOME/.cargo/bin:$PATH"')
 
     log("")
-    log("Done. Run: uv run soldr cargo check --workspace")
+    log("Done. Run: soldr cargo check --workspace")
     return True
 
 
@@ -290,6 +313,9 @@ def main():
 
     # Step 2: Initialize uv project
     uv_sync()
+
+    # Step 2b: Ensure soldr is globally installed (#251)
+    install_soldr_global()
 
     # Step 3: Install Rust
     current = current_rust_version()
@@ -317,7 +343,7 @@ def main():
         warn("")
         warn("Restart your terminal, then run:")
         warn("  rustc --version")
-        warn("  uv run soldr cargo check --workspace")
+        warn("  soldr cargo check --workspace")
 
 
 if __name__ == "__main__":

--- a/lint
+++ b/lint
@@ -49,13 +49,13 @@ def main() -> int:
 
     # --fix mode
     if fix:
-        rc = run(["uv", "run", "soldr", "cargo", "fmt", "--all"])
+        rc = run(["soldr", "cargo", "fmt", "--all"])
         if rc != 0:
             return rc
         if not file_arg:
             return run(
                 [
-                    "uv", "run", "soldr", "cargo", "clippy",
+                    "soldr", "cargo", "clippy",
                     "--workspace", "--all-targets", "--", "-D", "warnings",
                 ]
             )
@@ -66,27 +66,27 @@ def main() -> int:
         if not os.path.isfile(file_path):
             print(f"File not found: {file_path}", file=sys.stderr)
             return 1
-        rc = run(["uv", "run", "soldr", "rustfmt", file_path])
+        rc = run(["soldr", "rustfmt", file_path])
         if rc != 0:
             return rc
         crate = detect_crate(file_path)
         if crate:
             return run(
                 [
-                    "uv", "run", "soldr", "cargo", "clippy",
+                    "soldr", "cargo", "clippy",
                     "-p", crate, "--all-targets", "--", "-D", "warnings",
                 ]
             )
         else:
             return run(
                 [
-                    "uv", "run", "soldr", "cargo", "clippy",
+                    "soldr", "cargo", "clippy",
                     "--workspace", "--all-targets", "--", "-D", "warnings",
                 ]
             )
 
     # Full workspace mode
-    rc = run(["uv", "run", "soldr", "cargo", "fmt", "--all", "--check"])
+    rc = run(["soldr", "cargo", "fmt", "--all", "--check"])
     if rc != 0:
         print(
             "Formatting issues found. Run 'uv run --script lint --fix' to auto-fix.",
@@ -95,7 +95,7 @@ def main() -> int:
         return 1
     return run(
         [
-            "uv", "run", "soldr", "cargo", "clippy",
+            "soldr", "cargo", "clippy",
             "--workspace", "--all-targets", "--", "-D", "warnings",
         ]
     )

--- a/python/README.md
+++ b/python/README.md
@@ -14,7 +14,7 @@ The `_native` extension is **not** checked into the repo — it would go stale r
 
 ```bash
 # 1. Compile the PyO3 extension
-uv run soldr cargo build --release -p fbuild-python --features extension-module
+soldr cargo build --release -p fbuild-python --features extension-module
 
 # 2. Copy into python/fbuild/ (platform-specific extension name).
 #    Rustup may place output under target/<triple>/release/ on some hosts —

--- a/test
+++ b/test
@@ -37,7 +37,7 @@ for arg in "${ARGS[@]}"; do
     fi
 done
 
-CMD=(uv run soldr cargo test)
+CMD=(soldr cargo test)
 
 if [ ${#CARGO_ARGS[@]} -eq 0 ]; then
     CMD+=(--workspace)

--- a/uv.lock
+++ b/uv.lock
@@ -25,25 +25,6 @@ dev = [{ name = "fbuild-dev-tools", editable = "ci/dev-tools" }]
 name = "fbuild-dev-tools"
 version = "0.0.0"
 source = { editable = "ci/dev-tools" }
-dependencies = [
-    { name = "soldr" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "soldr", specifier = ">=0.7.4" }]
-
-[[package]]
-name = "soldr"
-version = "0.7.4"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/ca/3eea52ee622fb6fee3cf4d448c5d92f700e47d1a0f0d6839dd5b9dbfda8a/soldr-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ff59a9fc4c0419cfd5ea7d88c0c6bfa7bd8d8315d56ee13a4fa400cff0595ee0", size = 2785010, upload-time = "2026-04-20T01:22:20.144Z" },
-    { url = "https://files.pythonhosted.org/packages/87/69/7e934b078b9a10aa2e24eebdb3105e8c5d06737e05027f47eca223583026/soldr-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c84c35ce7ebe8058a23e735a8bde70b297af4d421db8b916d08737ced306612a", size = 2658121, upload-time = "2026-04-20T01:22:22.038Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/14/98783007f6c7cb3df9c0d0662a0a00b882c7853b42b12e5367833dc3f45e/soldr-0.7.4-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:2546c0a0f88db525d542817bd8905cd01d3f6332fb842d6e9f9ae7af07300106", size = 2902517, upload-time = "2026-04-20T01:22:24.315Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/e9/6ba7a0b58488cf8eb58f721bf9e0ba777468c41928624b40f884389d415e/soldr-0.7.4-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:beb757bf260e165e465083960006cf507bf45c99d7f6a467d35315ee9681d45a", size = 2972375, upload-time = "2026-04-20T01:22:25.905Z" },
-    { url = "https://files.pythonhosted.org/packages/54/26/f860b15ac40a6c1fa16cc034aa3e92fabdf1482b12828ae2415c1a732b84/soldr-0.7.4-py3-none-win_amd64.whl", hash = "sha256:3f60e73d8a4743720bfa5f87e9fd99e4afed4003a2d96b0883c29a5f8f75ff75", size = 2564899, upload-time = "2026-04-20T01:22:27.199Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/35/993057d64b2cce5bfc6d60099fbcbfabb8c7a5ca55559038ef66a54bb3fc/soldr-0.7.4-py3-none-win_arm64.whl", hash = "sha256:a14ec225f49cf83dfcc03433fe9a73cd51f3af2b422f3ac03f680624750a7d90", size = 2443430, upload-time = "2026-04-20T01:22:28.889Z" },
-]
 
 [[package]]
 name = "zccache"


### PR DESCRIPTION
Closes #251.

## Summary

`soldr` is no longer a dependency of the repo-local `fbuild-dev-tools` package. The repo now relies on `soldr` being installed globally on `PATH` — consistent with how all FastLED-org repos consume soldr.

## Changes

**Removed**
- `dependencies = [soldr>=0.7.4]` from `ci/dev-tools/pyproject.toml`.
- `uv run soldr ...` everywhere it was used at runtime — replaced with bare `soldr ...`:
  - `lint`, `ci/lint.py`, `ci/test.py`, `ci/measure_baseline_205.py` (actual subprocess calls)
  - command examples across crates, benches, docs, `CLAUDE.md`, `CODEX.md`, `install`

**Added**
- `install_soldr_global()` step in the root `install` script — when `soldr` is missing, bootstraps via `uv tool install soldr` and falls back to a clear pointer at https://github.com/zackees/soldr if uv is unavailable.
- Helpful missing-soldr error in `ci/trampoline.py::_soldr_prefix()`.
- `uv run soldr ...` is now actively **REJECTED** by `ci/hooks/tool_guard.py` (new `UV_RUN_FORBIDDEN_TARGETS` set covers `cargo`/`rustc`/etc. **and** `soldr`). Regression test added (`test_blocks_uv_run_soldr`).

**Intentionally untouched (historical)**
- `DONE.md`, `tasks/lessons.md`, `PLAN.md` — point-in-time records; preserving their original `uv run soldr` references.

## Acceptance criteria (from #251)

- [x] `ci/dev-tools/pyproject.toml` no longer declares `soldr` as a dep.
- [x] Helper code still runs `soldr` from `PATH`.
- [x] Missing-`soldr` error explains that global `soldr` is required.
- [x] Missing-`soldr` error recommends uv/uvx and links to https://github.com/zackees/soldr.

## Test plan

- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] `soldr cargo fmt --all --check` — clean
- [x] `python -m unittest test_tool_guard` — 7/7 pass (includes new `test_blocks_uv_run_soldr`)
- [ ] CI: Formatting, Documentation, board builds all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)