### PR TITLE
fix(library-select): honor Arduino library spec for 1.0 flat layout; release v2.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "blake3",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "blake3",
  "clap",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "libc",
  "running-process-core",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "criterion",
  "rayon",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "bincode",
  "blake3",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "axum",
  "bzip2",
@@ -1075,14 +1075,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.2.5"
+version = "2.2.6"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/fbuild-packages/src/library/framework_library.rs
+++ b/crates/fbuild-packages/src/library/framework_library.rs
@@ -77,26 +77,61 @@ pub fn library_include_dirs(lib_dir: &Path) -> Vec<PathBuf> {
     dirs
 }
 
-/// Collect every buildable source file from a library.
+/// Collect every buildable source file from a library, honoring the
+/// [Arduino library specification](https://arduino.github.io/arduino-cli/1.5/library-specification/).
 ///
-/// Skips `examples/`, `tests/`, and `extras/` subtrees to keep user-facing
-/// demos out of the build.
+/// - **1.5 recursive layout** (library has `src/`): scan `src/**` recursively.
+///   The library root is *not* scanned. This is the modern layout used by
+///   well-organized libraries.
+/// - **1.0 flat layout** (no `src/`): scan the library root *non-recursively*
+///   plus the literal `utility/` subdirectory recursively. Every other
+///   subdirectory (`fontconvert/`, `util/`, `Fonts/`, `examples/`, `extras/`,
+///   etc.) is ignored.
+///
+/// The flat-layout rule is what protects fbuild from compiling host-only
+/// tools that ship inside libraries — e.g. `ssd1351/fontconvert/fontconvert.c`
+/// (a libfreetype-linked desktop utility) under
+/// `framework-arduinoteensy/libraries/ssd1351/`. Arduino IDE and PlatformIO
+/// skip those because the spec says to scan only root + `utility/`; fbuild
+/// previously walked the full tree and tried to ARM-cross-compile the host
+/// tool, which fails at `#include <ft2build.h>`. See FastLED/fbuild#267.
 pub fn collect_library_sources(lib_dir: &Path) -> Vec<PathBuf> {
-    let search_dir = {
-        let src = lib_dir.join("src");
-        if src.is_dir() {
-            src
-        } else {
-            lib_dir.to_path_buf()
-        }
-    };
-
     let mut sources = Vec::new();
-    collect_library_sources_inner(&search_dir, &mut sources);
+    let src = lib_dir.join("src");
+    if src.is_dir() {
+        // 1.5 layout — recursive scan of src/ only.
+        collect_library_sources_inner(&src, &mut sources);
+    } else {
+        // 1.0 flat layout per Arduino spec:
+        //   * root level (non-recursive)
+        //   * utility/ (recursive, literal lowercase per the spec)
+        collect_root_level_sources(lib_dir, &mut sources);
+        let utility = lib_dir.join("utility");
+        if utility.is_dir() {
+            collect_library_sources_inner(&utility, &mut sources);
+        }
+    }
     sources.sort();
     sources
 }
 
+/// Non-recursive scan of a directory for buildable source files.
+/// Used only for the root of a 1.0 flat-layout library.
+fn collect_root_level_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && is_buildable_source(&path) {
+            out.push(path);
+        }
+    }
+}
+
+/// Recursive scan used inside `src/` (1.5 layout) and `utility/` (1.0 layout).
+/// Still skips `examples/`, `tests/`, and `extras/` defensively in case a
+/// library nests them under `src/` or `utility/`.
 fn collect_library_sources_inner(dir: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
@@ -117,17 +152,19 @@ fn collect_library_sources_inner(dir: &Path, out: &mut Vec<PathBuf>) {
                 continue;
             }
             collect_library_sources_inner(&path, out);
-        } else {
-            let ext = path
-                .extension()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_lowercase();
-            if matches!(ext.as_str(), "c" | "cpp" | "cc" | "cxx" | "s") {
-                out.push(path);
-            }
+        } else if is_buildable_source(&path) {
+            out.push(path);
         }
     }
