### PR TITLE
fix(teensy): auto-link Teensyduino CMSIS-DSP per-MCU (#300)

### DIFF
--- a/crates/fbuild-build/src/teensy/configs/teensy4x.json
+++ b/crates/fbuild-build/src/teensy/configs/teensy4x.json
@@ -38,7 +38,6 @@
   ],
 
   "linker_libs": [
-    "-larm_cortexM7lfsp_math",
     "-lgcc",
     "-lstdc++",
     "-lm",

--- a/crates/fbuild-build/src/teensy/mcu_config.rs
+++ b/crates/fbuild-build/src/teensy/mcu_config.rs
@@ -199,24 +199,39 @@ mod tests {
             .contains(&"-mcpu=cortex-m7".to_string()));
     }
 
-    /// Regression test for issue #257: teensy4x must link
-    /// `libarm_cortexM7lfsp_math.a` (CMSIS-DSP) so Teensy Audio FFT
-    /// examples (`Ports/PJRCSpectrumAnalyzer`) resolve symbols like
-    /// `arm_cfft_radix4_q15`. The library ships in the Teensy 4.x core
-    /// dir, which the linker already gets as `-L<core_dir>` via
-    /// `LinkerScripts::single`.
+    /// Regression test for issues #257 and #300: Teensy boards that ship a
+    /// Teensyduino-bundled CMSIS-DSP math library must auto-link it so Teensy
+    /// `Audio.h` FFT examples (`Ports/PJRCSpectrumAnalyzer`) resolve symbols
+    /// like `arm_cfft_radix4_q15`. After #300 the per-MCU library name is
+    /// data-driven via `BoardConfig.cmsis_dsp_lib` (populated from board JSON
+    /// `build.cmsis_dsp_lib`), mirroring PlatformIO+Teensyduino's SCons
+    /// builder. The library ships in the Teensy core dir, which the linker
+    /// already gets as `-L<core_dir>` via `LinkerScripts::single`.
     #[test]
