### PR TITLE
fix(ci): set linker=platform-default for native cross-builds

### DIFF
--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -60,6 +60,13 @@ jobs:
           build-cache: true
           target-cache: true
           prebuild-deps: none
+          # `fast` (the default) injects mold-or-rust-lld via SOLDR_LINKER,
+          # which clobbers the per-target linker config that
+          # `cargo zigbuild` needs for aarch64-unknown-linux-musl
+          # cross-compile (clang tries to use host /usr/bin/ld and fails
+          # with "file in wrong format" on the cross crt1.o). Disable the
+          # injection and let cargo + the toolchain decide.
+          linker: platform-default
           cache-key-suffix: native-${{ inputs.target }}
 
       - uses: actions/setup-python@v6


### PR DESCRIPTION
## Why

The v2.2.4 release-auto run failed at the **aarch64-unknown-linux-musl** native build:

```
/usr/bin/ld: <sysroot>/.../aarch64-unknown-linux-musl/lib/self-contained/crt1.o:
    error adding symbols: file in wrong format
clang: error: linker command failed with exit code 1
```

clang fell back to host `/usr/bin/ld` (x86_64) instead of zig's cross-linker, so the aarch64 cross-objects couldn't be linked.

## Root cause

setup-soldr's `linker:` input defaults to `""`, which auto-injects `fast` (mold-or-rust-lld on Linux) via `SOLDR_LINKER`. That clobbers the per-target linker that `cargo zigbuild` relies on for cross-compilation.

setup-soldr documents `linker: platform-default` as the explicit opt-out that keeps whatever cargo config / rust-toolchain.toml specifies.

## Fix

Set `linker: platform-default` only on `template_native_build.yml` (release native binaries). All host-native build workflows (check-*, fmt, msrv, docs, board builds, bench-205, acceptance-205) continue to use the `fast` default — it's a clear win there.

## Test plan

- [ ] CI on this PR passes (this template only fires from `release-auto.yml` / `build.yml` workflow_call — won't run inline on PR)
- [ ] After merge, manually trigger `release-auto.yml` via workflow_dispatch — no tag yet for v2.2.4, so prepare will fire the full build + publish + pypi pipeline
- [ ] All 4 native builds succeed, including aarch64 musl

🤖 Generated with [Claude Code](https://claude.com/claude-code)