### PR TITLE
fix(board-db): add Seeed XIAO BLE / BLE Sense (nRF52840) board defs

### DIFF
--- a/crates/fbuild-config/assets/boards/json/xiaoble_adafruit.json
+++ b/crates/fbuild-config/assets/boards/json/xiaoble_adafruit.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "nRF5",
+    "variant": "Seeed_XIAO_nRF52840",
+    "arduino": {
+      "ldscript": "nrf52840_s140_v7.ld"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "tools": {
+      "blackmagic": {},
+      "jlink": {},
+      "cmsis-dap": {}
+    }
+  },
+  "fcpu": 64000000,
+  "frameworks": [
+    "arduino"
+  ],
+  "id": "xiaoble_adafruit",
+  "mcu": "NRF52840",
+  "name": "Seeed XIAO BLE nRF52840",
+  "platform": "nordicnrf52",
+  "ram": 237568,
+  "rom": 811008,
+  "url": "https://wiki.seeedstudio.com/XIAO_BLE",
+  "vendor": "Seeed"
+}

--- a/crates/fbuild-config/assets/boards/json/xiaoblesense_adafruit.json
+++ b/crates/fbuild-config/assets/boards/json/xiaoblesense_adafruit.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "nRF5",
+    "variant": "Seeed_XIAO_nRF52840_Sense",
+    "arduino": {
+      "ldscript": "nrf52840_s140_v7.ld"
+    }
+  },
+  "connectivity": [
+    "bluetooth"
+  ],
+  "debug": {
+    "tools": {
+      "blackmagic": {},
+      "jlink": {},
+      "cmsis-dap": {}
+    }
+  },
+  "fcpu": 64000000,
+  "frameworks": [
+    "arduino"
+  ],
+  "id": "xiaoblesense_adafruit",
+  "mcu": "NRF52840",
+  "name": "Seeed XIAO BLE Sense",
+  "platform": "nordicnrf52",
+  "ram": 237568,
+  "rom": 811008,
+  "url": "https://wiki.seeedstudio.com/XIAO_BLE",
+  "vendor": "Seeed"
+}

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -494,6 +494,27 @@ fn test_nano_every_board_config() {
     assert_eq!(config.platform(), Some(fbuild_core::Platform::AtmelMegaAvr));
 }
 
+#[test]
+fn test_xiaoble_adafruit_board_config() {
+    // Seeed XIAO BLE (nRF52840, no IMU); maxgerhardt platform-nordicnrf52.
+    // Regression for FastLED `nrf52_xiaoblesense` workflow (#293).
+    let config = BoardConfig::from_board_id("xiaoble_adafruit", &HashMap::new()).unwrap();
+    assert_eq!(config.mcu, "nrf52840");
+    assert_eq!(config.core, "nRF5");
+    assert_eq!(config.variant, "Seeed_XIAO_nRF52840");
+}
+
+#[test]
+fn test_xiaoblesense_adafruit_board_config() {
+    // Seeed XIAO BLE Sense (nRF52840 + IMU/mic).
+    // Regression for FastLED `adafruit_xiaoblesense` workflow (#293).
+    let config =
+        BoardConfig::from_board_id("xiaoblesense_adafruit", &HashMap::new()).unwrap();
+    assert_eq!(config.mcu, "nrf52840");
+    assert_eq!(config.core, "nRF5");
+    assert_eq!(config.variant, "Seeed_XIAO_nRF52840_Sense");
+}
+
 /// Validate that ALL megatinycore boards have the required framework-injected
 /// defines in extra_flags. PlatformIO's builder script injects these at build
 /// time, but fbuild must carry them in the board JSON since we don't run


### PR DESCRIPTION
## Summary

- `fbuild`'s bundled board DB (`crates/fbuild-config/assets/boards/json/`) was missing both Seeed XIAO BLE variants. Every downstream consumer of `xiaoble_adafruit` or `xiaoblesense_adafruit` hit `config error: unknown board 'X' (no built-in defaults)` before any code was compiled.
- fbuild does not consult `~/.platformio/platforms/` at runtime, so maxgerhardt platform's board JSONs are invisible — they must be baked into the bundle (the `enrich_boards` maintenance bin is the canonical path, but these boards never made it through).
- Add both JSONs mirroring `maxgerhardt/platform-nordicnrf52/boards/{xiaoble_adafruit,xiaoblesense_adafruit}.json` (develop branch):
  - mcu = NRF52840, fcpu = 64 MHz
  - core = nRF5, variant = `Seeed_XIAO_nRF52840` / `Seeed_XIAO_nRF52840_Sense`
  - ldscript = `nrf52840_s140_v7.ld`
  - ram = 237568, rom = 811008 (from upstream `upload.maximum_ram_size` / `maximum_size`)
  - platform = `nordicnrf52`
- Affected FastLED workflows on master: `nrf52_xiaoblesense` (→ `xiaoble_adafruit`), `adafruit_xiaoblesense` (→ `xiaoblesense_adafruit`). Both fail every example in each workflow.

## Test plan

- [x] `cargo check -p fbuild-config` — clean.
- [x] `cargo test -p fbuild-config --lib board::` — 55/55 (was 53/53; added two regression tests).
- [ ] CI revival: FastLED's `nrf52_xiaoblesense` + `adafruit_xiaoblesense` workflows after a fbuild bump.

Fixes #293

Generated with Claude Code (https://claude.com/claude-code)