### PR TITLE
perf(ci): lighter board caches — shared soldr cook, drop heavy target-cache

### DIFF
--- a/.github/workflows/build-apollo3_red.yml
+++ b/.github/workflows/build-apollo3_red.yml
@@ -1,6 +1,7 @@
 name: Build Apollo3 RedBoard
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-apollo3_thing_explorable.yml
+++ b/.github/workflows/build-apollo3_thing_explorable.yml
@@ -1,6 +1,7 @@
 name: Build Apollo3 expLoRaBLE
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-atmega8.yml
+++ b/.github/workflows/build-atmega8.yml
@@ -1,6 +1,7 @@
 name: Build ATmega8
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-atmega8a.yml
+++ b/.github/workflows/build-atmega8a.yml
@@ -1,6 +1,7 @@
 name: Build ATmega8A
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-attiny1604.yml
+++ b/.github/workflows/build-attiny1604.yml
@@ -1,6 +1,7 @@
 name: Build ATtiny1604
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-attiny1616.yml
+++ b/.github/workflows/build-attiny1616.yml
@@ -1,6 +1,7 @@
 name: Build ATtiny1616
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-attiny4313.yml
+++ b/.github/workflows/build-attiny4313.yml
@@ -1,6 +1,7 @@
 name: Build ATtiny4313
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-attiny85.yml
+++ b/.github/workflows/build-attiny85.yml
@@ -1,6 +1,7 @@
 name: Build ATtiny85
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-attiny88.yml
+++ b/.github/workflows/build-attiny88.yml
@@ -1,6 +1,7 @@
 name: Build ATtiny88
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-blackpill.yml
+++ b/.github/workflows/build-blackpill.yml
@@ -1,6 +1,7 @@
 name: Build BlackPill F411CE
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-bluepill.yml
+++ b/.github/workflows/build-bluepill.yml
@@ -1,6 +1,7 @@
 name: Build BluePill F103C8
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-ch32v003.yml
+++ b/.github/workflows/build-ch32v003.yml
@@ -1,6 +1,7 @@
 name: Build CH32V003
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-ch32v006.yml
+++ b/.github/workflows/build-ch32v006.yml
@@ -1,6 +1,7 @@
 name: Build CH32V006
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-ch32v103.yml
+++ b/.github/workflows/build-ch32v103.yml
@@ -1,6 +1,7 @@
 name: Build CH32V103
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-ch32v203.yml
+++ b/.github/workflows/build-ch32v203.yml
@@ -1,6 +1,7 @@
 name: Build CH32V203
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-ch32v208.yml
+++ b/.github/workflows/build-ch32v208.yml
@@ -1,6 +1,7 @@
 name: Build CH32V208
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-ch32v303.yml
+++ b/.github/workflows/build-ch32v303.yml
@@ -1,6 +1,7 @@
 name: Build CH32V303
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-ch32v307.yml
+++ b/.github/workflows/build-ch32v307.yml
@@ -1,6 +1,7 @@
 name: Build CH32V307
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-ch32x035.yml
+++ b/.github/workflows/build-ch32x035.yml
@@ -1,6 +1,7 @@
 name: Build CH32X035
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-due.yml
+++ b/.github/workflows/build-due.yml
@@ -1,6 +1,7 @@
 name: Build Arduino Due
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32c2.yml
+++ b/.github/workflows/build-esp32c2.yml
@@ -1,6 +1,7 @@
 name: Build ESP32-C2
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32c3.yml
+++ b/.github/workflows/build-esp32c3.yml
@@ -1,6 +1,7 @@
 name: Build ESP32-C3
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32c5.yml
+++ b/.github/workflows/build-esp32c5.yml
@@ -1,6 +1,7 @@
 name: Build ESP32-C5
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32c6.yml
+++ b/.github/workflows/build-esp32c6.yml
@@ -1,6 +1,7 @@
 name: Build ESP32-C6
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32dev.yml
+++ b/.github/workflows/build-esp32dev.yml
@@ -1,6 +1,7 @@
 name: Build ESP32 Dev
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32h2.yml
+++ b/.github/workflows/build-esp32h2.yml
@@ -1,6 +1,7 @@
 name: Build ESP32-H2
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32p4.yml
+++ b/.github/workflows/build-esp32p4.yml
@@ -1,6 +1,7 @@
 name: Build ESP32-P4
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32s2.yml
+++ b/.github/workflows/build-esp32s2.yml
@@ -1,6 +1,7 @@
 name: Build ESP32-S2
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp32s3.yml
+++ b/.github/workflows/build-esp32s3.yml
@@ -1,6 +1,7 @@
 name: Build ESP32-S3
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-esp8266.yml
+++ b/.github/workflows/build-esp8266.yml
@@ -1,6 +1,7 @@
 name: Build ESP8266
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-giga-r1.yml
+++ b/.github/workflows/build-giga-r1.yml
@@ -1,6 +1,7 @@
 name: Build Arduino Giga R1
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-leonardo.yml
+++ b/.github/workflows/build-leonardo.yml
@@ -1,6 +1,7 @@
 name: Build Leonardo
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-mgm240.yml
+++ b/.github/workflows/build-mgm240.yml
@@ -1,6 +1,7 @@
 name: Build MGM240
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nano-every.yml
+++ b/.github/workflows/build-nano-every.yml
@@ -1,6 +1,7 @@
 name: Build Nano Every
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nano_every.yml
+++ b/.github/workflows/build-nano_every.yml
@@ -1,6 +1,7 @@
 name: Build Nano Every
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nice_nano_nrf52840.yml
+++ b/.github/workflows/build-nice_nano_nrf52840.yml
@@ -1,6 +1,7 @@
 name: Build nice!nano nRF52840
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nrf52840-sense.yml
+++ b/.github/workflows/build-nrf52840-sense.yml
@@ -1,6 +1,7 @@
 name: Build Adafruit Feather NRF52840 Sense
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nrf52840_dk.yml
+++ b/.github/workflows/build-nrf52840_dk.yml
@@ -1,6 +1,7 @@
 name: Build nRF52840 DK
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nrfmicro_nrf52840.yml
+++ b/.github/workflows/build-nrfmicro_nrf52840.yml
@@ -1,6 +1,7 @@
 name: Build nRFMicro nRF52840
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nucleo-f429zi.yml
+++ b/.github/workflows/build-nucleo-f429zi.yml
@@ -1,6 +1,7 @@
 name: Build Nucleo F429ZI
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nucleo-f439zi.yml
+++ b/.github/workflows/build-nucleo-f439zi.yml
@@ -1,6 +1,7 @@
 name: Build Nucleo F439ZI
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nucleo_f429zi.yml
+++ b/.github/workflows/build-nucleo_f429zi.yml
@@ -1,6 +1,7 @@
 name: Build Nucleo F429ZI
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-nucleo_f439zi.yml
+++ b/.github/workflows/build-nucleo_f439zi.yml
@@ -1,6 +1,7 @@
 name: Build Nucleo F439ZI
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-rp2040.yml
+++ b/.github/workflows/build-rp2040.yml
@@ -1,6 +1,7 @@
 name: Build RP2040
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-rp2350.yml
+++ b/.github/workflows/build-rp2350.yml
@@ -1,6 +1,7 @@
 name: Build RP2350
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-rpipico.yml
+++ b/.github/workflows/build-rpipico.yml
@@ -1,6 +1,7 @@
 name: Build Raspberry Pi Pico
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-rpipico2.yml
+++ b/.github/workflows/build-rpipico2.yml
@@ -1,6 +1,7 @@
 name: Build Raspberry Pi Pico 2
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-sam3x8e_due.yml
+++ b/.github/workflows/build-sam3x8e_due.yml
@@ -1,6 +1,7 @@
 name: Build Arduino Due
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-samd21.yml
+++ b/.github/workflows/build-samd21.yml
@@ -1,6 +1,7 @@
 name: Build SAMD21
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-samd21_zero.yml
+++ b/.github/workflows/build-samd21_zero.yml
@@ -1,6 +1,7 @@
 name: Build Arduino Zero
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-samd51j.yml
+++ b/.github/workflows/build-samd51j.yml
@@ -1,6 +1,7 @@
 name: Build SAMD51J
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-samd51p.yml
+++ b/.github/workflows/build-samd51p.yml
@@ -1,6 +1,7 @@
 name: Build SAMD51P
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-stm32f103c8.yml
+++ b/.github/workflows/build-stm32f103c8.yml
@@ -1,6 +1,7 @@
 name: Build STM32F103C8
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-stm32f103cb.yml
+++ b/.github/workflows/build-stm32f103cb.yml
@@ -1,6 +1,7 @@
 name: Build STM32F103CB
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-stm32f103tb.yml
+++ b/.github/workflows/build-stm32f103tb.yml
@@ -1,6 +1,7 @@
 name: Build STM32F103TB
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-stm32f411ce.yml
+++ b/.github/workflows/build-stm32f411ce.yml
@@ -1,6 +1,7 @@
 name: Build STM32F411CE
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-stm32h747xi.yml
+++ b/.github/workflows/build-stm32h747xi.yml
@@ -1,6 +1,7 @@
 name: Build STM32H747XI
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-supermini_nrf52840.yml
+++ b/.github/workflows/build-supermini_nrf52840.yml
@@ -1,6 +1,7 @@
 name: Build SuperMini nRF52840
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-teensy30.yml
+++ b/.github/workflows/build-teensy30.yml
@@ -1,6 +1,7 @@
 name: Build Teensy 3.0
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-teensy31.yml
+++ b/.github/workflows/build-teensy31.yml
@@ -1,6 +1,7 @@
 name: Build Teensy 3.1
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-teensy32.yml
+++ b/.github/workflows/build-teensy32.yml
@@ -1,6 +1,7 @@
 name: Build Teensy 3.2
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-teensy35.yml
+++ b/.github/workflows/build-teensy35.yml
@@ -1,6 +1,7 @@
 name: Build Teensy 3.5
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-teensy36.yml
+++ b/.github/workflows/build-teensy36.yml
@@ -1,6 +1,7 @@
 name: Build Teensy 3.6
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-teensy40.yml
+++ b/.github/workflows/build-teensy40.yml
@@ -1,6 +1,7 @@
 name: Build Teensy 4.0
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-teensy41.yml
+++ b/.github/workflows/build-teensy41.yml
@@ -1,6 +1,7 @@
 name: Build Teensy 4.1
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-teensylc.yml
+++ b/.github/workflows/build-teensylc.yml
@@ -1,6 +1,7 @@
 name: Build Teensy LC
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-thingplusmatter.yml
+++ b/.github/workflows/build-thingplusmatter.yml
@@ -1,6 +1,7 @@
 name: Build SparkFun Thing Plus Matter
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-tinystm.yml
+++ b/.github/workflows/build-tinystm.yml
@@ -1,6 +1,7 @@
 name: Build TinySTM103TB
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-uno-r4-wifi.yml
+++ b/.github/workflows/build-uno-r4-wifi.yml
@@ -1,6 +1,7 @@
 name: Build Arduino Uno R4 WiFi
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-uno.yml
+++ b/.github/workflows/build-uno.yml
@@ -1,6 +1,7 @@
 name: Build Arduino Uno
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/build-uno_r4_wifi.yml
+++ b/.github/workflows/build-uno_r4_wifi.yml
@@ -1,6 +1,7 @@
 name: Build UNO R4 WiFi
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -38,10 +38,19 @@ jobs:
         uses: zackees/setup-soldr@v0
         with:
           cache: true
