### PR TITLE
fix(pipeline): absolutize project_dir to fix relative-path include doubling

### DIFF
--- a/crates/fbuild-build/src/compiler.rs
+++ b/crates/fbuild-build/src/compiler.rs
@@ -303,7 +303,7 @@ fn command_hash_path(object: &Path) -> PathBuf {
 /// enforced by `clippy.toml` (1.75). Does not canonicalize symlinks or `..`.
 /// Falls back to the original path if `current_dir()` fails (e.g. cwd was
 /// deleted) — callers should treat that as the path they originally got.
-fn absolute_from_cwd(path: &Path) -> PathBuf {
+pub fn absolute_from_cwd(path: &Path) -> PathBuf {
     if path.is_absolute() {
         path.to_path_buf()
     } else {

--- a/crates/fbuild-build/src/pipeline/project_discovery.rs
+++ b/crates/fbuild-build/src/pipeline/project_discovery.rs
@@ -6,7 +6,21 @@ use std::path::{Path, PathBuf};
 /// Add the project's `include/` directory and `lib/` subdirectories to include paths.
 ///
 /// PlatformIO automatically adds these — replicate that behavior.
+///
+/// All emitted paths are absolute. When `project_dir` is relative, it is first
+/// resolved against the current working directory (see `absolute_from_cwd`).
+/// This is load-bearing for the compiler step: the zccache path normalizer
+/// (`zccache::path_arg_for_compile_cwd`) only strips the compile-cwd prefix
+/// from *absolute* include paths and passes relative ones through unchanged.
+/// Compiles run with `cwd = <project>/`, so a relative include like
+/// `.build/pio/esp32dev/lib/FastLED` would be re-resolved against the
+/// already-project-rooted cwd and yield a doubled path that GCC then fails to
+/// open (`fatal error: FastLED.h: No such file or directory`). Promoting
+/// `project_dir` to absolute up front keeps the include paths stable through
+/// the normalize→exec chain. See FastLED/fbuild#303.
 pub fn discover_project_includes(project_dir: &Path, include_dirs: &mut Vec<PathBuf>) {
+    let project_dir = crate::compiler::absolute_from_cwd(project_dir);
+
     // PlatformIO automatically includes the project's include/ directory
     let include_dir = project_dir.join("include");
     if include_dir.is_dir() {
@@ -67,4 +81,74 @@ pub fn is_platform_project(
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// FastLED/fbuild#303: every emitted include dir must be absolute, even
+    /// when `project_dir` is passed in relative form (which is what
+    /// `fbuild test-emu .build/pio/<env>` produces). A relative include path
+    /// survives `zccache::path_arg_for_compile_cwd` unchanged and then gets
+    /// re-resolved against `cwd = <project>/`, producing a doubled-prefix
+    /// non-existent path. Promoting to absolute up front breaks the cycle.
+    #[test]
+    fn includes_are_absolute_for_absolute_project_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        std::fs::create_dir_all(project.join("lib").join("FastLED")).unwrap();
+        std::fs::write(project.join("lib").join("FastLED").join("FastLED.h"), b"").unwrap();
+        std::fs::create_dir_all(project.join("include")).unwrap();
+
+        let mut dirs = Vec::new();
+        discover_project_includes(project, &mut dirs);
+
+        assert!(!dirs.is_empty(), "should discover include + lib paths");
+        for d in &dirs {
+            assert!(
+                d.is_absolute(),
+                "include dir must be absolute, got: {}",
+                d.display()
+            );
+        }
+        // The lib's root must be in the list — that's where FastLED.h lives.
+        assert!(
+            dirs.iter().any(|d| d.ends_with("FastLED")),
+            "lib/FastLED root missing from {:?}",
+            dirs
+        );
+    }
+
+    /// Same property, but with a relative `project_dir` — mirrors what the
+    /// daemon receives from `fbuild test-emu .build/pio/esp32dev` (the
+    /// `PathBuf` is built directly from the request string and never
+    /// canonicalized in the handler).
+    #[test]
+    fn includes_are_absolute_for_relative_project_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        std::fs::create_dir_all(project.join("lib").join("FastLED")).unwrap();
+
+        // Build a relative path against the current process cwd that points
+        // at our tempdir. If the tempdir isn't under cwd (varies by platform
+        // and TMPDIR), fall back to the absolute path — the absolutization
+        // invariant must still hold either way.
+        let cwd = std::env::current_dir().unwrap();
+        let relative = match project.strip_prefix(&cwd) {
+            Ok(rel) => PathBuf::from(".").join(rel),
+            Err(_) => project.to_path_buf(),
+        };
+
+        let mut dirs = Vec::new();
+        discover_project_includes(&relative, &mut dirs);
+
+        for d in &dirs {
+            assert!(
+                d.is_absolute(),
+                "include dir must be absolute even when project_dir is relative; got: {}",
+                d.display()
+            );
+        }
+    }
 }


### PR DESCRIPTION
﻿## Summary

`fbuild test-emu .build/pio/<env>` was failing every ESP32 QEMU CI run with `fatal error: FastLED.h: No such file or directory` even though the preceding `ci-compile.py` step had just produced a working firmware in the same project directory.

Issue described in #303.

## Root cause

The CLI passes the project-dir argument through verbatim to the daemon, which builds a `PathBuf` from the string and hands it to the orchestrator unchanged. Whether the path is absolute or relative depends entirely on what the user typed.

- `ci-compile.py` invokes fbuild with an **absolute** project dir (workspace-rooted). `discover_project_includes` produces absolute include flags. `zccache::path_arg_for_compile_cwd` strips the compile-cwd prefix, leaving project-relative include flags that GCC resolves correctly against `cwd = <project>/`.
- `fbuild test-emu .build/pio/<env>` (the CI form) sends a **relative** path. `discover_project_includes` joins it as-is, producing relative include paths like `-I.build/pio/esp32dev/lib/FastLED`. `zccache::path_arg_for_compile_cwd` short-circuits on non-absolute inputs (`if !path.is_absolute() { return path.to_string_lossy().to_string(); }`) and passes them through unchanged. GCC then resolves the already-relative include path against the project-rooted compile cwd, producing the doubled prefix `<project>/.build/pio/esp32dev/lib/FastLED` -- which doesn't exist -- and `FastLED.h` is reported missing.

The bug had nothing to do with lib-discovery logic (the original hypothesis in #303). `discover_project_includes` already implements PlatformIO's `lib/<Name>/src/` auto-discovery correctly. The output of that discovery was just spelled in a form that survived too far through the compile-cwd plumbing.

## Fix

`discover_project_includes` now calls `absolute_from_cwd(project_dir)` at the top, making every emitted include dir absolute regardless of how the caller spelled the input. The normalize-then-exec chain then behaves identically for absolute and relative call sites.

`absolute_from_cwd` already existed in `compiler.rs` as `pub fn absolute_from_cwd(path: &Path) -> PathBuf` (used for source and output paths in `compile_source` to fix the analogous #282 bug). Promoted from private to `pub` for cross-module use.

## Why this is the right layer

Three places could host the fix; pipeline-level is the smallest blast radius:

1. **Daemon handlers** (`build`, `test_emu`, `deploy`): would have to canonicalize on every handler; easy to miss new entry points.
2. **`zccache::path_arg_for_compile_cwd`**: would have to look up `current_dir()` for every relative path; couples the helper to process state.
3. **`discover_project_includes`** (chosen): one call, single responsibility (emit absolute include paths), already documents that callers should not depend on relativeness.

## Test plan

- [x] `cargo test --lib -p fbuild-build pipeline::project_discovery` -- 2/2 new regression tests passing
- [x] `cargo test --lib -p fbuild-build` -- 546/546 passing
- [ ] CI: `qemu_esp32dev_test`, `qemu_esp32s3_test`, `qemu_esp32c3_test` should turn green once a release of fbuild ships and FastLED bumps its pin.

Fixes #303

Generated with Claude Code (https://claude.com/claude-code)
