### PR TITLE
test(library-select): teensy41 LDF leak diagnostic (#267 follow-up)

### DIFF
--- a/crates/fbuild-library-select/tests/teensy41_ldf_diag.rs
+++ b/crates/fbuild-library-select/tests/teensy41_ldf_diag.rs
@@ -1,0 +1,178 @@
+//! Diagnostic-only test for FastLED/fbuild#267 (Fix 1).
+//!
+//! Runs the LDF resolver against the real cached Teensyduino framework
+//! library set plus the user's local FastLED source tree. Prints which
+//! framework libraries get selected and why. Marked `#[ignore]` so it
+//! only runs on explicit demand:
+//!
+//!     soldr cargo test -p fbuild-library-select \
+//!         --test teensy41_ldf_diag -- --ignored --nocapture
+//!
+//! Requires:
+//!   * Cached Teensyduino framework at:
+//!     `~/.fbuild/prod/cache/platforms/dl-framework-arduinoteensy-*/.../1.160.0/libraries/`
+//!   * Local FastLED checkout at `~/dev/fastled/`
+//!
+//! Skips with a printed reason when either is missing.
+
+use std::path::{Path, PathBuf};
+
+use fbuild_library_select::resolve_with_stats;
+use fbuild_packages::library::framework_library::discover_framework_libraries;
+use walkdir::WalkDir;
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var("USERPROFILE")
+        .ok()
+        .or_else(|| std::env::var("HOME").ok())
+        .map(PathBuf::from)
+}
+
+fn find_teensy_libraries() -> Option<PathBuf> {
+    let home = home_dir()?;
+    let root = home
+        .join(".fbuild")
+        .join("prod")
+        .join("cache")
+        .join("platforms");
+    let entries = std::fs::read_dir(&root).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !name.starts_with("dl-framework-arduinoteensy-") {
+            continue;
+        }
+        for hash_entry in std::fs::read_dir(entry.path()).ok()?.flatten() {
+            for version_entry in std::fs::read_dir(hash_entry.path()).ok()?.flatten() {
+                let libs = version_entry.path().join("libraries");
+                if libs.is_dir() {
+                    return Some(libs);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn find_fastled_src() -> Option<PathBuf> {
+    let home = home_dir()?;
+    let candidate = home.join("dev").join("fastled").join("src");
+    if candidate.is_dir() {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
+fn collect_seeds(root: &Path) -> Vec<PathBuf> {
+    let mut seeds = Vec::new();
+    for entry in WalkDir::new(root).into_iter().flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let ext = entry
+            .path()
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        if matches!(
+            ext.as_str(),
+            "c" | "cpp" | "cc" | "cxx" | "s" | "ino" | "h" | "hh" | "hpp" | "hxx"
+        ) {
+            seeds.push(entry.path().to_path_buf());
+        }
+    }
+    seeds
+}
+
+#[test]
+#[ignore = "needs cached Teensyduino + local FastLED; run with --ignored --nocapture"]
+fn diag_teensy41_blink_what_libs_get_selected() {
+    let Some(libraries_dir) = find_teensy_libraries() else {
+        eprintln!("SKIP: no cached Teensyduino libraries/ dir found");
+        return;
+    };
+    let Some(fastled_src) = find_fastled_src() else {
+        eprintln!("SKIP: ~/dev/fastled/src not found");
+        return;
+    };
+
+    eprintln!("libraries_dir = {}", libraries_dir.display());
+    eprintln!("fastled_src   = {}", fastled_src.display());
+
+    let libraries = discover_framework_libraries(&libraries_dir);
+    eprintln!("discovered {} framework libraries", libraries.len());
+
+    let seeds = collect_seeds(&fastled_src);
+    eprintln!("collected {} FastLED seed files", seeds.len());
+
+    let project_search_paths = vec![fastled_src.clone()];
+
+    let (selection, stats) = resolve_with_stats(&seeds, &project_search_paths, &libraries);
+
+    eprintln!("---");
+    eprintln!(
+        "RESOLVE STATS: passes={} files_read={}",
+        stats.passes, stats.files_read
+    );
+    eprintln!(
+        "REQUIRED LIBRARIES ({}):",
+        selection.required_libraries.len()
+    );
+    for name in &selection.required_libraries {
+        eprintln!("  - {name}");
+    }
+    eprintln!("SOURCE FILES ({}):", selection.source_files.len());
+    for src in &selection.source_files {
+        eprintln!("  - {}", src.display());
+    }
+
+    let ssd1351_selected = selection
+        .required_libraries
+        .iter()
+        .any(|n| n.eq_ignore_ascii_case("ssd1351"));
+    eprintln!(
+        "---\nssd1351 SELECTED? {}",
+        if ssd1351_selected {
+            "YES (leak — bug)"
+        } else {
+            "no"
+        }
+    );
+
+    // ---- Scenario B: project has NO local FastLED visible to the walker,
+    // only an example sketch that does `#include <FastLED.h>`. This is
+    // what happens if the per-example build's src_dir doesn't include the
+    // repo src. Walker falls through to bundled FastLED → expect leak.
+    eprintln!("---\n=== Scenario B: sketch-only project (no local FastLED in roots) ===");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sketch_src = tmp.path().join("src");
+    std::fs::create_dir_all(&sketch_src).unwrap();
+    std::fs::write(
+        sketch_src.join("Blink.ino"),
+        "#include <FastLED.h>\nvoid setup(){} void loop(){}\n",
+    )
+    .unwrap();
+    let sketch_seeds = collect_seeds(&sketch_src);
+    let sketch_paths = vec![sketch_src.clone()];
+    let (sketch_sel, sketch_stats) = resolve_with_stats(&sketch_seeds, &sketch_paths, &libraries);
+    eprintln!(
+        "Scenario B STATS: passes={} files_read={}",
+        sketch_stats.passes, sketch_stats.files_read
+    );
+    eprintln!(
+        "Scenario B SELECTED ({}):",
+        sketch_sel.required_libraries.len()
+    );
+    for name in &sketch_sel.required_libraries {
+        eprintln!("  - {name}");
+    }
+    let scen_b_ssd = sketch_sel
+        .required_libraries
+        .iter()
+        .any(|n| n.eq_ignore_ascii_case("ssd1351"));
+    eprintln!(
+        "Scenario B ssd1351? {}",
+        if scen_b_ssd { "YES (leak)" } else { "no" }
+    );
+}


### PR DESCRIPTION
Follow-up to #267 (Fix 1 investigation).

## Summary

Adds an `#[ignore]`-gated diagnostic test that runs the real LDF resolver against the cached `framework-arduinoteensy` library set with two scenarios:

- **Scenario A**: FastLED's full local source tree as the project root. Selects 10 framework libs; ssd1351 NOT among them.
- **Scenario B**: sketch-only project (just `#include <FastLED.h>`). Selects 4 framework libs; ssd1351 NOT among them.

The diagnostic was used to confirm that **Bug 1 from #267 (LDF selecting ssd1351 when Blink doesn't reference it) does not reproduce on current code (v2.2.6)**. Full investigation summary on the issue: https://github.com/FastLED/fbuild/issues/267#issuecomment-4527100596

## Why ship the diagnostic as a permanent test

Future LDF-leak investigations can quickly answer "does the resolver select X for board Y?" without rebuilding the harness from scratch. The `#[ignore]` gate keeps it out of normal CI; it skips silently if the cached Teensyduino framework isn't on the host.

## Test plan

- [x] `soldr cargo check -p fbuild-library-select --tests` — clean
- [x] `soldr cargo fmt --check` — clean
- [x] Run with `--ignored --nocapture` — both scenarios pass; ssd1351 NOT selected in either
- [ ] CI passes (the test is `#[ignore]`d so doesn't run by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added diagnostic test for LDF resolver validation against framework libraries.

---

**Note:** This release contains no user-facing changes or feature updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->