### PR TITLE
fix(board-db): add SparkFun XRP Controller (RP2350B) board def

### DIFF
--- a/crates/fbuild-config/assets/boards/json/sparkfun_xrp_controller.json
+++ b/crates/fbuild-config/assets/boards/json/sparkfun_xrp_controller.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "core": "earlephilhower",
+    "extra_flags": "-DARDUINO_SPARKFUN_XRP_CONTROLLER -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250 -DPICO_CYW43_SUPPORTED=1 -DCYW43_PIN_WL_DYNAMIC=1",
+    "f_cpu": "150000000L",
+    "mcu": "rp2350",
+    "pid": "0x00C0",
+    "variant": "sparkfun_xrp_controller",
+    "vid": "0x2E8A"
+  },
+  "debug": {
+    "tools": {
+      "cmsis-dap": {},
+      "jlink": {},
+      "raspberrypi-swd": {},
+      "picoprobe": {}
+    }
+  },
+  "fcpu": 150000000,
+  "frameworks": [
+    "arduino"
+  ],
+  "id": "sparkfun_xrp_controller",
+  "mcu": "RP2350",
+  "name": "SparkFun XRP Controller",
+  "platform": "raspberrypi",
+  "ram": 524288,
+  "rom": 16777216,
+  "upload": {
+    "protocol": "picotool",
+    "require_upload_port": true
+  },
+  "url": "https://www.sparkfun.com/products/27628",
+  "vendor": "SparkFun"
+}

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -324,6 +324,18 @@ fn test_pico_enriched_fields() {
 }
 
 #[test]
+fn test_sparkfun_xrp_controller_board_config() {
+    // SparkFun XRP Controller (RP2350B); maxgerhardt/platform-raspberrypi.
+    // Regression for FastLED `rp2350B SparkfunXRP` workflow (#295).
+    let config =
+        BoardConfig::from_board_id("sparkfun_xrp_controller", &HashMap::new()).unwrap();
+    assert_eq!(config.mcu, "rp2350");
+    assert_eq!(config.core, "earlephilhower");
+    assert_eq!(config.variant, "sparkfun_xrp_controller");
+    assert_eq!(config.upload_protocol, Some("picotool".to_string()));
+}
+
+#[test]
 fn test_extra_flags_produce_defines() {
     // Enriched extra_flags should produce correct ARDUINO_* defines
     let config = BoardConfig::from_board_id("uno", &HashMap::new()).unwrap();


### PR DESCRIPTION
## Summary

- Every FastLED `rp2350B SparkfunXRP` CI build on master failed with `config error: unknown board 'sparkfun_xrp_controller' (no built-in defaults)` — same shape as #293 (Seeed XIAO BLE).
- fbuild does not consult `~/.platformio/platforms/` at runtime; bundled board JSONs in `crates/fbuild-config/assets/boards/json/` are the source of truth. `sparkfun_xrp_controller.json` was missing.
- Added the JSON mirroring `maxgerhardt/platform-raspberrypi/boards/sparkfun_xrp_controller.json` (develop branch):
  - `mcu = RP2350`, `fcpu = 150 MHz`
  - `core = earlephilhower`, `variant = sparkfun_xrp_controller`
  - `ram = 524288` (512 KB), `rom = 16777216` (16 MB)
  - `platform = raspberrypi`, `upload.protocol = picotool`
  - Preserves upstream's `-DARDUINO_ARCH_RP2040` define quirk on a physical RP2350 board (matches platform-raspberrypi behavior).

## Test plan

- [x] `cargo check -p fbuild-config` clean.
- [x] `cargo test -p fbuild-config --lib board::` — 54/54 (was 53/53; added one regression test).
- [ ] CI revival: FastLED's `rp2350B SparkfunXRP` workflow after a fbuild bump.

Fixes #295

Generated with Claude Code (https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the SparkFun XRP Controller board, a new microcontroller platform compatible with the build system. Includes pre-configured settings for build optimization, debugging, and firmware uploads.

* **Tests**
  * Added automated tests to verify the board configuration is correctly recognized and loaded by the build system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->