### PR TITLE
deps(rust): migrate to running-process 4.0.0 mono-crate

### DIFF
--- a/.github/workflows/lint-subprocess.yml
+++ b/.github/workflows/lint-subprocess.yml
@@ -2,7 +2,7 @@ name: Lint subprocess spawns
 
 # Regression guard for FastLED/fbuild#141: every subprocess fbuild
 # starts must flow through the fbuild-core::subprocess wrappers (which
-# are backed by running-process-core). Direct std::process::Command /
+# are backed by running-process). Direct std::process::Command /
 # tokio::process::Command spawns are only allowed when annotated with
 # an // allow-direct-spawn: <reason> marker.
 #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +955,7 @@ name = "fbuild-core"
 version = "2.2.6"
 dependencies = [
  "libc",
- "running-process-core",
+ "running-process",
  "serde",
  "serde_json",
  "sha2",
@@ -1166,6 +1172,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1838,6 +1850,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2025,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
@@ -2158,6 +2210,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2309,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "logos",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2604,16 +2757,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "running-process-core"
-version = "3.4.1"
+name = "running-process"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f35c478beb7dff57f999628b301d5e18306e6fc80f90cf6c6c221904df9b56"
+checksum = "f64479526e50ccc2d842a78361bcf452e12e09329159e0beafd19d6e9d659d9e"
 dependencies = [
  "libc",
  "portable-pty",
+ "prost-build",
+ "protox",
+ "serde",
+ "serde_json",
  "sysinfo",
  "thiserror 2.0.18",
  "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2635,6 +2793,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,11 @@ tracing-test = "0.2"
 # Process containment: all subprocess spawns the daemon performs (compilers,
 # esptool, qemu, simavr, node, npm, …) and any grandchildren they fork must
 # die with the daemon. See FastLED/fbuild#32.
-running-process-core = "3.4"
+# Migrated from `running-process-core 3.4` to `running-process 4.0.0` after
+# the upstream mono-crate consolidation. We only use the `core` feature
+# (spawn API + containment); the `client`/`daemon` features and the IPC
+# client/daemon binary remain unused, so we pin `default-features = false`.
+running-process = { version = "4.0.0", default-features = false }
 
 [profile.dev]
 debug = 0

--- a/crates/fbuild-core/Cargo.toml
+++ b/crates/fbuild-core/Cargo.toml
@@ -17,7 +17,7 @@ sha2 = { workspace = true }
 # `ContainedProcessGroup` owned by the daemon ensures every child process
 # spawned through `fbuild_core::subprocess::run_command` (and the emulator
 # helpers) dies with the daemon. See FastLED/fbuild#32.
-running-process-core = { workspace = true }
+running-process = { workspace = true }
 # Async helpers for the tokio integration in `containment::tokio_spawn` —
 # we need the `process` feature so `tokio::process::Command` is in scope.
 tokio = { workspace = true }

--- a/crates/fbuild-core/src/containment.rs
+++ b/crates/fbuild-core/src/containment.rs
@@ -20,7 +20,7 @@
 //!   kernel sends SIGKILL when the daemon thread exits. Per-child groups
 //!   avoid the EPERM that the pre-publication
 //!   `ContainedProcessGroup::spawn_with_containment` (since removed from
-//!   `running-process-core` 3.4) hit when a second child tried to join a
+//!   `running-process` 4.0) hit when a second child tried to join a
 //!   stale, already-exited first child's pgid (see issue #129).
 //! * **macOS** — `prctl` is not available. Each child gets a fresh
 //!   process group; there is no drop-time `killpg` backstop because the
@@ -56,7 +56,7 @@
 use std::process::{Child, Command};
 use std::sync::OnceLock;
 
-use running_process_core::{ContainedProcessGroup, ORIGINATOR_ENV_VAR};
+use running_process::{ContainedProcessGroup, ORIGINATOR_ENV_VAR};
 
 /// Global process-wide containment group. Initialised once by the
 /// daemon; remains `None` in non-daemon contexts (CLI binary, tests).
@@ -102,8 +102,8 @@ pub fn is_initialised() -> bool {
 /// Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
 /// (via the private `windows_job::assign` helper) — the same containment
 /// mechanism the pre-publication `running-process-core` rev used internally,
-/// reimplemented locally since the published 3.4 API no longer exposes
-/// `spawn_with_containment(_, Containment::Contained)`.
+/// reimplemented locally since the published `running-process` 4.0 API no
+/// longer exposes `spawn_with_containment(_, Containment::Contained)`.
 ///
 /// **Unix**: installs a per-child `pre_exec` hook that creates a new
 /// process group (`setpgid(0, 0)`) and, on Linux, requests
@@ -125,9 +125,9 @@ pub fn spawn_contained(command: &mut Command) -> std::io::Result<Child> {
         use std::os::windows::io::AsRawHandle;
         if let Err(e) = windows_job::assign(child.as_raw_handle()) {
             // The atomic spawn+assign that `ContainedProcessGroup::spawn_with_containment`
-            // used to provide is gone in 3.4. If assign fails after spawn
-            // succeeds, kill the orphan so the caller can't leak an
-            // uncontained child by accident.
+            // used to provide is gone in `running-process` 4.0. If assign
+            // fails after spawn succeeds, kill the orphan so the caller
+            // can't leak an uncontained child by accident.
             let _ = child.kill();
             let _ = child.wait();
             return Err(e);
@@ -175,8 +175,8 @@ pub fn spawn_detached(command: &mut Command) -> std::io::Result<Child> {
 
 /// Mirror of `ContainedProcessGroup::inject_originator_env`: stamp
 /// `RUNNING_PROCESS_ORIGINATOR=TOOL:PID` onto the command's env. We do
-/// this manually because the published 3.4 API only exposes it via
-/// `ContainedProcessGroup::spawn` (which returns its own
+/// this manually because the published `running-process` 4.0 API only
+/// exposes it via `ContainedProcessGroup::spawn` (which returns its own
 /// `SpawnedChild`, not a `std::process::Child` — see #32).
 fn inject_originator_env(command: &mut Command, group: &ContainedProcessGroup) {
     if let Some(value) = group.originator_value() {
@@ -250,7 +250,7 @@ fn unix_install_detached_pre_exec(command: &mut Command) {
 ///   `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` flag, so daemon death still
 ///   kills every tokio-spawned child.
 ///
-/// Both job handles (the std-path one inside `running-process-core`,
+/// Both job handles (the std-path one inside `running-process`,
 /// and the one here) live for the lifetime of the daemon process and
 /// are closed automatically when the daemon exits, triggering
 /// kill-on-close for their respective children.

--- a/crates/fbuild-core/src/subprocess.rs
+++ b/crates/fbuild-core/src/subprocess.rs
@@ -1,7 +1,7 @@
-//! Subprocess runner backed by `running-process-core`.
+//! Subprocess runner backed by `running-process`.
 //!
 //! Every synchronous spawn in fbuild flows through this module. We use
-//! [`running_process_core::NativeProcess`] so that stdout and stderr are
+//! [`running_process::NativeProcess`] so that stdout and stderr are
 //! drained concurrently from the moment the child starts — the manual
 //! drain loop that preceded this module deadlocked the moment a compiler
 //! filled its stderr pipe (see FastLED/fbuild#141).
@@ -17,12 +17,13 @@
 //! installed the global containment group; CLI binaries and unit tests
 //! run uncontained just as before. (Earlier code used a `containment:`
 //! field on `ProcessConfig` from a pre-release `running-process-core`;
-//! the published 3.4 API does not expose that field — see #32.)
+//! the published `running-process` 4.0 API does not expose that field —
+//! see #32.)
 
 use std::path::Path;
 use std::time::Duration;
 
-use running_process_core::{
+use running_process::{
     CommandSpec, NativeProcess, ProcessConfig, ProcessError, StderrMode, StdinMode,
 };
 

--- a/dylints/ban_raw_subprocess/README.md
+++ b/dylints/ban_raw_subprocess/README.md
@@ -11,7 +11,7 @@ Every child process fbuild launches must flow through one of the blessed
 wrappers in `crates/fbuild-core/src/`:
 
 - `subprocess::run_command` — sync, captures stdout/stderr via
-  `running-process-core::NativeProcess` so the drain loop can't deadlock
+  `running-process::NativeProcess` so the drain loop can't deadlock
   on a full pipe buffer (see #141).
 - `containment::spawn_contained` /
   `containment::tokio_spawn::spawn_contained` — applies Windows Job

--- a/dylints/ban_raw_subprocess/src/allowlist.txt
+++ b/dylints/ban_raw_subprocess/src/allowlist.txt
@@ -8,12 +8,12 @@
 # Include an inline comment explaining why.
 
 # The blessed wrappers themselves. `subprocess.rs` runs commands via
-# `running_process_core::NativeProcess::start()` (not `Command::spawn`),
+# `running_process::NativeProcess::start()` (not `Command::spawn`),
 # but defensively allowlist it so internal helpers/refactors stay
 # unconstrained. `containment.rs` is the entire point of the file —
 # raw `command.spawn()` is the implementation detail that gives us a
 # `std::process::Child` to attach to the Windows Job Object (the
-# published `running-process-core` 3.4 API returns `SpawnedChild`, not
+# published `running-process` 4.0 API returns `SpawnedChild`, not
 # `Child`, so this raw-spawn pattern is the bridge — see PR #254).
 crates/fbuild-core/src/subprocess.rs
 crates/fbuild-core/src/containment.rs

--- a/dylints/ban_raw_subprocess/src/lib.rs
+++ b/dylints/ban_raw_subprocess/src/lib.rs
@@ -27,7 +27,7 @@ dylint_linting::declare_late_lint! {
     /// Every child process fbuild launches must go through one of the
     /// blessed wrappers in `crates/fbuild-core/src/`:
     /// `subprocess::run_command` (sync, captures stdout/stderr via
-    /// `running-process-core::NativeProcess` so the drain loop can't
+    /// `running-process::NativeProcess` so the drain loop can't
     /// deadlock on a full pipe buffer — see #141),
     /// `containment::spawn_contained` /
     /// `containment::tokio_spawn::spawn_contained` (apply Windows Job


### PR DESCRIPTION
## Summary

- Upstream [zackees/running-process 4.0.0](https://github.com/zackees/running-process/blob/main/CHANGELOG.md) consolidated 5 crates (`running-process-core`, `-proto`, `-client`, `-daemon`, `daemon-trampoline`) into a single `running-process` crate with feature-gated subsystems. fbuild only consumes the spawn API + containment primitives, so the new dep is pinned with `default-features = false` (the `client`/`daemon` features and their prost/interprocess/tokio transitives stay out of fbuild's graph).
- All `use running_process_core::` rewritten to `use running_process::` in `crates/fbuild-core/src/{subprocess,containment}.rs`. No behavioural change; identical `NativeProcess`, `ContainedProcessGroup`, `ORIGINATOR_ENV_VAR`, `CommandSpec`, `ProcessConfig`, `StdinMode`, `StderrMode`, `ProcessError` surface as 3.4.
- Doc comments, the `dylints/ban_raw_subprocess` README/allowlist/lint message, and the `lint-subprocess` workflow header updated to reference the new crate name (no functional dylint change).

## Test plan

- [x] `soldr cargo check --workspace --all-targets` — clean.
- [x] `soldr cargo test --workspace --no-fail-fast` — all suites pass on Windows MSVC, including:
  - `fbuild-core::containment::tests::sequential_contained_spawns_do_not_fail_with_eperm` (FastLED/fbuild#129 regression)
  - `fbuild-core::containment::tests::spawn_contained_without_init_falls_back_to_uncontained`
  - `fbuild-core::subprocess::tests::{run_echo, run_captures_stderr, run_nonexistent_command}`
- [x] `cargo tree -p running-process` confirms only `core` deps (libc, portable-pty, serde, sysinfo) — no prost/tokio/interprocess pulled in via running-process.
- [ ] CI green on Linux and macOS runners.

## Notes

- The two historical-context references to `running-process-core` left in `subprocess.rs` / `containment.rs` doc comments are intentional — they describe the *prior* API divergence (the pre-publication `ContainedProcessGroup::spawn_with_containment` and the post-3.4 `SpawnedChild` vs `Child` mismatch) that motivated the current bridge code. Rewriting them to "4.0" would erase the historical accuracy of why this file exists.
- `Cargo.lock` regenerated by `cargo update -p running-process-core --precise 0.0.0`, which removed the 3.4.1 entry and added `running-process v4.0.0` (no other dependency churn beyond the prost/protox build-script chain that running-process 4.0 brings in for its own optional `client` feature build — but those crates aren't compiled because `default-features = false` strips them).

Closes #271.
Refs zackees/running-process#203.

Generated with Claude Code (claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies and associated build configurations
  * Refreshed documentation and comments to maintain consistency with dependency updates
  * No changes to user-facing functionality or APIs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->