+}
+
+fn is_buildable_source(path: &Path) -> bool {
+    let ext = path
+        .extension()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_lowercase();
+    matches!(ext.as_str(), "c" | "cpp" | "cc" | "cxx" | "s")
 }
 
 #[cfg(test)]
@@ -162,6 +199,102 @@ mod tests {
 
         let sources = collect_library_sources(tmp.path());
         assert_eq!(sources, vec![tmp.path().join("OctoWS2811.cpp")]);
+    }
+
+    /// Regression for FastLED/fbuild#267 — 1.0 flat-layout libraries
+    /// (no `src/`) must scan only the library root non-recursively plus
+    /// the literal `utility/` subdirectory. Subdirectories like
+    /// `fontconvert/`, `util/`, `Fonts/`, and `examples/` are ignored
+    /// per the Arduino library spec.
+    ///
+    /// The specific failure this guards: `ssd1351/fontconvert/fontconvert.c`
+    /// is a desktop host tool linking `-lfreetype`; ARM-cross-compiling it
+    /// fails on `#include <ft2build.h>`. Arduino IDE / PlatformIO skip
+    /// `fontconvert/` because the spec says scan root + `utility/` only.
+    #[test]
+    fn collect_library_sources_flat_layout_arduino_spec() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let lib = tmp.path().join("ssd1351");
+        std::fs::create_dir_all(&lib).unwrap();
+
+        // Root level — compiled.
+        std::fs::write(lib.join("ssd1351.cpp"), "").unwrap();
+        std::fs::write(lib.join("ssd1351.h"), "").unwrap(); // header, not source
+
+        // `utility/` — compiled (recursive).
+        std::fs::create_dir_all(lib.join("utility")).unwrap();
+        std::fs::write(lib.join("utility").join("helpers.cpp"), "").unwrap();
+        std::fs::create_dir_all(lib.join("utility").join("nested")).unwrap();
+        std::fs::write(lib.join("utility").join("nested").join("deep.cpp"), "").unwrap();
+
+        // Non-standard subdirs — ALL must be skipped.
+        std::fs::create_dir_all(lib.join("fontconvert")).unwrap();
+        std::fs::write(
+            lib.join("fontconvert").join("fontconvert.c"),
+            "#include <ft2build.h>\n", // would fail to ARM-cross-compile
+        )
+        .unwrap();
+        std::fs::create_dir_all(lib.join("util")).unwrap();
+        std::fs::write(lib.join("util").join("misc.cpp"), "").unwrap();
+        std::fs::create_dir_all(lib.join("Fonts")).unwrap();
+        std::fs::write(lib.join("Fonts").join("Roboto.c"), "").unwrap();
+        std::fs::create_dir_all(lib.join("examples").join("Demo")).unwrap();
+        std::fs::write(lib.join("examples").join("Demo").join("Demo.ino"), "").unwrap();
+
+        let sources = collect_library_sources(&lib);
+
+        let mut expected = vec![
+            lib.join("ssd1351.cpp"),
+            lib.join("utility").join("helpers.cpp"),
+            lib.join("utility").join("nested").join("deep.cpp"),
+        ];
+        expected.sort();
+
+        assert_eq!(
+            sources, expected,
+            "1.0 flat layout must yield ONLY root non-recursive + utility/ \
+             recursive per Arduino spec — see #267. \
+             Got {sources:?}, expected {expected:?}"
+        );
+    }
+
+    /// Regression for FastLED/fbuild#267 — 1.5 recursive layout (library
+    /// has `src/`) must scan only `src/**`. Any root-level source files
+    /// are intentionally ignored per the Arduino library spec; the
+    /// library's `library.properties` declares it as 1.5 by virtue of
+    /// shipping `src/`.
+    #[test]
+    fn collect_library_sources_recursive_layout_arduino_spec() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let lib = tmp.path().join("SPI");
+        std::fs::create_dir_all(lib.join("src")).unwrap();
+        std::fs::create_dir_all(lib.join("src").join("sub")).unwrap();
+
+        // src/ — recursive scan.
+        std::fs::write(lib.join("src").join("SPI.cpp"), "").unwrap();
+        std::fs::write(lib.join("src").join("sub").join("bar.cpp"), "").unwrap();
+
+        // Root-level — must NOT be compiled (1.5 layout ignores root).
+        std::fs::write(lib.join("baz.cpp"), "").unwrap();
+
+        // examples/, tests/ — always skipped.
+        std::fs::create_dir_all(lib.join("examples")).unwrap();
+        std::fs::write(lib.join("examples").join("Demo.cpp"), "").unwrap();
+
+        let sources = collect_library_sources(&lib);
+
+        let mut expected = vec![
+            lib.join("src").join("SPI.cpp"),
+            lib.join("src").join("sub").join("bar.cpp"),
+        ];
+        expected.sort();
+
+        assert_eq!(
+            sources, expected,
+            "1.5 recursive layout must yield ONLY src/** per Arduino spec — \
+             root-level `baz.cpp` must be ignored — see #267. \
+             Got {sources:?}, expected {expected:?}"
+        );
     }
 
     #[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.5"
