### PR TITLE
feat(dylint): land ban_raw_subprocess governance lint (#264)

### DIFF
--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -1,0 +1,52 @@
+name: Dylint
+
+# Runs the custom `ban_raw_subprocess` dylint over the workspace.
+# Lives in its own job (and uses its own nightly toolchain pin) so the
+# stable workspace check on `check-ubuntu.yml` isn't blocked by dylint
+# infrastructure issues. See #264.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  dylint:
+    name: Dylint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v3
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+          toolchain: 1.94.1
+          cache-key-suffix: dylint
+          prebuild-deps: none
+      - name: Install Dylint nightly toolchain
+        # Pin matches `dylints/ban_raw_subprocess/rust-toolchain.toml`
+        # and zccache's `ci/build_dylint_driver.py::TOOLCHAIN_CHANNEL`.
+        run: rustup toolchain install nightly-2026-03-26 --component llvm-tools-preview --component rust-src --component rustc-dev --profile minimal
+      - name: Install Dylint
+        run: soldr cargo install cargo-dylint dylint-link --version 5.0.0 --locked
+      - name: Build compatible Dylint driver
+        # Published dylint_driver 5.0.0 does not build against the
+        # nightly toolchain pinned by dylint_linting 5.0.0; this script
+        # builds a matching driver from the same git rev. Exports
+        # DYLINT_DRIVER_PATH into $GITHUB_ENV for subsequent steps.
+        run: uv run python ci/build_dylint_driver.py
+      - name: Check dylint crate formatting
+        run: soldr cargo fmt --manifest-path dylints/ban_raw_subprocess/Cargo.toml --all -- --check
+      - name: Test dylint crate
+        run: |
+          export PATH="${CARGO_HOME}/bin:${PATH}"
+          cargo +nightly-2026-03-26 test --manifest-path dylints/ban_raw_subprocess/Cargo.toml
+      - name: Run dylint over workspace
+        run: |
+          export PATH="${CARGO_HOME}/bin:${PATH}"
+          cargo dylint --all -- --workspace --all-targets

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -47,6 +47,45 @@ jobs:
           export PATH="${CARGO_HOME}/bin:${PATH}"
           cargo +nightly-2026-03-26 test --manifest-path dylints/ban_raw_subprocess/Cargo.toml
       - name: Run dylint over workspace
+        # cargo-dylint 5.0.0 expects libraries on disk as
+        # `<name>@<toolchain>.<ext>` but cargo emits them as bare
+        # `<name>.<ext>` on first build. After each cargo-dylint
+        # invocation, alias any just-built libraries that lack the
+        # `@<toolchain>` suffix and retry. Same loop zccache uses in
+        # `ci/lint.py::lint_dylint_only`.
         run: |
           export PATH="${CARGO_HOME}/bin:${PATH}"
-          cargo dylint --all -- --workspace --all-targets
+          set +e
+          for attempt in 1 2 3; do
+            cargo dylint --all -- --workspace --all-targets
+            rc=$?
+            if [ $rc -eq 0 ]; then
+              exit 0
+            fi
+            created_any=0
+            for lib_dir in target/dylint/libraries/*/release; do
+              [ -d "$lib_dir" ] || continue
+              toolchain="$(basename "$(dirname "$lib_dir")")"
+              for ext in so dylib dll; do
+                for lib in "$lib_dir"/*."$ext"; do
+                  [ -f "$lib" ] || continue
+                  stem="$(basename "$lib" ".$ext")"
+                  case "$stem" in
+                    *"@"*) continue ;;
+                  esac
+                  alias_path="$lib_dir/${stem}@${toolchain}.${ext}"
+                  if [ ! -e "$alias_path" ]; then
+                    cp "$lib" "$alias_path"
+                    created_any=1
+                  fi
+                done
+              done
+            done
+            if [ "$created_any" -eq 0 ]; then
+              echo "::error::cargo dylint failed and no new aliases to create on attempt $attempt"
+              exit $rc
+            fi
+            echo "Created @<toolchain> aliases; retrying cargo dylint (attempt $((attempt+1)))..."
+          done
+          echo "::error::cargo dylint did not succeed after 3 attempts"
+          exit 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,14 @@ members = [
     "crates/fbuild-library-select",
     "bench/fastled-examples",
 ]
+# Custom dylints have their own nightly toolchain pin (see
+# `dylints/*/rust-toolchain.toml`) and must not be part of the
+# stable workspace build — `cargo dylint --all` builds them with
+# the pinned nightly via the discovery below. See #264.
+exclude = ["dylints/ban_raw_subprocess"]
+
+[workspace.metadata.dylint]
+libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
 version = "2.2.6"

--- a/ci/build_dylint_driver.py
+++ b/ci/build_dylint_driver.py
@@ -1,0 +1,176 @@
+"""Build a Dylint driver from the git revision used by the lint crate.
+
+The published `dylint_driver` 5.0.0 crate does not build against the
+nightly toolchain pinned by CI. The lint crate already pins Dylint's git
+revision for `dylint_linting` and `dylint_testing`; this script builds the
+matching driver from that checkout and exports DYLINT_DRIVER_PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+DYLINT_REPO = "https://github.com/trailofbits/dylint"
+DYLINT_REV = "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09"
+TOOLCHAIN_CHANNEL = "nightly-2026-03-26"
+
+
+def run(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:  # noqa: ANN003
+    print("+", " ".join(args), flush=True)
+    return subprocess.run(args, check=True, text=True, **kwargs)
+
+
+def rustc_host() -> str:
+    # Invoke rustc through `rustup run` so the call works even when PATH
+    # is fronted by shims (e.g. soldr) that do not understand the
+    # `+<toolchain>` directive that only the rustup `cargo`/`rustc`
+    # wrappers parse.
+    output = subprocess.check_output(
+        ["rustup", "run", TOOLCHAIN_CHANNEL, "rustc", "-vV"],
+        text=True,
+    )
+    for line in output.splitlines():
+        if line.startswith("host: "):
+            return line.split("host: ", 1)[1]
+    raise RuntimeError("could not determine rustc host triple")
+
+
+def rustc_toolchain_root(full_toolchain: str) -> Path:
+    rustc = subprocess.check_output(
+        ["rustup", "which", "--toolchain", full_toolchain, "rustc"],
+        text=True,
+    ).strip()
+    return Path(rustc).resolve().parent.parent
+
+
+def write_driver_package(package: Path, dylint_checkout: Path, full_toolchain: str) -> None:
+    src = package / "src"
+    src.mkdir(parents=True)
+
+    driver_path = str((dylint_checkout / "driver").resolve()).replace("\\", "\\\\")
+    (package / "Cargo.toml").write_text(
+        f"""
+[package]
+name = "dylint_driver-{full_toolchain}"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+env_logger = "0.11"
+dylint_driver = {{ path = "{driver_path}" }}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    # Use `.toml` extension so rustup unambiguously parses as TOML.
+    # The extensionless `rust-toolchain` form is ambiguous (single-line
+    # vs TOML) and on Windows hosts has been observed to silently fall
+    # through to the default toolchain, leaving the build script's
+    # `#![feature(...)]` rejected as "stable channel".
+    (package / "rust-toolchain.toml").write_text(
+        f"""
+[toolchain]
+channel = "{full_toolchain}"
+components = ["llvm-tools-preview", "rustc-dev"]
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (src / "main.rs").write_text(
+        """
+#![feature(rustc_private)]
+
+use anyhow::Result;
+use std::env;
+
+pub fn main() -> Result<()> {
+    env_logger::init();
+
+    let args: Vec<_> = env::args_os().collect();
+
+    dylint_driver::dylint_driver(&args)
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def append_github_env(name: str, value: Path) -> None:
+    github_env = os.environ.get("GITHUB_ENV")
+    if github_env:
+        with open(github_env, "a", encoding="utf-8") as file:
+            file.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    full_toolchain = f"{TOOLCHAIN_CHANNEL}-{rustc_host()}"
+    runner_temp = Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir())).resolve()
+    driver_root = runner_temp / "dylint-drivers"
+    driver_dir = driver_root / full_toolchain
+    driver_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="fbuild-dylint-") as temp:
+        temp_path = Path(temp)
+        checkout = temp_path / "dylint"
+        package = temp_path / "driver-package"
+
+        run(["git", "clone", "--filter=blob:none", DYLINT_REPO, str(checkout)])
+        run(["git", "-C", str(checkout), "checkout", DYLINT_REV])
+
+        package.mkdir()
+        write_driver_package(package, checkout, full_toolchain)
+
+        env = os.environ.copy()
+        # Force the rustup toolchain in the env so it propagates into
+        # nested cargo/rustc invocations (e.g. build-script compilation
+        # of dylint_driver which uses `#![feature(...)]` and requires
+        # nightly). Setting via env is more reliable than relying solely
+        # on the `rust-toolchain.toml` lookup, especially on Windows.
+        env["RUSTUP_TOOLCHAIN"] = full_toolchain
+        # Anchor RUSTC and CARGO to the specific nightly binaries to
+        # defeat shadowing by any stable `rustc`/`cargo` that may appear
+        # earlier in PATH (e.g. a Chocolatey-installed stable on
+        # Windows). Without this, cargo's build-script rustc invocation
+        # may resolve to a stable rustc and fail on `#![feature(...)]`
+        # with E0554.
+        nightly_bin = rustc_toolchain_root(full_toolchain) / "bin"
+        rustc_exe = nightly_bin / ("rustc.exe" if os.name == "nt" else "rustc")
+        cargo_exe = nightly_bin / ("cargo.exe" if os.name == "nt" else "cargo")
+        if rustc_exe.exists():
+            env["RUSTC"] = str(rustc_exe)
+        if cargo_exe.exists():
+            env["CARGO"] = str(cargo_exe)
+        if os.name != "nt":
+            toolchain_root = rustc_toolchain_root(full_toolchain)
+            rpath = f"-C link-args=-Wl,-rpath,{toolchain_root / 'lib'}"
+            env["RUSTFLAGS"] = f"{env.get('RUSTFLAGS', '')} {rpath}".strip()
+
+        # Use `rustup run` instead of `cargo +<toolchain>` because the
+        # cargo on PATH may be a shim (e.g. soldr's) that does not parse
+        # the `+<toolchain>` directive — that directive is only honored
+        # by the rustup-managed cargo wrapper. `rustup run` selects the
+        # toolchain explicitly and works regardless of which `cargo`
+        # comes first on PATH.
+        run(
+            ["rustup", "run", TOOLCHAIN_CHANNEL, "cargo", "build"],
+            cwd=package,
+            env=env,
+        )
+
+        exe_suffix = ".exe" if os.name == "nt" else ""
+        built_driver = package / "target" / "debug" / f"dylint_driver-{full_toolchain}{exe_suffix}"
+        installed_driver = driver_dir / f"dylint-driver{exe_suffix}"
+        shutil.copy2(built_driver, installed_driver)
+
+    append_github_env("DYLINT_DRIVER_PATH", driver_root)
+    print(f"DYLINT_DRIVER_PATH={driver_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dylints/README.md
+++ b/dylints/README.md
@@ -1,0 +1,59 @@
+# `dylints/`
+
+Custom [dylint](https://github.com/trailofbits/dylint) lints for fbuild
+production code. Each lint lives in its own crate so it can pin its own
+nightly toolchain (the rustc internal API moves fast; the workspace
+itself stays on stable 1.94.1).
+
+## Crates
+
+- **`ban_raw_subprocess/`** — forbids `Command::{spawn, output, status}`
+  on `std::process::Command` and `tokio::process::Command` in production
+  code (`crates/*/src/`). All subprocess spawns must flow through
+  `fbuild_core::subprocess::run_command` /
+  `fbuild_core::containment::*`. See #264.
+
+## Running locally
+
+```bash
+# One-time setup
+rustup toolchain install nightly-2026-03-26 \
+    --component llvm-tools-preview --component rust-src --component rustc-dev \
+    --profile minimal
+soldr cargo install cargo-dylint dylint-link --version 5.0.0 --locked
+uv run python ci/build_dylint_driver.py   # builds a matching driver
+
+# Run all dylints over the workspace
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
+cargo dylint --all -- --workspace --all-targets
+```
+
+CI runs this on every push/PR via `.github/workflows/dylint.yml`.
+
+## Why a separate toolchain pin
+
+`dylint_linting` builds against a specific nightly rustc; the rustc
+internal API (`rustc_lint`, `rustc_hir`, `rustc_span`) changes between
+nightlies. Keeping the dylint crate in `[workspace.exclude]` lets it
+pin `nightly-2026-03-26` in its own `rust-toolchain.toml` without
+forcing the entire workspace to nightly.
+
+The workspace registers the lint directory via:
+
+```toml
+[workspace.metadata.dylint]
+libraries = [{ path = "dylints/*" }]
+```
+
+so `cargo dylint --all` picks it up automatically.
+
+## Why `build_dylint_driver.py`
+
+Published `dylint_driver` 5.0.0 doesn't compile against the
+nightly-2026-03-26 toolchain (rustc internals drift). `cargo-dylint` would
+try to build it from crates.io and fail with `E0609: no field
+env_depinfo`. The script clones the dylint repo at the same git rev
+`dylint_linting` is pinned to (`4bd91ce…`) and builds a matching driver
+from that source, installing it where `cargo-dylint` expects.
+
+This mirrors zccache's approach 1:1; the script is a direct port.

--- a/dylints/ban_raw_subprocess/.gitignore
+++ b/dylints/ban_raw_subprocess/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/dylints/ban_raw_subprocess/Cargo.toml
+++ b/dylints/ban_raw_subprocess/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ban_raw_subprocess"
+version = "0.1.0"
+description = "Ban raw std/tokio Command spawn/output/status in fbuild production code"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Pinned to the same dylint_linting rev zccache's dylints use — same
+# rustup channel in rust-toolchain.toml, same upstream commit.
+dylint_linting = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09" }
+
+[dev-dependencies]
+dylint_testing = { git = "https://github.com/trailofbits/dylint", rev = "4bd91ce7729b74c7ee5664bbb588f7baf30b4a09" }
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/dylints/ban_raw_subprocess/README.md
+++ b/dylints/ban_raw_subprocess/README.md
@@ -1,0 +1,91 @@
+# `ban_raw_subprocess`
+
+Custom [dylint](https://github.com/trailofbits/dylint) that forbids direct
+calls to `Command::{spawn, output, status}` on `std::process::Command` and
+`tokio::process::Command` in fbuild production code (anything under
+`crates/*/src/`).
+
+## Why
+
+Every child process fbuild launches must flow through one of the blessed
+wrappers in `crates/fbuild-core/src/`:
+
+- `subprocess::run_command` — sync, captures stdout/stderr via
+  `running-process-core::NativeProcess` so the drain loop can't deadlock
+  on a full pipe buffer (see #141).
+- `containment::spawn_contained` /
+  `containment::tokio_spawn::spawn_contained` — applies Windows Job
+  Object containment + Linux per-child pgid + originator-env propagation
+  (see #129, #254).
+- `containment::spawn_detached` — for the rare case where the child must
+  outlive its launcher (daemon bootstrap from the CLI/Python).
+
+Bypassing the wrappers silently regresses one or more of those
+invariants. This lint catches both call shapes at compile time:
+
+- Method-call: `cmd.spawn()` / `cmd.output()` / `cmd.status()`
+- Qualified-path call:
+  `std::process::Command::spawn(&mut cmd)` /
+  `tokio::process::Command::output(&mut cmd)` /
+  `<Command>::status(&mut cmd)`
+
+## Scope
+
+Only files whose path contains BOTH `crates/` and a subsequent `/src/`
+segment are linted. Out of scope by design:
+
+- `crates/*/tests/` — integration tests can spawn binaries under test
+- `crates/*/examples/` — example code may spawn anything
+- `crates/*/benches/` — benchmark harnesses
+- `ci/` — Python tooling, not Rust production
+- `dylints/` — this crate and its siblings
+- Build scripts, anything else
+
+## Allowlist
+
+Files in scope that legitimately need raw spawns are listed in
+`src/allowlist.txt`. Each entry needs an inline comment explaining why.
+Current entries:
+
+| Path | Reason |
+|---|---|
+| `crates/fbuild-core/src/subprocess.rs` | Internal helpers in the wrapper itself |
+| `crates/fbuild-core/src/containment.rs` | IS the wrapper — `command.spawn()` is the implementation |
+| `crates/fbuild-daemon/src/bin/containment_harness.rs` | Test harness for #129 |
+| `crates/fbuild-cli/src/daemon_client.rs` | Daemon bootstrap — must outlive CLI |
+| `crates/fbuild-python/src/daemon.rs` | Daemon bootstrap from Python interop |
+| `crates/fbuild-build/src/zccache.rs` | Starts the zccache daemon (cross-tool) |
+| `crates/fbuild-cli/src/cli/clang_tools.rs` | Async fan-out, no daemon containment in CLI |
+
+## Toolchain
+
+Pinned to the same `nightly-2026-03-26` channel and the same
+`trailofbits/dylint` git rev (`4bd91ce…`) that zccache uses for its own
+dylints — this keeps the `dylint_linting` / `dylint_driver` versions
+aligned across both repos and lets `ci/build_dylint_driver.py` (ported
+from zccache) build a matching driver for CI.
+
+## Running locally
+
+```bash
+# One-time setup
+rustup toolchain install nightly-2026-03-26 --component llvm-tools-preview \
+    --component rust-src --component rustc-dev --profile minimal
+soldr cargo install cargo-dylint dylint-link --version 5.0.0
+uv run python ci/build_dylint_driver.py   # exports DYLINT_DRIVER_PATH
+
+# Run the lint over the workspace
+cargo dylint --all -- --workspace --all-targets
+```
+
+CI runs this on every push/PR via `.github/workflows/dylint.yml`.
+
+## See also
+
+- Issue #264 — this lint's tracking issue (3 CR blockers from PR #262)
+- PR #262 — original LTO fix that prototyped this lint and deferred it
+- zccache `dylints/ban_raw_subprocess_in_daemon/` — sibling pattern this
+  is modeled on
+- `ci/find_direct_subprocess.py` — the prior string-matching guard that
+  catches `Command::new(`; complements this lint by checking the
+  constructor side at the import/syntax level

--- a/dylints/ban_raw_subprocess/rust-toolchain.toml
+++ b/dylints/ban_raw_subprocess/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-03-26"
+components = ["llvm-tools-preview", "rust-src", "rustc-dev"]

--- a/dylints/ban_raw_subprocess/src/README.md
+++ b/dylints/ban_raw_subprocess/src/README.md
@@ -1,0 +1,31 @@
+# `ban_raw_subprocess` — sources
+
+- **`lib.rs`** — late-pass `LintContext` visitor that fires on:
+  - `ExprKind::MethodCall` whose resolved `type_dependent_def_id` matches
+    one of `BANNED_METHOD_PATHS` (catches `cmd.spawn()` / `cmd.output()`
+    / `cmd.status()`)
+  - `ExprKind::Path` whose `qpath_res` resolves to a banned associated
+    function (catches `Command::spawn(&mut cmd)`, `<Command>::output(...)`,
+    `tokio::process::Command::status(...)`, etc.)
+
+  Matching is exact — any other method on `Command` (`args`, `env`,
+  `current_dir`) or on `Child` (`wait_with_output`, `kill`, `try_wait`)
+  is intentionally not banned.
+
+  Scope is restricted to files whose path contains BOTH `crates/` and a
+  subsequent `/src/` segment, via `in_production_scope`. This excludes
+  `crates/*/tests/`, `crates/*/examples/`, `crates/*/benches/`, `ci/`,
+  `dylints/`, and anything outside `crates/`. (See #264 CR blocker #2:
+  the prior prototype's `SOURCE_PREFIX = "crates/"` was too loose and
+  flagged test files that legitimately spawn binaries under test.)
+
+- **`allowlist.txt`** — newline-separated tail-suffix matches for source
+  files that legitimately need to call the banned APIs (the blessed
+  helpers themselves; daemon-bootstrap spawns from the CLI/Python;
+  cross-tool zccache daemon launch; CLI-side async fan-out where no
+  containment group exists). New entries require a justification
+  comment.
+
+The `_in_daemon` suffix that zccache's sibling crate uses isn't applied
+here because fbuild's wrappers are used by *every* crate, not just the
+daemon — the scope is "production code under `crates/*/src/`".

--- a/dylints/ban_raw_subprocess/src/allowlist.txt
+++ b/dylints/ban_raw_subprocess/src/allowlist.txt
@@ -1,0 +1,47 @@
+# Each non-empty, non-comment line is matched against the tail of each
+# source file path (slashes normalized to /). The lint only fires on
+# files whose path contains BOTH `crates/` and `/src/`; anywhere else
+# is out of scope and does not need an entry here.
+#
+# Add an entry ONLY for files that legitimately need to bypass the
+# wrappers in `crates/fbuild-core/src/{subprocess,containment}.rs`.
+# Include an inline comment explaining why.
+
+# The blessed wrappers themselves. `subprocess.rs` runs commands via
+# `running_process_core::NativeProcess::start()` (not `Command::spawn`),
+# but defensively allowlist it so internal helpers/refactors stay
+# unconstrained. `containment.rs` is the entire point of the file —
+# raw `command.spawn()` is the implementation detail that gives us a
+# `std::process::Child` to attach to the Windows Job Object (the
+# published `running-process-core` 3.4 API returns `SpawnedChild`, not
+# `Child`, so this raw-spawn pattern is the bridge — see PR #254).
+crates/fbuild-core/src/subprocess.rs
+crates/fbuild-core/src/containment.rs
+
+# Test harness binary that exercises the containment regression for
+# FastLED/fbuild#129. Lives under `src/bin/` (production tree) so it
+# falls inside the lint scope, but it spawns itself to validate the
+# EPERM-on-second-child fix — that's the test, raw spawn is correct.
+crates/fbuild-daemon/src/bin/containment_harness.rs
+
+# CLI spawns the daemon detached so it outlives the CLI process. No
+# tokio variant of `containment::spawn_detached` exists (the wrapper
+# only covers `spawn_contained` for tokio). The raw spawn here is
+# intentional and documented inline ("daemon must outlive the CLI").
+crates/fbuild-cli/src/daemon_client.rs
+
+# Python interop layer spawns `fbuild-daemon` for the
+# `from fbuild.api import ...` use case. Same rationale as daemon
+# bootstrap from the CLI: daemon must outlive the Python interpreter.
+crates/fbuild-python/src/daemon.rs
+
+# `fbuild-build/src/zccache.rs` starts the `zccache` daemon which must
+# outlive the fbuild daemon (cross-tool dependency: zccache is a
+# separate process, not subordinate to fbuild). Documented inline.
+crates/fbuild-build/src/zccache.rs
+
+# Parallel async fan-out for clang-tidy/iwyu in the CLI binary. The
+# CLI doesn't install a global containment group, so going through
+# `containment::tokio_spawn::spawn_contained` would be a no-op anyway;
+# documented inline at each call site.
+crates/fbuild-cli/src/cli/clang_tools.rs

--- a/dylints/ban_raw_subprocess/src/lib.rs
+++ b/dylints/ban_raw_subprocess/src/lib.rs
@@ -1,0 +1,269 @@
+#![feature(rustc_private)]
+
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use rustc_errors::DiagDecorator;
+use rustc_hir::{def::Res, Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_span::{symbol::Symbol, FileName, RemapPathScopeComponents};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Bans `Command::spawn`, `Command::output`, and `Command::status`
+    /// on `std::process::Command` and `tokio::process::Command` in
+    /// fbuild production code (files under `crates/*/src/`).
+    ///
+    /// Catches both call shapes:
+    ///   * Method-call:  `cmd.spawn()` / `cmd.output()` / `cmd.status()`
+    ///   * Qualified path call:
+    ///     `std::process::Command::spawn(&mut cmd)` /
+    ///     `tokio::process::Command::output(&mut cmd)` etc.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Every child process fbuild launches must go through one of the
+    /// blessed wrappers in `crates/fbuild-core/src/`:
+    /// `subprocess::run_command` (sync, captures stdout/stderr via
+    /// `running-process-core::NativeProcess` so the drain loop can't
+    /// deadlock on a full pipe buffer — see #141),
+    /// `containment::spawn_contained` /
+    /// `containment::tokio_spawn::spawn_contained` (apply Windows Job
+    /// Object containment + Linux per-child pgid + originator env), or
+    /// `containment::spawn_detached` for the rare case where the child
+    /// must outlive its launcher (daemon bootstrap).
+    ///
+    /// Bypassing them silently regresses one or more invariants. The
+    /// dylint enforces the contract at lint time so the requirement
+    /// can't drift back as new code is added.
+    ///
+    /// ### Known problems
+    ///
+    /// Allowlisting is file-level via `src/allowlist.txt`. The lint
+    /// does not detect `#[cfg(test)]` scope programmatically — if a
+    /// test file under `crates/*/src/` legitimately needs raw spawns
+    /// (e.g. inline unit tests in the wrapper itself), add the file to
+    /// the allowlist with a justification comment.
+    ///
+    /// Files outside `crates/*/src/` (integration tests under
+    /// `crates/*/tests/`, examples under `crates/*/examples/`, benches
+    /// under `crates/*/benches/`, build scripts, the `ci/` and
+    /// `dylints/` trees) are out-of-scope by design.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// let mut cmd = std::process::Command::new("rustc");
+    /// cmd.args(["--version"]);
+    /// let output = cmd.output().unwrap();
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust,ignore
+    /// let output = fbuild_core::subprocess::run_command(
+    ///     &["rustc", "--version"],
+    ///     None,
+    ///     None,
+    ///     None,
+    /// )?;
+    /// ```
+    pub BAN_RAW_SUBPROCESS,
+    Deny,
+    "ban raw Command::{spawn, output, status} in fbuild production code"
+}
+
+/// Each entry is a fully-qualified path to a banned method. Matching is
+/// exact. We list `std::process::Command::*` and
+/// `tokio::process::Command::*` separately — they are distinct types
+/// with distinct DefIds — and intentionally omit other methods on
+/// `Command` (e.g. `args`, `env`, `current_dir`) and on `Child` (e.g.
+/// `wait_with_output`, `kill`). The bug class is at *spawn time*.
+const BANNED_METHOD_PATHS: &[&[&str]] = &[
+    &["std", "process", "Command", "spawn"],
+    &["std", "process", "Command", "output"],
+    &["std", "process", "Command", "status"],
+    &["tokio", "process", "Command", "spawn"],
+    &["tokio", "process", "Command", "output"],
+    &["tokio", "process", "Command", "status"],
+];
+
+const ALLOWLIST: &str = include_str!("allowlist.txt");
+
+/// Production-code scope. Only files whose path contains BOTH
+/// `crates/` and `/src/` are linted. This intentionally excludes
+/// `crates/*/tests/`, `crates/*/examples/`, `crates/*/benches/`,
+/// `ci/`, `dylints/`, build scripts, and any other non-production
+/// path. See #264 (CR blocker #2) for the prior over-broad scope bug.
+const CRATES_PREFIX: &str = "crates/";
+const SRC_SEGMENT: &str = "/src/";
+
+impl<'tcx> LateLintPass<'tcx> for BanRawSubprocess {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let filename = source_filename(cx, expr.span);
+        let normalized = normalize_slashes(&filename);
+
+        // Out-of-scope file → never fires.
+        if !in_production_scope(&normalized) {
+            return;
+        }
+
+        // Allowlisted file → exempt by configuration.
+        if is_allowlisted(&normalized) {
+            return;
+        }
+
+        match expr.kind {
+            // Method-call shape: `cmd.spawn()` / `cmd.output()` /
+            // `cmd.status()`. `type_dependent_def_id` returns the
+            // canonical DefId of the resolved method, so re-exports
+            // and aliases still resolve to the canonical
+            // `std::process::Command::spawn` etc.
+            ExprKind::MethodCall(_, _, _, _) => {
+                if let Some(def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
+                    check_def_id(cx, expr.span, def_id);
+                }
+            }
+            // Qualified-path call shape: `std::process::Command::spawn(&mut cmd)` /
+            // `tokio::process::Command::output(&mut cmd)` / `<Command>::status(&mut cmd)`.
+            // CR blocker #3 from #264: the prior prototype only
+            // handled `ExprKind::MethodCall` and missed this entire
+            // call shape. `qpath_res` is the resolver for any path
+            // expression — including ones written as fully-qualified
+            // calls and ones with explicit `<Type>::method` syntax.
+            ExprKind::Path(ref qpath) => {
+                if let Res::Def(_, def_id) = cx.qpath_res(qpath, expr.hir_id) {
+                    check_def_id(cx, expr.span, def_id);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn check_def_id(cx: &LateContext<'_>, span: rustc_span::Span, def_id: rustc_hir::def_id::DefId) {
+    for banned in BANNED_METHOD_PATHS {
+        if def_path_equals(cx, def_id, banned) {
+            emit_lint(cx, span, banned);
+            return;
+        }
+    }
+}
+
+fn emit_lint(cx: &LateContext<'_>, span: rustc_span::Span, banned: &[&str]) {
+    let joined = banned.join("::");
+    cx.opt_span_lint(
+        BAN_RAW_SUBPROCESS,
+        Some(span),
+        DiagDecorator(move |diag| {
+            diag.primary_message(format!(
+                "`{joined}` bypasses fbuild's spawn discipline; route through \
+                 `fbuild_core::subprocess::run_command` (sync, capture) or \
+                 `fbuild_core::containment::spawn_contained` / `spawn_detached` / \
+                 `tokio_spawn::spawn_contained` so containment, drain semantics, \
+                 and originator-env propagation are applied. If raw spawn is \
+                 truly justified for this file, allowlist it in \
+                 `dylints/ban_raw_subprocess/src/allowlist.txt` with a one-line \
+                 reason."
+            ));
+        }),
+    );
+}
+
+fn source_filename(cx: &LateContext<'_>, span: rustc_span::Span) -> String {
+    match cx.sess().source_map().span_to_filename(span) {
+        FileName::Real(real_filename) => real_filename
+            .local_path()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_else(|| {
+                real_filename
+                    .path(RemapPathScopeComponents::DIAGNOSTICS)
+                    .to_string_lossy()
+                    .into_owned()
+            }),
+        filename => filename
+            .display(RemapPathScopeComponents::DIAGNOSTICS)
+            .to_string(),
+    }
+}
+
+fn in_production_scope(normalized: &str) -> bool {
+    // Require BOTH "crates/" and a subsequent "/src/" segment. The
+    // `/src/` lookup is anchored after the `crates/` hit so a file
+    // like `ci/src/foo.rs` wouldn't accidentally match.
+    let Some(crates_at) = normalized.find(CRATES_PREFIX) else {
+        return false;
+    };
+    let after_crates = &normalized[crates_at + CRATES_PREFIX.len()..];
+    after_crates.contains(SRC_SEGMENT)
+}
+
+fn is_allowlisted(normalized: &str) -> bool {
+    ALLOWLIST
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .any(|allowed| normalized.ends_with(allowed))
+}
+
+fn normalize_slashes(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn def_path_equals(
+    cx: &LateContext<'_>,
+    def_id: rustc_hir::def_id::DefId,
+    expected: &[&str],
+) -> bool {
+    let def_path = cx.get_def_path(def_id);
+    if def_path.len() != expected.len() {
+        return false;
+    }
+    def_path
+        .iter()
+        .zip(expected.iter())
+        .all(|(actual, expected_segment)| *actual == Symbol::intern(expected_segment))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_production_scope_matches_src_files() {
+        assert!(in_production_scope("crates/fbuild-core/src/subprocess.rs"));
+        assert!(in_production_scope(
+            "/home/runner/work/fbuild/crates/fbuild-cli/src/cli/build.rs"
+        ));
+        assert!(in_production_scope(
+            "C:/Users/x/dev/fbuild/crates/fbuild-build/src/teensy/orchestrator.rs"
+        ));
+    }
+
+    #[test]
+    fn in_production_scope_rejects_non_src() {
+        assert!(!in_production_scope(
+            "crates/fbuild-cli/tests/lib_select.rs"
+        ));
+        assert!(!in_production_scope("crates/fbuild-build/examples/demo.rs"));
+        assert!(!in_production_scope(
+            "crates/fbuild-core/benches/bench_subprocess.rs"
+        ));
+        assert!(!in_production_scope("ci/find_direct_subprocess.py"));
+        assert!(!in_production_scope(
+            "dylints/ban_raw_subprocess/src/lib.rs"
+        ));
+        assert!(!in_production_scope("build.rs"));
+    }
+
+    #[test]
+    fn is_allowlisted_matches_path_suffix() {
+        // The real allowlist has its own entries; this just sanity-checks the
+        // suffix-match logic against a small synthetic example.
+        assert!(crate::is_allowlisted(
+            "/anywhere/crates/fbuild-core/src/containment.rs"
+        ));
+    }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.3"
+version = "2.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },


### PR DESCRIPTION
## Summary

Closes #264. Lands the custom `ban_raw_subprocess` dylint that was prototyped in PR #262 and deferred, addressing all three CR blockers from that prior attempt.

The lint fires on `Command::{spawn, output, status}` (both `std::process::Command` and `tokio::process::Command`) outside an explicit allowlist, so every subprocess fbuild launches has to flow through one of the blessed wrappers in `fbuild-core::{subprocess, containment}` and the running-process-core / Job-Object invariants can't drift back in via new code.

## What's new vs. the PR #262 prototype

| CR blocker | Fix in this PR |
|---|---|
| 1. Published `dylint_driver 5.0.0` can't build against `nightly-2026-03-26` — `cargo dylint` fails on `env_depinfo` / `file_depinfo` E0609 | Port `ci/build_dylint_driver.py` from zccache. Builds a driver from the same `trailofbits/dylint` git rev (`4bd91ce…`) that `dylint_linting` is pinned to, installs it where `cargo-dylint` looks (`DYLINT_DRIVER_PATH`). |
| 2. `SOURCE_PREFIX = "crates/"` matched `crates/*/tests/`, `examples/`, `benches/` and flagged test drivers that legitimately spawn binaries under test | Tightened to `crates/*/src/` via `in_production_scope` — requires BOTH `crates/` AND a subsequent `/src/` segment. |
| 3. Only `ExprKind::MethodCall` was handled — qualified-path calls like `Command::spawn(&mut cmd)` were missed | Added `ExprKind::Path` branch using `qpath_res` to catch the qualified-path call shape. Mirrors zccache's `ban_unrooted_tempdir`. |

Plus two Windows-specific tweaks vs the zccache driver script that surfaced during local testing:
- Writes `rust-toolchain.toml` (not extensionless `rust-toolchain`) so rustup unambiguously parses TOML.
- Anchors `RUSTC`/`CARGO` env vars to the nightly binaries so a chocolatey-installed stable `rustc` earlier in PATH can't shadow them and trip the build-script's `#![feature(...)]` with E0554.

## Allowlist (7 production files)

| Path | Why allowed |
|---|---|
| `crates/fbuild-core/src/subprocess.rs` | Internal helpers in the wrapper itself |
| `crates/fbuild-core/src/containment.rs` | IS the wrapper — raw `.spawn()` is the implementation |
| `crates/fbuild-daemon/src/bin/containment_harness.rs` | Test harness for #129 |
| `crates/fbuild-cli/src/daemon_client.rs` | Daemon bootstrap — must outlive CLI |
| `crates/fbuild-python/src/daemon.rs` | Daemon bootstrap from Python interop |
| `crates/fbuild-build/src/zccache.rs` | Starts the zccache daemon (cross-tool) |
| `crates/fbuild-cli/src/cli/clang_tools.rs` | Async fan-out, no daemon containment in CLI |

## Test plan

- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all -- --check` — clean
- [x] `cd dylints/ban_raw_subprocess && RUSTUP_TOOLCHAIN=nightly-2026-03-26 soldr cargo test` — 3 unit tests pass (scope filter + allowlist suffix match)
- [x] `uv run python ci/build_dylint_driver.py` — builds a working driver locally
- [x] Existing string-based `ci/find_direct_subprocess.py` still passes (complementary check on `Command::new(` constructor side)
- [ ] **CI Dylint job runs `cargo dylint --all -- --workspace --all-targets` clean** — that's the real acceptance criterion since the lint requires the prebuilt driver + Ubuntu Linux env (cargo-dylint 5.0.0 driver-discovery has Windows-specific quirks that don't bite the Ubuntu CI runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom automated linting rules to enforce controlled subprocess usage in production code, ensuring all process spawning routes through approved wrappers.

* **Chores**
  * Added CI/CD workflow for continuous linting checks.
  * Added documentation and tooling to support local development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->