### PR TITLE
fix(boards): catch up tinyuf2 partition rename + whitelist cmsis_dsp_lib (clears 27/39 drift)

### DIFF
--- a/ci/validate_boards.py
+++ b/ci/validate_boards.py
@@ -27,6 +27,20 @@ from pathlib import Path
 # Must match enrich_boards.rs exactly
 BUILD_FIELDS = ("core", "variant", "extra_flags", "f_cpu", "f_flash", "f_image", "flash_mode", "mcu")
 ARDUINO_FIELDS = ("ldscript", "partitions", "memory_type")
+
+# Intentional fbuild-only extensions to the board schema that PlatformIO does
+# not carry upstream. Stripped from the actual side before diffing so they
+# aren't reported as drift. Keep this list short and document why each entry
+# is here — every addition is a place where fbuild semantically extends PIO.
+FBUILD_EXTENSION_BUILD_FIELDS = frozenset(
+    {
+        # Teensy 3.x/4.x CMSIS-DSP per-MCU library name (FastLED/fbuild#300).
+        # PlatformIO leaves this implicit and lets Teensyduino's makefile pick
+        # the matching `-l...` flag; fbuild needs it declared so the linker can
+        # auto-link the right `arm_cortexM*_math` archive.
+        "cmsis_dsp_lib",
+    }
+)
 UPLOAD_FIELDS = (
     "protocol",
     "speed",
@@ -208,6 +222,10 @@ def validate_board(board_path: Path, pio_dir: Path) -> list[str] | None:
     if isinstance(pio_build, dict):
         expected_build = extract_build(pio_build)
         actual_build = board.get("build", {})
+        # Strip intentional fbuild-only extensions from the actual side so
+        # they aren't reported as drift (see FBUILD_EXTENSION_BUILD_FIELDS).
+        if isinstance(actual_build, dict) and any(k in actual_build for k in FBUILD_EXTENSION_BUILD_FIELDS):
+            actual_build = {k: v for k, v in actual_build.items() if k not in FBUILD_EXTENSION_BUILD_FIELDS}
         if expected_build and expected_build != actual_build:
             diffs.extend(diff_dicts(expected_build, actual_build, "build"))
 
@@ -268,13 +286,7 @@ def run_external_comparison(output_json: bool = False) -> int:
             "external_board_count": total_external,
             "missing_count": total_missing,
             "errors": [{"source": r.source_id, "error": r.error} for r in errors],
-            "missing_by_source": {
-                src: [
-                    {"name": b.name, "architecture": b.architecture, "vendor": b.vendor}
-                    for b in boards
-                ]
-                for src, boards in sorted(missing.items())
-            },
+            "missing_by_source": {src: [{"name": b.name, "architecture": b.architecture, "vendor": b.vendor} for b in boards] for src, boards in sorted(missing.items())},
         }
         print(json.dumps(out, indent=2))
     else:

--- a/crates/fbuild-config/assets/boards/json/4d_systems_esp32s3_gen4_r8n16.json
+++ b/crates/fbuild-config/assets/boards/json/4d_systems_esp32s3_gen4_r8n16.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi",
-      "partitions": "esp_sr_16.csv"
+      "partitions": "default_16MB.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_S3R8N16 -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s2.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s2.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s2_out.ld",
       "memory_type": "qio_qspi",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_FEATHER_ESP32S2 -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s2_reversetft.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s2_reversetft.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_FEATHER_ESP32S2_REVTFT -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s2_tft.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s2_tft.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s2_out.ld",
       "memory_type": "qio_qspi",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_FEATHER_ESP32S2_TFT -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s3.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s3.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s3_out.ld",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_FEATHER_ESP32S3 -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1 -DBOARD_HAS_PSRAM",

--- a/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s3_nopsram.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s3_nopsram.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_qspi",
-      "partitions": "tinyuf2-partitions-8MB.csv"
+      "partitions": "partitions-8MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_FEATHER_ESP32S3_NOPSRAM -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s3_reversetft.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s3_reversetft.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_qspi",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_FEATHER_ESP32S3_REVTFT -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1 -DBOARD_HAS_PSRAM",

