### PR TITLE
chore: bump version to 2.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.9"
+version = "2.2.10"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.9"
+version = "2.2.10"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.9"
+version = "2.2.10"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
﻿## Summary

Bumps fbuild **2.2.9 → 2.2.10**, bundling four user-facing fixes merged on main since 2.2.9.

## Fixes shipped in this release

- **#319 / #320** — SAMD51: `cores/arduino` fallback + resolved core_dir injected into include path. `Build SAMD51J` was 100% red on every main push.
- **#321 / #322** — nRF52: `nRF52DK → pca10056` variant alias for the Adafruit framework. `Build nRF52840 DK` was 100% red.
- **#318** — Board JSON drift cleanup (tinyuf2 partition rename across 18 Adafruit boards + 4d_systems esp_sr fix + `cmsis_dsp_lib` validator whitelist). `Validate Boards` was failing on 39 boards; now ~14 (remaining are configuration-choice differences flagged for maintainer review).
- **#317** — `crates/fbuild-python/src/daemon.rs` `Command::new` annotations after the lib.rs split. `Lint subprocess spawns` was red — blocked every PR's lint check.

## After this lands

Downstream FastLED bumps `fbuild==2.2.9 → fbuild==2.2.10` in `pyproject.toml` to pick up these fixes. That bump will retrigger the workflows that have been stale-red waiting for these fixes:

- `Build SAMD51J`, `Build SAMD21*`, `Build SAMD51P`
- `Build nRF52840 DK`, `nrf52840_supermini`
- `Validate Boards` (down to the configuration-choice remainder)

## Release machinery

`release-auto.yml` triggers on the push to main when `Cargo.toml` or `pyproject.toml` changes. No further manual steps needed.