+          # Lighter cache strategy (was: build-cache + heavy target-cache, keyed
+          # per-board). The Rust build here (`cargo build -p fbuild-cli
+          # -p fbuild-daemon`, debug) is board-INDEPENDENT, so:
+          #  - cook (Cargo.lock-keyed) prewarms deps in ONE cache shared across
+          #    every board, instead of a ~1.5GB target tree per board;
+          #  - build-cache (zccache compile-cache) under a SHARED key caches the
+          #    workspace compile once for all boards (was ~462MiB x board x SHA);
+          #  - the heavy whole-target cache (target-cache) is dropped.
+          # Safe to cook since soldr 0.7.44 fixed the cook project-restore bug.
           build-cache: true
-          target-cache: true
-          prebuild-deps: none
-          cache-key-suffix: board-${{ inputs.env-name }}
+          prebuild-deps: soldr-cook
+          prebuild-deps-flags: ""
+          cache-key-suffix: fbuild-rust-debug
 
       - name: Reset zccache daemon after cache warm
         run: pkill -f '[z]ccache-daemon' || true


### PR DESCRIPTION
## Summary

The per-board build (`soldr cargo build -p fbuild-cli -p fbuild-daemon`, debug) in `template_build.yml` is **board-independent**, but was cached with `build-cache: true` + the heavy whole-`target/` cache (`target-cache: true`), keyed **per board** (`cache-key-suffix: board-<env>`).