--- a/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s3_tft.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_feather_esp32s3_tft.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_qspi",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_FEATHER_ESP32S3_TFT -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1 -DBOARD_HAS_PSRAM",

--- a/crates/fbuild-config/assets/boards/json/adafruit_funhouse_esp32s2.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_funhouse_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_FUNHOUSE_ESP32S2 -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_magtag29_esp32s2.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_magtag29_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_MAGTAG29_ESP32S2 -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_matrixportal_esp32s3.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_matrixportal_esp32s3.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_qspi",
-      "partitions": "tinyuf2-partitions-8MB.csv"
+      "partitions": "partitions-8MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_MATRIXPORTAL_ESP32S3 -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1 -DBOARD_HAS_PSRAM",

--- a/crates/fbuild-config/assets/boards/json/adafruit_metro_esp32s2.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_metro_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_METRO_ESP32S2 -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_metro_esp32s3.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_metro_esp32s3.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi",
-      "partitions": "tinyuf2-partitions-16MB.csv"
+      "partitions": "partitions-16MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_METRO_ESP32S3 -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1 -DBOARD_HAS_PSRAM",

--- a/crates/fbuild-config/assets/boards/json/adafruit_qtpy_esp32s2.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_qtpy_esp32s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_QTPY_ESP32S2 -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_qtpy_esp32s3_n4r2.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_qtpy_esp32s3_n4r2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s3_out.ld",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2 -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1 -DBOARD_HAS_PSRAM",

--- a/crates/fbuild-config/assets/boards/json/adafruit_qtpy_esp32s3_nopsram.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_qtpy_esp32s3_nopsram.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s3_out.ld",
-      "partitions": "tinyuf2-partitions-8MB.csv"
+      "partitions": "partitions-8MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1",

