### PR TITLE
fix(teensy41): link libarm_cortexM7lfsp_math (CMSIS-DSP) (#257)

### DIFF
--- a/crates/fbuild-build/src/teensy/configs/teensy4x.json
+++ b/crates/fbuild-build/src/teensy/configs/teensy4x.json
@@ -38,6 +38,7 @@
   ],
 
   "linker_libs": [
+    "-larm_cortexM7lfsp_math",
     "-lgcc",
     "-lstdc++",
     "-lm",

--- a/crates/fbuild-build/src/teensy/mcu_config.rs
+++ b/crates/fbuild-build/src/teensy/mcu_config.rs
@@ -199,6 +199,26 @@ mod tests {
             .contains(&"-mcpu=cortex-m7".to_string()));
     }
 
+    /// Regression test for issue #257: teensy4x must link
+    /// `libarm_cortexM7lfsp_math.a` (CMSIS-DSP) so Teensy Audio FFT
+    /// examples (`Ports/PJRCSpectrumAnalyzer`) resolve symbols like
+    /// `arm_cfft_radix4_q15`. The library ships in the Teensy 4.x core
+    /// dir, which the linker already gets as `-L<core_dir>` via
+    /// `LinkerScripts::single`.
+    #[test]
+    fn teensy4x_links_cmsis_dsp_math() {
+        let config = get_teensy_config_for_mcu("imxrt1062").expect("teensy4x config");
+        assert!(
+            config
+                .linker_libs
+                .contains(&"-larm_cortexM7lfsp_math".to_string()),
+            "teensy4x linker_libs must include -larm_cortexM7lfsp_math \
+             so Teensy Audio FFT examples link; see issue #257. \
+             Actual libs: {:?}",
+            config.linker_libs
+        );
+    }
+
     #[test]
     fn test_teensy_config_for_mcu_mk20dx256() {
         let config = get_teensy_config_for_mcu("mk20dx256").expect("teensy3x config");


### PR DESCRIPTION
Closes #257.

## Symptom

`Ports/PJRCSpectrumAnalyzer` (and any other Teensy Audio FFT example) fails to link on teensy41:

```
undefined reference to `arm_cfft_radix4_init_q15'
undefined reference to `arm_cfft_radix4_q15'
collect2: error: ld returned 1 exit status
FAILED: Ports/PJRCSpectrumAnalyzer
```

## Root cause

These symbols live in `libarm_cortexM7lfsp_math.a`, shipped with the Teensy 4.x core under `cores/teensy4/`. Teensyduino's `boards.txt` specifies this lib mandatorily for the platform (`build.flags.libs=-larm_cortexM7lfsp_math -lm -lstdc++`), not just for FFT examples. fbuild's `teensy4x.json` `linker_libs` was missing it.

## Fix

- Add `-larm_cortexM7lfsp_math` to the front of `teensy4x.json` `linker_libs`.
- The `-L<core_dir>` search path is already emitted via `LinkerScripts::single(core_dir, ...)` in `teensy/orchestrator.rs:244` — the same dir that holds the `.ld` script also holds the lib, so no extra config needed.
- Regression test `teensy4x_links_cmsis_dsp_math` added to `teensy/mcu_config.rs`.

The PlatformIO reference JSON also omits this lib — PlatformIO has the same gap. Following Teensyduino's `boards.txt` rather than PlatformIO's reference is the correct call per the issue's analysis.

Applies to both teensy40 and teensy41 (both use the shared `teensy4x.json`).

## Test plan

- [x] `soldr cargo test -p fbuild-build --lib teensy` — 38/38 pass, including new `teensy4x_links_cmsis_dsp_math`
- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings` — clean
- [ ] FastLED teensy41 CI links `Ports/PJRCSpectrumAnalyzer` cleanly after this lands
- [ ] FastLED teensy41 workflow goes green for the first time since mid-April

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teensy 4.x builds now include the ARM Cortex M7 LFSP floating-point math library for optimized mathematical operations.

* **Tests**
  * Added regression test to ensure math library inclusion in Teensy 4.x configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->