### PR TITLE
fix(teensy): derive map_path from elf_path (unbreak main CI)

### DIFF
--- a/crates/fbuild-build/src/teensy/teensy_linker.rs
+++ b/crates/fbuild-build/src/teensy/teensy_linker.rs
@@ -90,7 +90,7 @@ impl TeensyLinker {
         args.extend(["-o".to_string(), elf_path.to_string_lossy().to_string()]);
 
         // Always emit a linker map next to firmware.elf for debugging (#305).
-        let map_path = output_dir.join("firmware.map");
+        let map_path = elf_path.with_extension("map");
         args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
 
         // Sketch objects first
@@ -321,6 +321,37 @@ mod tests {
         assert!(
             args.iter().any(|a| a == "-L/teensy3"),
             "expected -L/teensy3 for library search, got {:?}",
+            args
+        );
+    }
+
+    /// Regression test: `build_link_args` always emits `-Wl,-Map=` next to
+    /// the elf path so debug builds can inspect link decisions. Reverted
+    /// previously by an out-of-scope `output_dir` reference (see #313 hotfix).
+    #[test]
+    fn test_teensy_link_command_emits_linker_map_next_to_elf() {
+        let linker = TeensyLinker::new(
+            PathBuf::from("/bin/arm-none-eabi-gcc"),
+            PathBuf::from("/bin/arm-none-eabi-ar"),
+            PathBuf::from("/bin/arm-none-eabi-objcopy"),
+            PathBuf::from("/bin/arm-none-eabi-size"),
+            LinkerScripts::single(PathBuf::from("/teensy4"), "imxrt1062_t41.ld"),
+            crate::teensy::mcu_config::get_teensy_config_for_mcu("imxrt1062").unwrap(),
+            BuildProfile::Release,
+            Some(8126464),
+            Some(524288),
+            None,
+            false,
+        );
+        let args = linker.build_link_args(
+            &[],
+            &[],
+            &PathBuf::from("/build/firmware.elf"),
+            &LinkExtraArgs::default(),
+        );
+        assert!(
+            args.iter().any(|a| a == "-Wl,-Map=/build/firmware.map"),
+            "expected -Wl,-Map=/build/firmware.map next to firmware.elf. Args: {:?}",
             args
         );
     }


### PR DESCRIPTION
## Summary

`build_link_args` (added by #313) inherited a hold-over from #305 that referenced `output_dir.join(\"firmware.map\")` — but `output_dir` isn't a parameter of `build_link_args`; it takes `elf_path: &Path`. The workspace stopped compiling on every PR built against main since #313 landed:

```
error[E0425]: cannot find value \`output_dir\` in this scope
  --> crates/fbuild-build/src/teensy/teensy_linker.rs:93:24
```

Every open PR (#306, #307, #315, …) is red because of this. Hotfix first so the other PRs can get green CI.

## Fix

Derive the map path from \`elf_path.with_extension(\"map\")\`, which is equivalent to \`output_dir.join(\"firmware.map\")\` since \`elf_path = output_dir.join(\"firmware.elf\")\` at the only call site. One-line change.

Adds \`test_teensy_link_command_emits_linker_map_next_to_elf\` to catch this if anyone factors the path source again.

## Test plan

- [x] \`soldr cargo check -p fbuild-build\` — clean
- [x] \`soldr cargo test -p fbuild-build --lib teensy::teensy_linker\` — 6/6 pass (5 existing + 1 new)
- [x] \`soldr cargo clippy -p fbuild-build --all-targets -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)