### PR TITLE
perf(ci): stabilize fbuild-toolchain cache key on platformio.ini hash, not commit SHA

### DIFF
--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.fbuild/prod/cache
-          key: fbuild-toolchain-${{ runner.os }}-${{ inputs.env-name }}-${{ github.sha }}
+          key: fbuild-toolchain-${{ runner.os }}-${{ inputs.env-name }}-${{ hashFiles(format('{0}/platformio.ini', inputs.test-dir)) }}
           restore-keys: |
             fbuild-toolchain-${{ runner.os }}-${{ inputs.env-name }}-
             fbuild-toolchain-${{ runner.os }}-
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.fbuild/prod/cache
-          key: fbuild-toolchain-${{ runner.os }}-${{ inputs.env-name }}-${{ github.sha }}
+          key: fbuild-toolchain-${{ runner.os }}-${{ inputs.env-name }}-${{ hashFiles(format('{0}/platformio.ini', inputs.test-dir)) }}
 
       - name: Save platform build artifacts
         if: always()


### PR DESCRIPTION
## Summary

Mirror of setup-soldr#237 / fastled/fbuild#280 for the **firmware toolchain** cache layer. The Restore/Save `fbuild-toolchain-*` cache keys were suffixed with `${{ github.sha }}`, so every commit on every board produced a brand-new ~2 GB cache entry even when the board's toolchain pin hadn't changed. With 71 boards × every commit, that's a lot of redundant uploads churning the 10 GB Actions LRU budget.

Replace the SHA suffix with `${{ hashFiles(format('{0}/platformio.ini', inputs.test-dir)) }}` so the key only invalidates when the board's `platformio.ini` actually changes (which is rare — typically only when bumping `platform = …` or adding/removing a framework). Restore-keys fallback ladder is preserved, so a cold board still restores the nearest neighbor's toolchain set as a starting point.

`fbuild-build-*` (platform build artifacts cache) keeps `${{ github.sha }}` because firmware artifacts are commit-source-derived and should invalidate on every commit.

## Expected impact

- `fbuild-toolchain-*` entry count: was ~71 × every commit. After: ~71 entries that persist across commits until a board's `platformio.ini` changes.
- Cache footprint (per-toolchain): unchanged (~2 GB each, still per-board because boards pin different toolchains via `platform = …`).
- Aggregate upload bandwidth per PR run: massive reduction (most board jobs no-op the toolchain save instead of uploading a fresh ~2 GB).
- Warm hit rate: same or higher (steady-state key matches more often without SHA noise).

## Trade-off

If fbuild internally bumps a toolchain URL/version *without* changing any board's `platformio.ini` (e.g., a config baked into `crates/fbuild-toolchains` source), the cache stays stale until manually cleared. That's an acceptable trade because:
- fbuild's `~/.fbuild/prod/cache/toolchains/{stem}/{hash}/{version}/` layout is content-addressed internally; new content adds new subdirs alongside the old.
- Restoring a slightly stale cache + fbuild downloading the new tool on top still works (just a small cold-download cost on the affected boards until the next platformio.ini-touching commit re-seeds).

## Test plan

- [ ] Full ~71-board matrix runs green on first cold burst (no key collisions, restore-keys fallback works).
- [ ] Re-run warm — expect ~all `fbuild-toolchain-*` restores to be `HIT` against entries that *don't* have a SHA component.
- [ ] After merge, `gh cache list` should show ~stable number of `fbuild-toolchain-Linux-<board>-<hash>` entries instead of growing per-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build toolchain caching strategy to better detect and respond to configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->