+version = "2.2.6"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Closes #267 (Fix 2 — scanner correctness). Cuts release v2.2.6.

## The bug

`fbuild 2.2.5` fails to build any sketch for `teensy41`:

```
fatal error: ft2build.h: No such file or directory
   23 | #include <ft2build.h>
compilation terminated.
```

The offending file is `framework-arduinoteensy/libraries/ssd1351/fontconvert/fontconvert.c` — a **host-only** desktop tool that links `-lfreetype`. ssd1351 ships it as a font preprocessor; it was never meant to be ARM-cross-compiled.

## Root cause

`collect_library_sources` in `framework_library.rs` walked the entire library directory recursively for 1.0 flat-layout libraries (no `src/`), violating the [Arduino library spec](https://arduino.github.io/arduino-cli/1.5/library-specification/):

- **1.5 recursive layout** (has `src/`): scan `src/**` only.
- **1.0 flat layout** (no `src/`): scan root non-recursively plus literal `utility/`.

Subdirectories like `fontconvert/`, `util/`, `Fonts/`, `examples/`, `extras/` must be ignored. The ssd1351 author parked `fontconvert.c` in `fontconvert/` (not `utility/`) precisely so Arduino IDE and PlatformIO would skip it. fbuild's recursive walk swept it in.

## Fix

Rewrite `collect_library_sources` to dispatch on layout — 1.5 stays recursive into `src/`; 1.0 is non-recursive at root plus a single recurse into `utility/`. Matches `arduino-cli` exactly.

## Regression tests

- `collect_library_sources_flat_layout_arduino_spec` — ssd1351 fixture. Asserts root + utility/ only; fontconvert/ + util/ + Fonts/ + examples/ are all dropped.
- `collect_library_sources_recursive_layout_arduino_spec` — `src/` fixture. Asserts only `src/**`; root-level `baz.cpp` dropped.

## Release v2.2.6

Cargo + pyproject bumped to 2.2.6. On merge, `release-auto.yml` triggers (path filter matches `Cargo.toml` + `pyproject.toml`).

## Deferred (separate work)

Fix 1 from #267 — investigate why ssd1351 is reaching the compile set at all when Blink doesn't `#include <ssd1351.h>`. With Fix 2 in place, even if ssd1351 IS selected, only `ssd1351.cpp` at the root would be compiled (which cross-compiles fine for ARM). The user-reported build failure is resolved by Fix 2 alone.

## Test plan

- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all -- --check` — clean
- [x] `soldr cargo test --workspace` — all green; new framework_library tests pass
- [ ] CI passes
- [ ] `release-auto.yml` ships v2.2.6 to PyPI + GitHub
- [ ] FastLED's `bash compile teensy41` succeeds on v2.2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.2.6

* **Bug Fixes**
  * Improved library source collection handling. Libraries with `src/` directories now recursively scan only that directory, while libraries without `src/` scan the root non-recursively plus the `utility/` subdirectory. Other subdirectories are now properly excluded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->