### PR TITLE
fix(teensy): disable LTO on teensylc release profile (Thumb-1 offset overflow)

### DIFF
--- a/crates/fbuild-build/src/teensy/configs/teensylc.json
+++ b/crates/fbuild-build/src/teensy/configs/teensylc.json
@@ -51,8 +51,9 @@
 
   "profiles": {
     "release": {
-      "compile_flags": ["-Os", "-flto=auto", "-fno-fat-lto-objects"],
-      "link_flags": ["-Os", "-flto=auto", "-fuse-linker-plugin"]
+      "_comment_no_lto": "Teensy LC is Cortex-M0+ (Thumb-1 only). Thumb-1 PC-relative loads have an immediate-offset limit (~1 KB / 0x400) that LTO output routinely overflows when whole-program optimization rearranges literal pools. Symptom: `Error: invalid offset, value too big (0x000004CC)` from the assembler on `.lto-tmp/*.s`, then `lto-wrapper: fatal error: make returned 2 exit status`. Drop LTO here; the cost is a slightly larger image but actual link success. Other Cortex-M (>=M3, Thumb-2) profiles keep LTO.",
+      "compile_flags": ["-Os"],
+      "link_flags": ["-Os"]
     },
     "quick": {
       "compile_flags": ["-O1"],


### PR DESCRIPTION
## Summary

- Every FastLED `teensyLC` release build on master fails at the assembler with `Error: invalid offset, value too big (0x000004CC)` on `.lto-tmp/*.s`, then `lto-wrapper: fatal error: make returned 2 exit status`.
- Teensy LC = Cortex-M0+ = Thumb-1 only. Thumb-1 PC-relative loads (`ldr Rd, [PC, #imm]`) max out around 1 KB (10-bit word-aligned immediate → 0x3FC). LTO rearranges literal pools across TUs and overshoots that on FastLED-sized projects.
- Every other Teensy MCU is Cortex-M3 or later (Thumb-2, 12-bit immediate) — they keep LTO.
- Drop `-flto=auto` / `-fno-fat-lto-objects` / `-fuse-linker-plugin` from teensylc's release profile in `crates/fbuild-build/src/teensy/configs/teensylc.json`. Keep `-Os` for size.

## Test plan

- [x] `cargo check -p fbuild-build` clean.
- [x] `cargo test -p fbuild-build --lib teensy::` — 38/38 (including `test_teensylc_linker_flags_match_platformio` and `test_linker_flags_match_platformio_reference` which don't reference `-flto` in the linker_flags allow-list).
- [ ] CI: `teensyLC` workflow should now link successfully.

Fixes #301

Generated with Claude Code (https://claude.com/claude-code)
