### PR TITLE
ci: build Linux musl releases with zigbuild

### DIFF
--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Build release binaries
         shell: bash
         run: |
-          if [ "${{ inputs.linux_cross }}" = "true" ]; then
+          if [[ "${{ inputs.target }}" == *-unknown-linux-musl ]]; then
             soldr cargo zigbuild --release --target ${{ inputs.target }} \
               -p fbuild-cli \
               -p fbuild-daemon


### PR DESCRIPTION
## Summary
- build both Linux musl release binary targets through cargo zigbuild
- keep non-Linux/native targets on the existing cargo build path

## Why
The automatic 2.2.7 release failed on x86_64-unknown-linux-musl while linking bundled C dependencies (libsqlite3-sys, libmimalloc-sys) with missing libc symbols such as __memcpy_chk and open64. The aarch64 musl path already uses cargo zigbuild; applying that path to all Linux musl binary builds keeps the release packaging path consistent.

FastLED dependency bump precondition: FastLED/FastLED#2514

## Verification
- git diff --check