### PR TITLE
fix(board-db): add build.extra_flags for nRF52840 boards (Arduino macros)

### DIFF
--- a/crates/fbuild-config/assets/boards/json/adafruit_feather_nrf52840_sense.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_feather_nrf52840_sense.json
@@ -1,6 +1,7 @@
 {
   "build": {
     "core": "nRF5",
+    "extra_flags": "-DARDUINO_NRF52840_FEATHER_SENSE -DNRF52840_XXAA",
     "variant": "feather_nrf52840_sense",
     "arduino": {
       "ldscript": "nrf52840_s140_v6.ld"

--- a/crates/fbuild-config/assets/boards/json/nrf52840_dk.json
+++ b/crates/fbuild-config/assets/boards/json/nrf52840_dk.json
@@ -1,6 +1,7 @@
 {
   "build": {
     "core": "nRF5",
+    "extra_flags": "-DARDUINO_NRF52_DK",
     "variant": "pca10056",
     "arduino": {
       "ldscript": "nrf52840_s140_v6.ld"

--- a/crates/fbuild-config/assets/boards/json/nrf52840_dk_adafruit.json
+++ b/crates/fbuild-config/assets/boards/json/nrf52840_dk_adafruit.json
@@ -1,6 +1,7 @@
 {
   "build": {
     "core": "nRF5",
+    "extra_flags": "-DARDUINO_NRF52840_PCA10056 -DNRF52840_XXAA",
     "variant": "pca10056",
     "arduino": {
       "ldscript": "nrf52840_s140_v6.ld"

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -316,6 +316,44 @@ fn test_esp32_flash_mode_env_override_honoured() {
 }
 
 #[test]
+fn test_nrf52840_dk_carries_arduino_macro() {
+    // Regression for FastLED CI fail: missing ARDUINO_NRF52_DK meant FastLED's
+    // nRF52 variants header fell through to the "Unknown variant" fallback
+    // (pin 1 invalid), blowing up Apa102.ino's static_assert. See fbuild#298.
+    let config = BoardConfig::from_board_id("nrf52840_dk", &HashMap::new()).unwrap();
+    let defines = config.get_defines();
+    assert_eq!(defines.get("ARDUINO_NRF52_DK"), Some(&"1".to_string()));
+}
+
+#[test]
+fn test_nrf52840_dk_adafruit_carries_arduino_macro() {
+    // Same fbuild#298 root cause — used by FastLED's `supermini_nrf52840` board.
+    let config =
+        BoardConfig::from_board_id("nrf52840_dk_adafruit", &HashMap::new()).unwrap();
+    let defines = config.get_defines();
+    assert_eq!(
+        defines.get("ARDUINO_NRF52840_PCA10056"),
+        Some(&"1".to_string())
+    );
+    assert_eq!(defines.get("NRF52840_XXAA"), Some(&"1".to_string()));
+}
+
+#[test]
+fn test_adafruit_feather_nrf52840_sense_carries_arduino_macro() {
+    let config = BoardConfig::from_board_id(
+        "adafruit_feather_nrf52840_sense",
+        &HashMap::new(),
+    )
+    .unwrap();
+    let defines = config.get_defines();
+    assert_eq!(
+        defines.get("ARDUINO_NRF52840_FEATHER_SENSE"),
+        Some(&"1".to_string())
+    );
+    assert_eq!(defines.get("NRF52840_XXAA"), Some(&"1".to_string()));
+}
+
+#[test]
 fn test_pico_enriched_fields() {
     let config = BoardConfig::from_board_id("rpipico", &HashMap::new()).unwrap();
     assert_eq!(config.core, "earlephilhower");


### PR DESCRIPTION
## Summary

- Immediate-unblock subset of #298: restore `build.extra_flags` on three nRF52840 board JSONs that FastLED CI currently exercises. Values mirror upstream `platformio/platform-nordicnrf52` verbatim.
- Without these, every nRF52 build falls through FastLED's "Unknown nRF52840 variant" fallback block in `platforms/arm/nrf52/fastpin_arm_nrf52_variants.h`, which marks pin 1 invalid → `static_assert "This pin has been marked as an invalid pin"` at `fl/system/fastpin_base.h:146` on `examples/Apa102/Apa102.ino`.

| board | added |
|---|---|
| `nrf52840_dk` | `-DARDUINO_NRF52_DK` |
| `nrf52840_dk_adafruit` | `-DARDUINO_NRF52840_PCA10056 -DNRF52840_XXAA` |
| `adafruit_feather_nrf52840_sense` | `-DARDUINO_NRF52840_FEATHER_SENSE -DNRF52840_XXAA` |

This unblocks FastLED `nrf52840_dk`, `nrf52840_supermini` (via `real_board_name="nrf52840_dk_adafruit"`), and `adafruit_feather_nrf52840_sense` workflows.

The full sweep — every other bundled board missing `extra_flags`, including the rest of the nRF52 family — is a separate follow-up tracked at #298 (re-run `enrich_boards` end-to-end to import `extra_flags` for everything).

## Test plan

- [x] `cargo check -p fbuild-config` clean.
- [x] `cargo test -p fbuild-config --lib board::` — 56/56 (was 53/53 before; +3 regression tests).
- [ ] CI on FastLED side: `nrf52840_dk`, `nrf52840_supermini`, `adafruit_feather_nrf52840_sense` workflows should now reach actual compilation past the static_assert.

Refs #298

Generated with Claude Code (https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced nRF52840 board support with updated compiler definitions for Adafruit Feather, DK, and DK Adafruit variants.

* **Tests**
  * Added unit tests to verify correct compiler definitions are applied for nRF52840 boards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->