### PR TITLE
feat(debug): print link command on -v + always emit firmware.map (fixes #305)

### DIFF
--- a/crates/fbuild-build/src/avr/avr_linker.rs
+++ b/crates/fbuild-build/src/avr/avr_linker.rs
@@ -54,21 +54,19 @@ impl AvrLinker {
     }
 }
 
-impl Linker for AvrLinker {
-    fn archive(&self, objects: &[PathBuf], output: &Path) -> Result<()> {
-        crate::linker::LinkerBase::archive(&self.ar_path, objects, output, "avr-ar")
-    }
-
-    fn link(
+impl AvrLinker {
+    /// Build the argv that will be passed to `avr-gcc` for the link step.
+    ///
+    /// Factored out so it can be unit-tested without invoking the toolchain
+    /// (see #305 — assert that `-Wl,-Map=` is present).
+    fn build_link_args(
         &self,
         objects: &[PathBuf],
         archives: &[PathBuf],
         output_dir: &Path,
+        elf_path: &Path,
         extra: &LinkExtraArgs,
-    ) -> Result<PathBuf> {
-        std::fs::create_dir_all(output_dir)?;
-        let elf_path = output_dir.join("firmware.elf");
-
+    ) -> Vec<String> {
         let mut args: Vec<String> = vec![
             self.gcc_path.to_string_lossy().to_string(),
             format!("-mmcu={}", self.mcu),
@@ -84,6 +82,10 @@ impl Linker for AvrLinker {
         args.extend(extra.flags.iter().cloned());
 
         args.extend(["-o".to_string(), elf_path.to_string_lossy().to_string()]);
+
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
 
         // Sketch objects first
         for obj in objects {
@@ -102,7 +104,29 @@ impl Linker for AvrLinker {
         args.extend(extra.libs.iter().cloned());
         args.push("-Wl,--end-group".to_string());
 
+        args
+    }
+}
+
+impl Linker for AvrLinker {
+    fn archive(&self, objects: &[PathBuf], output: &Path) -> Result<()> {
+        crate::linker::LinkerBase::archive(&self.ar_path, objects, output, "avr-ar")
+    }
+
+    fn link(
+        &self,
+        objects: &[PathBuf],
+        archives: &[PathBuf],
+        output_dir: &Path,
+        extra: &LinkExtraArgs,
+    ) -> Result<PathBuf> {
+        std::fs::create_dir_all(output_dir)?;
+        let elf_path = output_dir.join("firmware.elf");
+
+        let args = self.build_link_args(objects, archives, output_dir, &elf_path, extra);
+
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 
@@ -167,5 +191,41 @@ mod tests {
         assert_eq!(linker.mcu, "atmega328p");
         assert_eq!(linker.max_flash, Some(32256));
         assert_eq!(linker.max_ram, Some(2048));
+    }
+
+    /// #305: every per-platform linker must emit a `firmware.map` next to
+    /// `firmware.elf`. Assert the generated argv contains a `-Wl,-Map=` token.
+    #[test]
+    fn test_avr_link_args_contain_map_flag() {
+        let linker = AvrLinker::new(
+            PathBuf::from("/bin/avr-gcc"),
+            PathBuf::from("/bin/avr-ar"),
+            PathBuf::from("/bin/avr-objcopy"),
+            PathBuf::from("/bin/avr-size"),
+            "atmega328p",
+            get_avr_config().unwrap(),
+            BuildProfile::Release,
+            Some(32256),
+            Some(2048),
+            false,
+        );
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let output_dir = tmp.path();
+        let elf_path = output_dir.join("firmware.elf");
+        let extra = LinkExtraArgs::default();
+        let args = linker.build_link_args(&[], &[], output_dir, &elf_path, &extra);
+
+        let map_flag = args
+            .iter()
+            .find(|a| a.starts_with("-Wl,-Map="))
+            .expect("link args must contain -Wl,-Map= for firmware.map emission");
+        let expected_map = output_dir.join("firmware.map");
+        assert!(
+            map_flag.contains(&*expected_map.to_string_lossy()),
+            "expected map flag to reference {}, got {}",
+            expected_map.display(),
+            map_flag
+        );
     }
 }

--- a/crates/fbuild-build/src/ch32v/ch32v_linker.rs
+++ b/crates/fbuild-build/src/ch32v/ch32v_linker.rs
@@ -86,6 +86,10 @@ impl Linker for Ch32vLinker {
             elf_path.to_string_lossy().to_string(),
         ]);
 
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
         // Sketch objects first
         for obj in objects {
             args.push(obj.to_string_lossy().to_string());
@@ -101,6 +105,7 @@ impl Linker for Ch32vLinker {
         args.extend(extra.libs.iter().cloned());
 
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 

--- a/crates/fbuild-build/src/esp8266/esp8266_linker.rs
+++ b/crates/fbuild-build/src/esp8266/esp8266_linker.rs
@@ -199,6 +199,10 @@ impl Linker for Esp8266Linker {
 
         args.extend(["-o".to_string(), elf_path.to_string_lossy().to_string()]);
 
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
         // Sketch objects first
         for obj in objects {
             args.push(obj.to_string_lossy().to_string());
@@ -216,6 +220,7 @@ impl Linker for Esp8266Linker {
         args.push("-Wl,--end-group".to_string());
 
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 

--- a/crates/fbuild-build/src/generic_arm/arm_linker.rs
+++ b/crates/fbuild-build/src/generic_arm/arm_linker.rs
@@ -86,6 +86,10 @@ impl Linker for ArmLinker {
             elf_path.to_string_lossy().to_string(),
         ]);
 
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
         // Sketch objects first
         for obj in objects {
             args.push(obj.to_string_lossy().to_string());
@@ -101,6 +105,7 @@ impl Linker for ArmLinker {
         args.extend(extra.libs.iter().cloned());
 
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 

--- a/crates/fbuild-build/src/nrf52/nrf52_linker.rs
+++ b/crates/fbuild-build/src/nrf52/nrf52_linker.rs
@@ -94,6 +94,10 @@ impl Linker for Nrf52Linker {
             elf_path.to_string_lossy().to_string(),
         ]);
 
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
         // Sketch objects first
         for obj in objects {
             args.push(obj.to_string_lossy().to_string());
@@ -109,6 +113,7 @@ impl Linker for Nrf52Linker {
         args.extend(extra.libs.iter().cloned());
 
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 

--- a/crates/fbuild-build/src/renesas/renesas_linker.rs
+++ b/crates/fbuild-build/src/renesas/renesas_linker.rs
@@ -99,6 +99,10 @@ impl Linker for RenesasLinker {
             elf_path.to_string_lossy().to_string(),
         ]);
 
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
         // Sketch objects first
         for obj in objects {
             args.push(obj.to_string_lossy().to_string());
@@ -114,6 +118,7 @@ impl Linker for RenesasLinker {
         args.extend(extra.libs.iter().cloned());
 
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 

--- a/crates/fbuild-build/src/sam/sam_linker.rs
+++ b/crates/fbuild-build/src/sam/sam_linker.rs
@@ -100,6 +100,10 @@ impl Linker for SamLinker {
             elf_path.to_string_lossy().to_string(),
         ]);
 
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
         // Sketch objects first
         for obj in objects {
             args.push(obj.to_string_lossy().to_string());
@@ -130,6 +134,7 @@ impl Linker for SamLinker {
         args.extend(extra.libs.iter().cloned());
 
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 

--- a/crates/fbuild-build/src/silabs/silabs_linker.rs
+++ b/crates/fbuild-build/src/silabs/silabs_linker.rs
@@ -92,6 +92,10 @@ impl Linker for SilabsLinker {
             elf_path.to_string_lossy().to_string(),
         ]);
 
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
         // Sketch objects first
         for obj in objects {
             args.push(obj.to_string_lossy().to_string());
@@ -117,6 +121,7 @@ impl Linker for SilabsLinker {
         args.push("-Wl,--end-group".to_string());
 
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 

--- a/crates/fbuild-build/src/teensy/teensy_linker.rs
+++ b/crates/fbuild-build/src/teensy/teensy_linker.rs
@@ -83,6 +83,10 @@ impl Linker for TeensyLinker {
         args.extend(self.linker_scripts.to_args());
         args.extend(["-o".to_string(), elf_path.to_string_lossy().to_string()]);
 
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        let map_path = output_dir.join("firmware.map");
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
         // Sketch objects first
         for obj in objects {
             args.push(obj.to_string_lossy().to_string());
@@ -98,6 +102,7 @@ impl Linker for TeensyLinker {
         args.extend(extra.libs.iter().cloned());
 
         if self.verbose {
+            eprintln!("link: {}", args.join(" "));
             tracing::info!("link: {}", args.join(" "));
         }
 


### PR DESCRIPTION
## Summary

Fixes #305. Two tiny patches:

1. Per-platform linkers' `-v`-gated log of the link command line now goes through `eprintln!` in addition to `tracing::info!`, so plain CLI users see it without configuring tracing subscribers.
2. Every per-platform linker that produces a `firmware.elf` via `-o` now adds `-Wl,-Map=firmware.map` next to the ELF. Tiny artifact, huge debugging value.

## Linkers covered

| Linker | -v eprintln | -Wl,-Map= |
|---|---|---|
| `avr/avr_linker.rs` | yes | yes |
| `ch32v/ch32v_linker.rs` | yes | yes |
| `esp8266/esp8266_linker.rs` | yes | yes |
| `generic_arm/arm_linker.rs` | yes | yes |
| `nrf52/nrf52_linker.rs` | yes | yes |
| `renesas/renesas_linker.rs` | yes | yes |
| `sam/sam_linker.rs` | yes | yes |
| `silabs/silabs_linker.rs` | yes | yes |
| `teensy/teensy_linker.rs` | yes | yes |

## Out of scope

- **ESP32 and WASM** linker paths skipped per the issue — different pipeline / different artifact shape (per the comments in `pipeline/sequential.rs:27-28`). Happy to follow up if a maintainer wants those covered too.
- Fix C from the issue (a standalone `fbuild diag` subcommand) deferred — the `-v` + map file combo already unblocks the kind of investigation that motivated the issue.

## Implementation notes

- `eprintln!` is added alongside `tracing::info!` — log integration is preserved, and stderr surfacing is additive.
- The map flag uses an absolute path (`output_dir.join("firmware.map")`) so the artifact lands deterministically next to `firmware.elf`.
- `avr_linker.rs` extracts arg-building into a private `build_link_args()` helper so the new unit test can assert the argv without invoking the toolchain. No behavior change.

## Verification

- `soldr cargo check -p fbuild-build` — clean.
- `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings` — exit 0 (only the pre-existing global "MSRV in clippy.toml differs from Cargo.toml" warning, unrelated to this PR).
- `soldr cargo test -p fbuild-build --lib avr_linker` — 2 passed, 0 failed (new `test_avr_link_args_contain_map_flag` asserts the argv contains `-Wl,-Map=` and that the path resolves to `<output_dir>/firmware.map`).
- AVR / device builds not exercised on this box (no toolchain) — additive flag, no behavior change beyond the new artifact.