--- a/crates/fbuild-config/assets/boards/json/adafruit_qualia_s3_rgb666.json
+++ b/crates/fbuild-config/assets/boards/json/adafruit_qualia_s3_rgb666.json
@@ -3,7 +3,7 @@
     "arduino": {
       "ldscript": "esp32s3_out.ld",
       "memory_type": "qio_opi",
-      "partitions": "tinyuf2-partitions-16MB.csv"
+      "partitions": "partitions-16MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_QUALIA_S3_RGB666 -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1 -DBOARD_HAS_PSRAM",

--- a/crates/fbuild-config/assets/boards/json/featheresp32-s2.json
+++ b/crates/fbuild-config/assets/boards/json/featheresp32-s2.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "ldscript": "esp32s2_out.ld",
-      "partitions": "tinyuf2-partitions-4MB.csv"
+      "partitions": "partitions-4MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ADAFRUIT_FEATHER_ESP32S2_NOPSRAM -DARDUINO_USB_CDC_ON_BOOT=1",

--- a/crates/fbuild-config/assets/boards/json/wt32-sc01-plus.json
+++ b/crates/fbuild-config/assets/boards/json/wt32-sc01-plus.json
@@ -2,7 +2,7 @@
   "build": {
     "arduino": {
       "memory_type": "qio_qspi",
-      "partitions": "tinyuf2-partitions-16MB.csv"
+      "partitions": "partitions-16MB-tinyuf2.csv"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_WT32_SC01_PLUS -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_RUNNING_CORE=1 -DARDUINO_EVENT_RUNNING_CORE=1",

--- a/crates/fbuild-python/src/daemon.rs
+++ b/crates/fbuild-python/src/daemon.rs
@@ -93,7 +93,9 @@ impl Daemon {
         // (FastLED/fbuild#275) so a venv install never gets shadowed by a
         // stale user-level daemon on PATH.
         let mut cmd = match daemon_spawn_target() {
+            // allow-direct-spawn: daemon must outlive the Python interpreter.
             Some(path) => std::process::Command::new(path),
+            // allow-direct-spawn: daemon must outlive the Python interpreter.
             None => std::process::Command::new(DAEMON_BIN_NAME),
         };
         if fbuild_paths::is_dev_mode() {
@@ -244,7 +246,9 @@ impl AsyncDaemon {
             // from inside this async block.
             // allow-direct-spawn: daemon must outlive the Python interpreter.
             let mut cmd = match spawn_target {
+                // allow-direct-spawn: daemon must outlive the Python interpreter.
                 Some(path) => std::process::Command::new(path),
+                // allow-direct-spawn: daemon must outlive the Python interpreter.
                 None => std::process::Command::new(DAEMON_BIN_NAME),
             };
             if dev_mode {


### PR DESCRIPTION
﻿## Summary

`Validate Board Definitions` workflow has been failing with **39 boards drifted from PlatformIO**. The two largest categories are pure schema drift that this PR resolves; the remaining ~14 are configuration-choice differences that need maintainer review.

## Fixed in this PR

### 1. tinyuf2 partition CSV rename (18 boards)

Upstream Adafruit / the espressif32 platform's Adafruit board defs renamed `tinyuf2-partitions-<size>.csv` → `partitions-<size>-tinyuf2.csv`. Our bundled board JSONs still pointed to the old name.

Renamed in:
- `adafruit_feather_esp32s2{,_reversetft,_tft}`
- `adafruit_feather_esp32s3{,_nopsram,_reversetft,_tft}`
- `adafruit_funhouse_esp32s2`
- `adafruit_magtag29_esp32s2`
- `adafruit_matrixportal_esp32s3`
- `adafruit_metro_esp32s2`, `adafruit_metro_esp32s3`
- `adafruit_qtpy_esp32s2`
- `adafruit_qtpy_esp32s3_n4r2`, `adafruit_qtpy_esp32s3_nopsram`
- `adafruit_qualia_s3_rgb666`
- `featheresp32-s2`
- `wt32-sc01-plus`

All swaps are mechanical `s/tinyuf2-partitions-<N>MB.csv/partitions-<N>MB-tinyuf2.csv/`.

### 2. 4d_systems_esp32s3_gen4_r8n16 partitions

`esp_sr_16.csv` → `default_16MB.csv` per upstream.

### 3. Validator whitelist for `cmsis_dsp_lib` (8 teensy boards)

`build.cmsis_dsp_lib` was added by fbuild#300 (PR #313) as an **intentional fbuild-only schema extension** — Teensyduino's makefile picks the matching `arm_cortexM*_math` archive at link time, but fbuild needs it declared statically. The validator was flagging all 8 teensy variants because `diff_dicts` treats every key present in the actual asset that's missing in the expected (PIO) side as drift.

Added `FBUILD_EXTENSION_BUILD_FIELDS` whitelist (currently just `cmsis_dsp_lib`) and strip those from the actual side before diffing. Documented in-place so future fbuild-only extensions have a place to land with a one-line note.

## Not in scope

Remaining ~14 boards have **configuration-choice drift** that needs a real decision:

- `arduino_nano_esp32`: `BOARD_HAS_PIN_REMAP` (upstream) vs `BOARD_USES_HW_GPIO_NUMBERS` (ours)
- `um_feathers3`, `um_nanos3`, `um_pros3`, `um_tinys3`: ours have `-DARDUINO_USB_MODE=1` extra
- `seeed_xiao_esp32c6`: `XIAO_ESP32C6` variant + USB defines + PID drift
- `m5stack_core` family: `m5stack_core` (ours) vs `m5stack_core_esp32` (upstream)
- `um_tinys2`: extra `memory_type` + `partitions`
- `labplus_mpython`, `lolin_s3_mini`: similar one-offs

Each requires a maintainer decision about which value is correct for fbuild's compile path — not auto-resolvable by a snapshot rebase. Leaving those for a separate sweep.

## Test plan

- [x] `ci/validate_boards.py` count after fix: down from 39 → ~14 (the configuration-choice drifts).
- [ ] CI `Validate Board Definitions` check: still RED (real drift remains) but the categories that are mechanical schema drift are cleared. A follow-up PR per maintainer review closes the rest.

Refs fbuild#300, fbuild#313.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Board validation process now correctly handles and excludes build-specific configuration extensions from drift detection.

* **Chores**
  * Updated partition scheme references for multiple supported boards including Adafruit Feather, Metro, and compatible variants to improve build consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->