On `fastled/fbuild` that currently produces **~6.7 GB** of `~462 MiB` build-cache entries — one per board **and** per commit SHA (near-zero cross-commit reuse) — churning the 10 GB Actions LRU budget.

This switches `template_build.yml` to a lighter strategy:
- **`prebuild-deps: soldr-cook`** (Cargo.lock-keyed) → **one shared deps cache** for all boards instead of a ~1.5 GB target tree per board;
- **`build-cache` under a shared key** (`fbuild-rust-debug`) → the workspace compile cached **once** for all boards;
- **drop `target-cache: true`** (the heavy whole-target layer).

Safe to cook now: soldr 0.7.44 (setup-soldr v0.9.16, which `@v0` already resolves to) fixed the cook project-restore bug that previously left the workspace stubbed at `0.0.1`.

Also adds **`workflow_dispatch`** to all board workflows so any board can be re-run on demand (e.g. for warm-cache measurement) once on `main`.

## Expected impact

| | before | after (steady state) |
|---|---:|---:|
| Rust build-cache entries | ~per board × per commit (462 MiB each) | 1 shared (`fbuild-rust-debug`) |
| Deps cache | per-board target tree (~1.5 GB ea) | 1 shared cook cache (~250 MB) |
| Total Rust-build footprint | ~6.7 GB | < ~1 GB |

## Test plan

- [ ] First (cold) run: all boards seed the **one** shared cook + build-cache entry (parallel jobs race to save; losers skip-save, harmless).
- [ ] Re-run (warm): boards hit the shared caches; confirm `build-cache HIT` + `soldr cook` reuse.
- [ ] Verify firmware outputs still generated (quick + release) for a representative board subset.
- [ ] Compare `gh cache list` footprint before vs after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled manual triggering for all microcontroller board build workflows through GitHub Actions, allowing developers to run builds on-demand directly from the Actions UI without requiring code commits or pull requests.

* **Chores**
  * Optimized the build caching strategy to enhance overall workflow performance and reduce build times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->