-    fn teensy4x_links_cmsis_dsp_math() {
-        let config = get_teensy_config_for_mcu("imxrt1062").expect("teensy4x config");
-        assert!(
-            config
-                .linker_libs
-                .contains(&"-larm_cortexM7lfsp_math".to_string()),
-            "teensy4x linker_libs must include -larm_cortexM7lfsp_math \
-             so Teensy Audio FFT examples link; see issue #257. \
-             Actual libs: {:?}",
-            config.linker_libs
-        );
+    fn teensy_boards_carry_cmsis_dsp_lib() {
+        let expectations: &[(&str, &str)] = &[
+            ("teensy30", "arm_cortexM4l_math"),
+            ("teensy31", "arm_cortexM4l_math"),
+            ("teensy35", "arm_cortexM4lf_math"),
+            ("teensy36", "arm_cortexM4lf_math"),
+            ("teensy40", "arm_cortexM7lfsp_math"),
+            ("teensy41", "arm_cortexM7lfsp_math"),
+            ("teensymm", "arm_cortexM7lfsp_math"),
+            ("teensylc", "arm_cortexM0l_math"),
+        ];
+        for (board_id, expected) in expectations {
+            let board = fbuild_config::BoardConfig::from_board_id(board_id, &HashMap::new())
+                .unwrap_or_else(|_| panic!("BoardConfig should load for {}", board_id));
+            assert_eq!(
+                board.cmsis_dsp_lib.as_deref(),
+                Some(*expected),
+                "{} must declare build.cmsis_dsp_lib={} so Teensy Audio FFT \
+                 examples link (mirrors PlatformIO+Teensyduino's per-MCU \
+                 auto-link). See FastLED/fbuild#300.",
+                board_id,
+                expected,
+            );
+        }
     }
 
     #[test]

--- a/crates/fbuild-build/src/teensy/orchestrator.rs
+++ b/crates/fbuild-build/src/teensy/orchestrator.rs
@@ -261,6 +261,7 @@ impl BuildOrchestrator for TeensyOrchestrator {
             params.profile,
             ctx.board.max_flash,
             ctx.board.max_ram,
+            ctx.board.cmsis_dsp_lib.clone(),
             params.verbose,
         );
 

--- a/crates/fbuild-build/src/teensy/teensy_linker.rs
+++ b/crates/fbuild-build/src/teensy/teensy_linker.rs
@@ -22,6 +22,11 @@ pub struct TeensyLinker {
     profile: BuildProfile,
     max_flash: Option<u64>,
     max_ram: Option<u64>,
+    /// Bare CMSIS-DSP math library name (e.g. `arm_cortexM4lf_math`) to link
+    /// via `-l<name>`. Mirrors PlatformIO+Teensyduino's per-MCU auto-link of
+    /// the appropriate `libarm_cortex*_math.a` so Teensy `Audio.h` FFT classes
+    /// resolve at link time. See FastLED/fbuild#300.
+    cmsis_dsp_lib: Option<String>,
     verbose: bool,
 }
 
@@ -37,6 +42,7 @@ impl TeensyLinker {
         profile: BuildProfile,
         max_flash: Option<u64>,
         max_ram: Option<u64>,
+        cmsis_dsp_lib: Option<String>,
         verbose: bool,
     ) -> Self {
         Self {
@@ -49,26 +55,26 @@ impl TeensyLinker {
             profile,
             max_flash,
             max_ram,
+            cmsis_dsp_lib,
             verbose,
         }
     }
-}
 
-impl Linker for TeensyLinker {
-    fn archive(&self, objects: &[PathBuf], output: &Path) -> Result<()> {
-        crate::linker::LinkerBase::archive(&self.ar_path, objects, output, "arm-none-eabi-ar")
+    /// Bare CMSIS-DSP library name configured for this linker, if any.
+    pub fn cmsis_dsp_lib(&self) -> Option<&str> {
+        self.cmsis_dsp_lib.as_deref()
     }
 
-    fn link(
+    /// Build the full `arm-none-eabi-gcc` link command-line for the given
+    /// inputs. Exposed for unit-testing the auto-appended CMSIS-DSP lib
+    /// (FastLED/fbuild#300) without spawning the real linker.
+    fn build_link_args(
         &self,
         objects: &[PathBuf],
         archives: &[PathBuf],
-        output_dir: &Path,
+        elf_path: &Path,
         extra: &LinkExtraArgs,
-    ) -> Result<PathBuf> {
-        std::fs::create_dir_all(output_dir)?;
-        let elf_path = output_dir.join("firmware.elf");
-
+    ) -> Vec<String> {
         let mut args: Vec<String> = vec![self.gcc_path.to_string_lossy().to_string()];
 
         // Linker flags from config
@@ -95,7 +101,37 @@ impl Linker for TeensyLinker {
 
         // Linker libraries from config
         args.extend(self.mcu_config.linker_libs.iter().cloned());
+        // Per-board CMSIS-DSP math library auto-link (FastLED/fbuild#300).
+        // Mirrors PlatformIO+Teensyduino's behaviour: when the board defines
+        // `build.cmsis_dsp_lib`, append `-l<name>` so the linker resolves
+        // CMSIS-DSP symbols (`arm_cfft_*`, etc.) referenced by `Audio.h` FFT
+        // classes from `libarm_cortex*_math.a` that ships in the Teensy core
+        // dir (already on the search path via `-L<core_dir>`).
+        if let Some(ref lib) = self.cmsis_dsp_lib {
+            args.push(format!("-l{}", lib));
+        }
         args.extend(extra.libs.iter().cloned());
+
+        args
+    }
+}
+
+impl Linker for TeensyLinker {
+    fn archive(&self, objects: &[PathBuf], output: &Path) -> Result<()> {
+        crate::linker::LinkerBase::archive(&self.ar_path, objects, output, "arm-none-eabi-ar")
+    }
+
+    fn link(
+        &self,
+        objects: &[PathBuf],
+        archives: &[PathBuf],
+        output_dir: &Path,
+        extra: &LinkExtraArgs,
+    ) -> Result<PathBuf> {
+        std::fs::create_dir_all(output_dir)?;
+        let elf_path = output_dir.join("firmware.elf");
+
+        let args = self.build_link_args(objects, archives, &elf_path, extra);
 
         if self.verbose {
             tracing::info!("link: {}", args.join(" "));
@@ -181,10 +217,12 @@ mod tests {
             BuildProfile::Release,
             Some(8126464),
             Some(1048576),
+            None,
             false,
         );
         assert_eq!(linker.max_flash, Some(8126464));
         assert_eq!(linker.max_ram, Some(1048576));
+        assert!(linker.cmsis_dsp_lib().is_none());
     }
 
     #[test]
@@ -199,6 +237,7 @@ mod tests {
             BuildProfile::Release,
             Some(8126464),
             Some(1048576),
+            None,
             false,
         );
         assert!(linker
@@ -206,5 +245,97 @@ mod tests {
             .scripts
             .iter()
             .any(|s| s.contains("imxrt1062")));
+    }
+
+    /// Regression test for FastLED/fbuild#300: when a CMSIS-DSP library is
+    /// configured, the linker stores it so the `-l<lib>` flag is appended at
+    /// link time (mirrors PlatformIO+Teensyduino's auto-link behaviour).
+    #[test]
+    fn test_teensy_linker_stores_cmsis_dsp_lib() {
+        let linker = TeensyLinker::new(
+            PathBuf::from("/bin/arm-none-eabi-gcc"),
+            PathBuf::from("/bin/arm-none-eabi-ar"),
+            PathBuf::from("/bin/arm-none-eabi-objcopy"),
+            PathBuf::from("/bin/arm-none-eabi-size"),
+            LinkerScripts::single(PathBuf::from("/teensy3"), "mk66fx1m0.ld"),
+            crate::teensy::mcu_config::get_teensy_config_for_mcu("mk66fx1m0").unwrap(),
+            BuildProfile::Release,
+            Some(1048576),
+            Some(262144),
+            Some("arm_cortexM4lf_math".to_string()),
+            false,
+        );
+        assert_eq!(linker.cmsis_dsp_lib(), Some("arm_cortexM4lf_math"));
+    }
+
+    /// Regression test for FastLED/fbuild#300: the constructed link command
+    /// includes `-larm_cortexM4lf_math` for teensy36 (MK66FX1M0). Mirrors
+    /// PlatformIO+Teensyduino's per-MCU auto-link so Teensy `Audio.h` FFT
+    /// classes (e.g. `arm_cfft_radix4_q15`) resolve at link time.
+    #[test]
+    fn test_teensy36_link_command_includes_cmsis_dsp_lib() {
+        let linker = TeensyLinker::new(
+            PathBuf::from("/bin/arm-none-eabi-gcc"),
+            PathBuf::from("/bin/arm-none-eabi-ar"),
+            PathBuf::from("/bin/arm-none-eabi-objcopy"),
+            PathBuf::from("/bin/arm-none-eabi-size"),
+            LinkerScripts::single(PathBuf::from("/teensy3"), "mk66fx1m0.ld"),
+            crate::teensy::mcu_config::get_teensy_config_for_mcu("mk66fx1m0").unwrap(),
+            BuildProfile::Release,
+            Some(1048576),
+            Some(262144),
+            Some("arm_cortexM4lf_math".to_string()),
+            false,
+        );
+        let args = linker.build_link_args(
+            &[PathBuf::from("/build/sketch.o")],
+            &[PathBuf::from("/build/core.o")],
+            &PathBuf::from("/build/firmware.elf"),
+            &LinkExtraArgs::default(),
+        );
+        assert!(
+            args.iter().any(|a| a == "-larm_cortexM4lf_math"),
+            "teensy36 link command must include -larm_cortexM4lf_math \
+             so Audio.h FFT examples link (see fbuild#300). Args: {:?}",
+            args
+        );
+        // The `-L<core_dir>` flag from LinkerScripts is what lets the linker
+        // resolve the `-l` to `libarm_cortexM4lf_math.a` inside teensy3/.
+        assert!(
+            args.iter().any(|a| a == "-L/teensy3"),
+            "expected -L/teensy3 for library search, got {:?}",
+            args
+        );
+    }
+
+    /// Boards that do not declare a CMSIS-DSP lib (e.g. user override clears
+    /// it) must not have a spurious `-l` argument appended.
+    #[test]
+    fn test_teensy_link_command_omits_cmsis_dsp_lib_when_none() {
+        let linker = TeensyLinker::new(
+            PathBuf::from("/bin/arm-none-eabi-gcc"),
+            PathBuf::from("/bin/arm-none-eabi-ar"),
+            PathBuf::from("/bin/arm-none-eabi-objcopy"),
+            PathBuf::from("/bin/arm-none-eabi-size"),
+            LinkerScripts::single(PathBuf::from("/teensy4"), "imxrt1062_t41.ld"),
+            crate::teensy::mcu_config::get_teensy_config_for_mcu("imxrt1062").unwrap(),
+            BuildProfile::Release,
+            Some(8126464),
+            Some(524288),
+            None,
+            false,
+        );
+        let args = linker.build_link_args(
+            &[],
+            &[],
+            &PathBuf::from("/build/firmware.elf"),
+            &LinkExtraArgs::default(),
+        );
+        assert!(
+            !args.iter().any(|a| a.starts_with("-larm_cortex")),
+            "no CMSIS-DSP -l flag should be appended when cmsis_dsp_lib is None. \
+             Args: {:?}",
+            args
+        );
     }
 }

--- a/crates/fbuild-config/assets/boards/json/teensy30.json
+++ b/crates/fbuild-config/assets/boards/json/teensy30.json
@@ -3,6 +3,7 @@
     "arduino": {
       "ldscript": "mk20dx128.ld"
     },
+    "cmsis_dsp_lib": "arm_cortexM4l_math",
     "core": "teensy3",
     "extra_flags": "-D__MK20DX128__ -DARDUINO_TEENSY30",
     "f_cpu": "48000000L",

--- a/crates/fbuild-config/assets/boards/json/teensy31.json
+++ b/crates/fbuild-config/assets/boards/json/teensy31.json
@@ -3,6 +3,7 @@
     "arduino": {
       "ldscript": "mk20dx256.ld"
     },
+    "cmsis_dsp_lib": "arm_cortexM4l_math",
     "core": "teensy3",
     "extra_flags": "-D__MK20DX256__ -DARDUINO_TEENSY31",
     "f_cpu": "72000000L",

--- a/crates/fbuild-config/assets/boards/json/teensy35.json
+++ b/crates/fbuild-config/assets/boards/json/teensy35.json
@@ -3,6 +3,7 @@
     "arduino": {
       "ldscript": "mk64fx512.ld"
     },
+    "cmsis_dsp_lib": "arm_cortexM4lf_math",
     "core": "teensy3",
     "extra_flags": "-D__MK64FX512__ -DARDUINO_TEENSY35",
     "f_cpu": "120000000L",

--- a/crates/fbuild-config/assets/boards/json/teensy36.json
+++ b/crates/fbuild-config/assets/boards/json/teensy36.json
@@ -3,6 +3,7 @@
     "arduino": {
       "ldscript": "mk66fx1m0.ld"
     },
+    "cmsis_dsp_lib": "arm_cortexM4lf_math",
     "core": "teensy3",
     "extra_flags": "-D__MK66FX1M0__ -DARDUINO_TEENSY36",
     "f_cpu": "180000000L",

--- a/crates/fbuild-config/assets/boards/json/teensy40.json
+++ b/crates/fbuild-config/assets/boards/json/teensy40.json
@@ -3,6 +3,7 @@
     "arduino": {
       "ldscript": "imxrt1062.ld"
     },
+    "cmsis_dsp_lib": "arm_cortexM7lfsp_math",
     "core": "teensy4",
     "extra_flags": "-D__IMXRT1062__ -DARDUINO_TEENSY40",
     "f_cpu": "600000000",

--- a/crates/fbuild-config/assets/boards/json/teensy41.json
+++ b/crates/fbuild-config/assets/boards/json/teensy41.json
@@ -3,6 +3,7 @@
     "arduino": {
       "ldscript": "imxrt1062_t41.ld"
     },
+    "cmsis_dsp_lib": "arm_cortexM7lfsp_math",
     "core": "teensy4",
     "extra_flags": "-D__IMXRT1062__ -DARDUINO_TEENSY41",
     "f_cpu": "600000000",

--- a/crates/fbuild-config/assets/boards/json/teensylc.json
+++ b/crates/fbuild-config/assets/boards/json/teensylc.json
@@ -3,6 +3,7 @@
     "arduino": {
       "ldscript": "mkl26z64.ld"
     },
+    "cmsis_dsp_lib": "arm_cortexM0l_math",
     "core": "teensy3",
     "extra_flags": "-D__MKL26Z64__ -DARDUINO_TEENSYLC",
     "f_cpu": "48000000L",

--- a/crates/fbuild-config/assets/boards/json/teensymm.json
+++ b/crates/fbuild-config/assets/boards/json/teensymm.json
@@ -3,6 +3,7 @@
     "arduino": {
       "ldscript": "imxrt1062_mm.ld"
     },
+    "cmsis_dsp_lib": "arm_cortexM7lfsp_math",
     "core": "teensy4",
     "extra_flags": "-D__IMXRT1062__ -DARDUINO_TEENSY_MICROMOD",
     "f_cpu": "600000000",

--- a/crates/fbuild-config/src/board/db.rs
+++ b/crates/fbuild-config/src/board/db.rs
@@ -178,6 +178,9 @@ pub(super) fn get_board_defaults(board_id: &str) -> Option<HashMap<String, Strin
         if let Some(f_image) = build.get("f_image").and_then(|v| v.as_str()) {
             d.insert("f_image".into(), f_image.to_string());
         }
+        if let Some(cmsis_dsp_lib) = build.get("cmsis_dsp_lib").and_then(|v| v.as_str()) {
+            d.insert("cmsis_dsp_lib".into(), cmsis_dsp_lib.to_string());
+        }
         // Arduino sub-fields
         if let Some(arduino) = build.get("arduino").and_then(|v| v.as_object()) {
             if let Some(ldscript) = arduino.get("ldscript").and_then(|v| v.as_str()) {

--- a/crates/fbuild-config/src/board/loaders.rs
+++ b/crates/fbuild-config/src/board/loaders.rs
@@ -107,6 +107,7 @@ impl BoardConfig {
             partitions: get("partitions"),
             ldscript: get("ldscript"),
             platform_str: get("platform_str"),
+            cmsis_dsp_lib: get("cmsis_dsp_lib"),
             debug_tools: None, // boards.txt format does not contain debug metadata
         })
     }
@@ -231,6 +232,10 @@ impl BoardConfig {
                 .cloned()
                 .or_else(|| defaults.get("ldscript").cloned()),
             platform_str: defaults.get("platform_str").cloned(),
+            cmsis_dsp_lib: overrides
+                .get("cmsis_dsp_lib")
+                .cloned()
+                .or_else(|| defaults.get("cmsis_dsp_lib").cloned()),
             debug_tools: get_board_debug_tools(board_id),
         })
     }

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -289,6 +289,79 @@ fn test_teensy41_core_teensy4() {
     assert_eq!(config.upload_protocol, Some("teensy-gui".to_string()));
 }
 
+/// Regression for FastLED/fbuild#300: every ARM-based Teensy board must
+/// declare its Teensyduino-bundled CMSIS-DSP math library via
+/// `build.cmsis_dsp_lib` so the linker can auto-link it (mirroring
+/// PlatformIO+Teensyduino's SCons behaviour). Without this, FastLED's
+/// `Ports/PJRCSpectrumAnalyzer` example and any sketch using `Audio.h`
+/// FFT classes fails with `undefined reference to arm_cfft_radix4_q15`.
+#[test]
+fn test_teensy_boards_declare_cmsis_dsp_lib() {
+    let cases: &[(&str, &str)] = &[
+        ("teensy30", "arm_cortexM4l_math"),
+        ("teensy31", "arm_cortexM4l_math"),
+        ("teensy35", "arm_cortexM4lf_math"),
+        ("teensy36", "arm_cortexM4lf_math"),
+        ("teensy40", "arm_cortexM7lfsp_math"),
+        ("teensy41", "arm_cortexM7lfsp_math"),
+        ("teensymm", "arm_cortexM7lfsp_math"),
+        ("teensylc", "arm_cortexM0l_math"),
+    ];
+    for (board_id, expected) in cases {
+        let config = BoardConfig::from_board_id(board_id, &HashMap::new()).unwrap();
+        assert_eq!(
+            config.cmsis_dsp_lib.as_deref(),
+            Some(*expected),
+            "{} should declare cmsis_dsp_lib={} (see fbuild#300)",
+            board_id,
+            expected
+        );
+    }
+}
+
+/// AVR-based Teensy 2.0 / Teensy++ 2.0 ship with the avr-libc math lib but
+/// no CMSIS-DSP — they're not Cortex-M parts. Their JSONs omit the field.
+#[test]
+fn test_teensy_avr_boards_no_cmsis_dsp_lib() {
+    for board_id in ["teensy2", "teensy2pp"] {
+        let config = BoardConfig::from_board_id(board_id, &HashMap::new()).unwrap();
+        assert_eq!(
+            config.cmsis_dsp_lib, None,
+            "{} is AVR-based and must not declare a CMSIS-DSP lib",
+            board_id
+        );
+    }
+}
+
+/// Non-Teensy boards must not have a CMSIS-DSP lib populated.
+#[test]
+fn test_non_teensy_boards_have_no_cmsis_dsp_lib() {
+    for board_id in ["uno", "mega", "esp32dev", "rpipico"] {
+        let config = BoardConfig::from_board_id(board_id, &HashMap::new()).unwrap();
+        assert_eq!(
+            config.cmsis_dsp_lib, None,
+            "{} should not declare a cmsis_dsp_lib",
+            board_id
+        );
+    }
+}
+
+/// Overrides (e.g. from `[env]` `board_build.cmsis_dsp_lib = ...`) should
+/// win over the bundled JSON value.
+#[test]
+fn test_cmsis_dsp_lib_override_wins() {
+    let mut overrides = HashMap::new();
+    overrides.insert(
+        "cmsis_dsp_lib".to_string(),
+        "arm_cortexM4lf_math_custom".to_string(),
+    );
+    let config = BoardConfig::from_board_id("teensy36", &overrides).unwrap();
+    assert_eq!(
+        config.cmsis_dsp_lib,
+        Some("arm_cortexM4lf_math_custom".to_string())
+    );
+}
+
 #[test]
 fn test_esp32dev_enriched_fields() {
     let config = BoardConfig::from_board_id("esp32dev", &HashMap::new()).unwrap();
@@ -328,8 +401,7 @@ fn test_nrf52840_dk_carries_arduino_macro() {
 #[test]
 fn test_nrf52840_dk_adafruit_carries_arduino_macro() {
     // Same fbuild#298 root cause — used by FastLED's `supermini_nrf52840` board.
-    let config =
-        BoardConfig::from_board_id("nrf52840_dk_adafruit", &HashMap::new()).unwrap();
+    let config = BoardConfig::from_board_id("nrf52840_dk_adafruit", &HashMap::new()).unwrap();
     let defines = config.get_defines();
     assert_eq!(
         defines.get("ARDUINO_NRF52840_PCA10056"),
@@ -340,11 +412,8 @@ fn test_nrf52840_dk_adafruit_carries_arduino_macro() {
 
 #[test]
 fn test_adafruit_feather_nrf52840_sense_carries_arduino_macro() {
-    let config = BoardConfig::from_board_id(
-        "adafruit_feather_nrf52840_sense",
-        &HashMap::new(),
-    )
-    .unwrap();
+    let config =
+        BoardConfig::from_board_id("adafruit_feather_nrf52840_sense", &HashMap::new()).unwrap();
     let defines = config.get_defines();
     assert_eq!(
         defines.get("ARDUINO_NRF52840_FEATHER_SENSE"),
@@ -365,8 +434,7 @@ fn test_pico_enriched_fields() {
 fn test_sparkfun_xrp_controller_board_config() {
     // SparkFun XRP Controller (RP2350B); maxgerhardt/platform-raspberrypi.
     // Regression for FastLED `rp2350B SparkfunXRP` workflow (#295).
-    let config =
-        BoardConfig::from_board_id("sparkfun_xrp_controller", &HashMap::new()).unwrap();
+    let config = BoardConfig::from_board_id("sparkfun_xrp_controller", &HashMap::new()).unwrap();
     assert_eq!(config.mcu, "rp2350");
     assert_eq!(config.core, "earlephilhower");
     assert_eq!(config.variant, "sparkfun_xrp_controller");
@@ -558,8 +626,7 @@ fn test_xiaoble_adafruit_board_config() {
 fn test_xiaoblesense_adafruit_board_config() {
     // Seeed XIAO BLE Sense (nRF52840 + IMU/mic).
     // Regression for FastLED `adafruit_xiaoblesense` workflow (#293).
-    let config =
-        BoardConfig::from_board_id("xiaoblesense_adafruit", &HashMap::new()).unwrap();
+    let config = BoardConfig::from_board_id("xiaoblesense_adafruit", &HashMap::new()).unwrap();
     assert_eq!(config.mcu, "nrf52840");
     assert_eq!(config.core, "nRF5");
     assert_eq!(config.variant, "Seeed_XIAO_nRF52840_Sense");

--- a/crates/fbuild-config/src/board/types.rs
+++ b/crates/fbuild-config/src/board/types.rs
@@ -83,6 +83,19 @@ pub struct BoardConfig {
     pub ldscript: Option<String>,
     /// Platform string from board JSON (e.g. "atmelmegaavr", "atmelavr")
     pub platform_str: Option<String>,
+    /// Bare CMSIS-DSP math library name to auto-link, without the leading `lib`
+    /// and `.a` (e.g. `arm_cortexM4lf_math`, `arm_cortexM7lfsp_math`).
+    ///
+    /// Populated from board JSON `build.cmsis_dsp_lib`. Mirrors the behaviour
+    /// of PlatformIO+Teensyduino's SCons builder, which auto-appends the right
+    /// CMSIS-DSP archive to the link command based on MCU so that Teensy
+    /// `Audio.h` FFT classes (and anything else referencing `arm_cfft_*`)
+    /// resolve at link time. The library ships inside the Teensyduino
+    /// toolchain (`framework-arduinoteensy.../cores/teensy*/`), which the
+    /// Teensy linker already adds to the library search path via `-L`.
+    /// See FastLED/fbuild#300.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmsis_dsp_lib: Option<String>,
     /// Debug tools from board JSON `debug.tools` section.
     /// Maps tool name (e.g. "simavr", "qemu", "renode") to its metadata.
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
Data-driven CMSIS-DSP auto-link for Teensy 3.x / 4.x / LC / MM, mirroring PlatformIO+Teensyduino's per-MCU matrix. Adds optional `build.cmsis_dsp_lib` field to the board JSON schema, surfaces it as `BoardConfig.cmsis_dsp_lib`, and has `TeensyLinker` append `-l<lib>` after `mcu_config.linker_libs`. Resolves via the existing `-L<core_dir>` so the Teensyduino-bundled `libarm_cortex*_math.a` is found without extra downloads.

| MCU | Library | Boards |
|---|---|---|
| MK20DX128/256 | `arm_cortexM4l_math` | teensy30, teensy31 |
| MK64FX512, MK66FX1M0 | `arm_cortexM4lf_math` | teensy35, teensy36 |
| MKL26Z64 | `arm_cortexM0l_math` | teensylc |
| IMXRT1062 | `arm_cortexM7lfsp_math` | teensy40, teensy41, teensymm |

Unblocks FastLED's `Ports/PJRCSpectrumAnalyzer` example on Teensy 3.x/4.x.

Closes #300.

## Test plan
- [x] 4 new BoardConfig tests (ARM Teensy boards, AVR Teensy 2.x absence, non-Teensy absence, override precedence)
- [x] 3 new TeensyLinker tests (link-command includes/omits the lib; field round-trip)
- [x] `teensy_boards_carry_cmsis_dsp_lib` data-driven test asserts every ARM Teensy board's JSON value
- [x] `soldr cargo check/clippy --workspace --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps` clean
- [x] Full workspace `./test` — no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)