### PR TITLE
release: v2.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "async-trait",
  "blake3",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "blake3",
  "clap",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "libc",
  "running-process-core",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "criterion",
  "rayon",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "axum",
  "bzip2",
@@ -1075,14 +1075,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.2.3"
+version = "2.2.4"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.3"
+version = "2.2.4"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release rolling up fixes + CI/dev-tooling cleanup since v2.2.3.

## User-facing
- **fix(teensy41)**: link `libarm_cortexM7lfsp_math` so Teensy Audio FFT examples (`Ports/PJRCSpectrumAnalyzer`) link cleanly (#258 → #257). First teensy41 CI green path since mid-April.

## Internal / CI / dev tooling
- **chore(deps)**: adopt upstream soldr/zccache/setup-soldr updates; `zccache-artifact` 1.4.0 → 1.8; `zccache` PyPI ≥ 1.8.2; `profile = "minimal"` in rust-toolchain.toml; `prebuild-deps: none` workaround for the setup-soldr cargo-chef regression (#253).
- **refactor(fbuild-core)**: migrate to `running-process-core` 3.4 from crates.io, dropping the abandoned-branch git pin (#254).
- **fix(ci)**: unblock Formatting + Documentation on main after the loc-gate-refactor split (#255).
- **chore(dev-tools)**: drop `soldr` from `ci/dev-tools/pyproject.toml`; require a globally-installed `soldr` everywhere; `uv run soldr ...` is now actively rejected by the `tool_guard` hook (#256 → #251).

## Release flow

On merge, `release-auto.yml` triggers automatically (path filter matches `Cargo.toml` + `pyproject.toml`):
1. Verifies Cargo + pyproject versions match (2.2.4 ↔ 2.2.4) ✓
2. Builds native binaries for 4 targets: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`
3. Publishes GitHub release `v2.2.4` (`--generate-notes` auto-fills from commit messages)
4. Builds PyPI wheels (with attestations) and publishes to PyPI under environment `pypi`

## Test plan

- [x] `soldr cargo check --workspace` — clean (Cargo.lock regenerated)
- [x] Cargo.toml version = pyproject.toml version = 2.2.4
- [ ] CI on this PR passes
- [ ] `release-auto.yml` fires on merge, ships GitHub release + PyPI wheels

🤖 Generated with [Claude Code](https://claude.com/claude-code)