### PR TITLE
fix(lint): annotate Python daemon Command::new sites

### DIFF
--- a/crates/fbuild-python/src/daemon.rs
+++ b/crates/fbuild-python/src/daemon.rs
@@ -93,7 +93,9 @@ impl Daemon {
         // (FastLED/fbuild#275) so a venv install never gets shadowed by a
         // stale user-level daemon on PATH.
         let mut cmd = match daemon_spawn_target() {
+            // allow-direct-spawn: daemon must outlive the Python interpreter.
             Some(path) => std::process::Command::new(path),
+            // allow-direct-spawn: daemon must outlive the Python interpreter.
             None => std::process::Command::new(DAEMON_BIN_NAME),
         };
         if fbuild_paths::is_dev_mode() {
@@ -244,7 +246,9 @@ impl AsyncDaemon {
             // from inside this async block.
             // allow-direct-spawn: daemon must outlive the Python interpreter.
             let mut cmd = match spawn_target {
+                // allow-direct-spawn: daemon must outlive the Python interpreter.
                 Some(path) => std::process::Command::new(path),
+                // allow-direct-spawn: daemon must outlive the Python interpreter.
                 None => std::process::Command::new(DAEMON_BIN_NAME),
             };
             if dev_mode {


### PR DESCRIPTION
﻿## Summary

After commit `f86817a9` (refactor `lib.rs` -> submodules) the four `std::process::Command::new` sites in `crates/fbuild-python/src/daemon.rs` ended up inside `match` arms two lines below their `// allow-direct-spawn:` comment. The detector in `ci/find_direct_subprocess.py` only checks "same line or the line immediately above", so the annotation no longer covered the actual call sites and CI started reporting:

```
NEW direct spawns without an `allow-direct-spawn: <reason>` marker:
  crates/fbuild-python/src/daemon.rs:96
  crates/fbuild-python/src/daemon.rs:97
  crates/fbuild-python/src/daemon.rs:247
  crates/fbuild-python/src/daemon.rs:248
```

This blocks every PR's `Lint subprocess spawns` check — including #306 (the actual FastLED-vs-PIO size regression for fbuild#304).

## Fix

Add an inline `// allow-direct-spawn: daemon must outlive the Python interpreter.` annotation immediately above each of the four `match`-arm `Command::new` calls. Behavior unchanged.

## Verification

```
uv run python ci/find_direct_subprocess.py --fail
# Direct Command::new sites: 29
#   to migrate: 0
#   allowlisted: 29
```

Down from `to migrate: 4` on main. Once this lands, PR #306's `Lint subprocess spawns` should turn green.
