### PR TITLE
fix(esp32): strip Windows UNC prefix + collect .S/.s assembly sources (FastLED #2507)

### DIFF
--- a/crates/fbuild-build/src/zccache.rs
+++ b/crates/fbuild-build/src/zccache.rs
@@ -211,9 +211,13 @@ pub fn path_arg_for_compile_cwd(path: &Path, cwd: &Path) -> String {
         return path.to_string_lossy().to_string();
     }
 
+    // Both ends must be in the same normal form (stripped of any `\\?\`
+    // Windows extended-length prefix) for `strip_prefix` to match, since
+    // `canonicalize_existing_path` now strips that prefix from `path`.
     let stable_path = canonicalize_existing_path(path).unwrap_or_else(|| path.to_path_buf());
+    let stable_cwd = strip_unc_prefix(cwd.to_path_buf());
     stable_path
-        .strip_prefix(cwd)
+        .strip_prefix(&stable_cwd)
         .unwrap_or(&stable_path)
         .to_string_lossy()
         .to_string()
@@ -262,14 +266,41 @@ pub fn normalize_flags_for_compile_cwd(flags: &[String], cwd: &Path) -> Vec<Stri
 
 fn canonicalize_existing_path(path: &Path) -> Option<PathBuf> {
     if let Ok(canonical) = path.canonicalize() {
-        return Some(canonical);
+        return Some(strip_unc_prefix(canonical));
     }
 
     let parent = path.parent()?.canonicalize().ok()?;
-    Some(match path.file_name() {
+    let joined = match path.file_name() {
         Some(name) => parent.join(name),
         None => parent,
-    })
+    };
+    Some(strip_unc_prefix(joined))
+}
+
+/// On Windows, `Path::canonicalize` returns paths prefixed with the
+/// extended-length namespace marker `\\?\`. That prefix only works with
+/// backslash path separators, but the response-file writer rewrites all
+/// backslashes to forward slashes (so GCC doesn't interpret them as escape
+/// sequences). The result is `//?/C:/…` which neither GCC nor mingw's path
+/// search code understands as a valid drive-letter path, so `#include`
+/// lookups against canonicalized include dirs silently fail (see FastLED
+/// issue #2507 — `soc/soc_caps.h` not found on esp32p4).
+///
+/// Stripping the prefix here turns `\\?\C:\…` into `C:\…`, which survives
+/// the backslash→slash rewrite as the standard `C:/…` form GCC accepts.
+/// The trade-off is that long-path support (>260 chars) is lost for the
+/// stripped paths, but the cache root is `<home>/.fbuild` which is well
+/// under the limit in practice.
+fn strip_unc_prefix(path: PathBuf) -> PathBuf {
+    if !cfg!(windows) {
+        return path;
+    }
+    let s = path.to_string_lossy();
+    // Handle both `\\?\C:\…` and (defensively) the already-rewritten `//?/C:/…`.
+    if let Some(rest) = s.strip_prefix(r"\\?\").or_else(|| s.strip_prefix("//?/")) {
+        return PathBuf::from(rest);
+    }
+    path
 }
 
 fn flag_takes_path_argument(flag: &str) -> bool {
@@ -399,12 +430,32 @@ mod tests {
         let workspace = tmp.path().join("project");
         let output = workspace.join(".fbuild/build/main.o");
         std::fs::create_dir_all(output.parent().unwrap()).unwrap();
-        let expected = workspace.canonicalize().unwrap();
+        // On Windows, canonicalize() yields a `\\?\` extended-length prefix
+        // that the response-file writer cannot use (forward-slash rewrite
+        // produces `//?/` which gcc rejects). The helper now strips that
+        // prefix on Windows, so the expected value must match.
+        let expected = strip_unc_prefix(workspace.canonicalize().unwrap());
 
         assert_eq!(
             compile_cwd_from_output(&output).as_deref(),
             Some(expected.as_path())
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn strip_unc_prefix_removes_extended_length_marker() {
+        let raw = std::path::PathBuf::from(r"\\?\C:\Users\test\.fbuild\cache");
+        let stripped = strip_unc_prefix(raw);
+        assert_eq!(stripped, std::path::PathBuf::from(r"C:\Users\test\.fbuild\cache"));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn strip_unc_prefix_is_idempotent_for_already_normal_paths() {
+        let raw = std::path::PathBuf::from(r"C:\Users\test\include");
+        let stripped = strip_unc_prefix(raw.clone());
+        assert_eq!(stripped, raw);
     }
 
     #[test]

--- a/crates/fbuild-packages/src/library/library_info.rs
+++ b/crates/fbuild-packages/src/library/library_info.rs
@@ -118,11 +118,18 @@ fn collect_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-/// Check if a file is a C/C++ source file.
+/// Check if a file is a C/C++/assembly source file.
+///
+/// `.S` (preprocessed) and `.s` (raw) assembly are intentionally included so
+/// libraries that ship hand-written ISRs or arch-specific stubs (e.g.
+/// FastLED's `gpio_isr_rx/fast_isr.S` on RISC-V — symbol
+/// `gpio_fast_edge_isr`) actually get linked. Without this the library
+/// archive is missing the assembly symbols and the final link fails with
+/// `undefined reference` errors.
 fn is_source_file(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|e| e.to_str()),
-        Some("c") | Some("cpp") | Some("cc") | Some("cxx")
+        Some("c") | Some("cpp") | Some("cc") | Some("cxx") | Some("S") | Some("s")
     )
 }
 


### PR DESCRIPTION
## Summary

Two bugs in the Windows compile path prevent FastLED's AutoResearch sketch from building for esp32p4 via fbuild. Both fixed here.

Cross-ref: FastLED/FastLED#2507 (meta issue), FastLED/FastLED#2493 (the PARLIO perf-trace work this unblocks).

## Bug 1 — `\?\` UNC prefix mangled into `//?/` in response files

`Path::canonicalize` on Windows returns paths prefixed with the extended-length namespace marker `\?\`. That prefix only works with backslash separators, but `fbuild-core::response_file::replace_path_backslashes` rewrites all backslashes to forward slashes so gcc doesn't interpret them as escape sequences. The result was `-I//?/C:/…` on every include directory.

Some headers happened to resolve (gcc tolerates the prefix on some lookups) but chip-specific SoC headers like `soc/soc_caps.h` did not:

```
cores/esp32/USBMSC.h:17:10: fatal error: soc/soc_caps.h: No such file
   17 | #include "soc/soc_caps.h"
```

**Fix:** strip the `\?\` prefix in `canonicalize_existing_path` (cfg(windows) only). New helper `strip_unc_prefix` removes both `\?\` and the defensively-handled `//?/` form, leaving `C:\…` which survives the backslash→slash rewrite as the standard `C:/…` form gcc accepts. `path_arg_for_compile_cwd` also strips from its `cwd` argument so `strip_prefix` matches when callers pass an un-stripped canonical path.

**Trade-off:** long-path support (>260 chars) is lost for stripped paths, but the cache root is `<home>/.fbuild` which is well under the Windows limit in practice.

## Bug 2 — `.S`/`.s` assembly files silently dropped from library archives

`library_info::is_source_file` only matched `.c/.cpp/.cc/.cxx`, so hand-written assembly stubs were never compiled into library archives. On esp32p4 the FastLED RX ISR path (`fl::GpioIsrRxMcpwm::begin` → `src/platforms/esp/32/drivers/gpio_isr_rx/fast_isr.S` → `gpio_fast_edge_isr`) failed at link:

```
ld.exe: libFastLED.a(platforms+_f948.o): in function
`fl::GpioIsrRxMcpwm::begin(fl::RxConfig const&)':
undefined reference to `gpio_fast_edge_isr'
```

**Fix:** extend `is_source_file` to include `S` and `s` extensions.

## Tests

- `cargo test --release -p fbuild-build --lib zccache::` — 7/7 pass (5 existing + 2 new for the strip helper).
- The existing `compile_cwd_from_output_canonicalizes_existing_workspace` test was updated to reflect the new contract (calls `strip_unc_prefix` on its `expected` value).

## End-to-end verification

Before: `bash compile esp32p4 --examples AutoResearch --no-filter` failed during framework lib compile with `soc/soc_caps.h: No such file`.

After: succeeds — 1.7 MB firmware.bin produced in ~100 s.

```
build succeeded in 99.7s (flash: 1785050 bytes, ram: 1288852 bytes)
✅ Compilation succeeded (fbuild) [100.0s]
SUCCESS: AutoResearch
```

## Test plan

- [x] `cargo test --release -p fbuild-build --lib zccache::`
- [x] End-to-end build of FastLED AutoResearch sketch for esp32p4 via fbuild
- [ ] Sanity check on Linux/macOS that the cfg(windows) gate doesn't regress non-Windows compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved Windows path canonicalization issues affecting cache consistency and build reliability.

* **New Features**
  * Added support for assembly source files (.S and .s extensions) in library builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->