### PR TITLE
fix(avr8js): write headless.mjs inside cache dir so ESM can resolve avr8js

### DIFF
--- a/crates/fbuild-daemon/src/handlers/emulator/avr8js_deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/avr8js_deploy.rs
@@ -208,7 +208,15 @@ pub async fn deploy_avr8js(
             }
         };
 
-        let script_path = session_dir.join("headless.mjs");
+        // headless.mjs uses `import ... from "avr8js"` (bare ESM specifier).
+        // Node's ESM resolver does NOT honor NODE_PATH — it only walks
+        // upward from the script's directory looking for node_modules.
+        // Stage the script inside the cache dir so node_modules/avr8js
+        // is on that walk-up path. Script content is a compile-time
+        // constant (`include_str!`), so concurrent writes are idempotent.
+        // The per-session firmware.hex and session.json continue to live
+        // under session_dir. See FastLED/fbuild#291.
+        let script_path = avr8js_cache.join("headless.mjs");
         if let Err(e) = std::fs::write(&script_path, AVR8JS_HEADLESS_MJS) {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/fbuild-daemon/src/handlers/emulator/runners.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/runners.rs
@@ -173,8 +173,15 @@ impl EmulatorRunner for Avr8jsRunner {
         let node_path = find_node()?;
         let avr8js_cache = ensure_avr8js_npm()?;
 
-        let session_dir = tempfile::TempDir::new()?;
-        let script_path = session_dir.path().join("headless.mjs");
+        // headless.mjs uses `import ... from "avr8js"` (a bare ESM
+        // specifier). Node's ESM resolver does NOT honor NODE_PATH —
+        // it only walks upward from the script's directory looking
+        // for node_modules. Stage the script directly inside the
+        // cache dir so its node_modules/avr8js is on that walk-up
+        // path. Script content is a compile-time constant
+        // (`include_str!`), so concurrent writes are idempotent.
+        // See FastLED/fbuild#291.
+        let script_path = avr8js_cache.join("headless.mjs");
         std::fs::write(&script_path, AVR8JS_HEADLESS_MJS)?;
 
         let f_cpu_hz: u32 = self


### PR DESCRIPTION
## Summary

- Every `fbuild test-emu --emulator avr8js` run failed with `ERR_MODULE_NOT_FOUND: Cannot find package 'avr8js' imported from /tmp/.tmpXXX/headless.mjs`. Reproducible in FastLED CI: every `uno_avr8js_test` run on master.
- Root cause: `headless.mjs` uses a bare ESM specifier (`import ... from 'avr8js'`). Node's ESM resolver does NOT honor `NODE_PATH` (that's CJS-only) — it walks upward from the script's directory looking for `node_modules`. Both call sites wrote the script to a directory disconnected from the cache:
  - `runners.rs` → `tempfile::TempDir::new()` (`/tmp/.tmpXXX/headless.mjs`)
  - `avr8js_deploy.rs` → `<project>/.fbuild/emulators/avr8js/<env>/<uuid>/headless.mjs`
- Fix: write `headless.mjs` inside the cache dir (`<cache>/headless.mjs`), which already has `node_modules/avr8js` next to it. Script content is a compile-time constant (`include_str!`), so concurrent writes from multiple `Avr8jsRunner::run` invocations are idempotent. Per-project session_dir (firmware.hex, session.json) is unchanged in `avr8js_deploy.rs` — only the script moves.
- Affected: every consumer of `fbuild test-emu --emulator avr8js`. FastLED's `uno_avr8js_test` workflow is the immediate beneficiary.

## Test plan

- [x] `cargo check -p fbuild-daemon` clean.
- [x] `cargo test -p fbuild-daemon --lib emulator::` — 42/42 passing (existing avr8js process tests, simavr tests, runner-select tests).
- [ ] CI revival: FastLED's `uno_avr8js_test` should reach `Test loop` after a fbuild bump.

Fixes #291

## Repro

```bash
mkdir /tmp/no-nodeMods && cd /tmp/no-nodeMods
echo 'import "avr8js"; console.log("ok");' > t.mjs
NODE_PATH=$HOME/.fbuild/cache/avr8js-node/node_modules node t.mjs
# → ERR_MODULE_NOT_FOUND  (NODE_PATH ignored by ESM)

cp t.mjs ~/.fbuild/cache/avr8js-node/t.mjs
node ~/.fbuild/cache/avr8js-node/t.mjs
# → ok                    (script under cache dir, ESM resolver finds node_modules)
```

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal script staging for the AVR8JS emulator, improving deployment efficiency and resource organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->