### PR TITLE
chore: bump version to 2.2.11

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -327,3 +327,27 @@ jobs:
           packages-dir: dist
           attestations: true
           skip-existing: true
+
+      - name: Verify all wheels visible on PyPI
+        shell: bash
+        env:
+          PYPI_VERSION: ${{ needs.prepare.outputs.project_version }}
+        run: |
+          set -euo pipefail
+          expected=4
+          deadline=$(( $(date +%s) + 300 ))
+          while :; do
+            count="$(curl -fsSL "https://pypi.org/pypi/fbuild/${PYPI_VERSION}/json" \
+              | python -c 'import json,sys; print(len(json.load(sys.stdin).get("urls",[])))' 2>/dev/null \
+              || echo 0)"
+            echo "PyPI reports ${count}/${expected} files for fbuild ${PYPI_VERSION}"
+            if [ "$count" -ge "$expected" ]; then
+              echo "All wheels visible on PyPI"
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "Timed out waiting for ${expected} wheels on PyPI (saw ${count})" >&2
+              exit 1
+            fi
+            sleep 15
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.10"
+version = "2.2.11"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.10"
+version = "2.2.11"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.9"
+version = "2.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },


### PR DESCRIPTION
## Summary

- Bumps fbuild to 2.2.11
- Hardens `release-auto.yml` against the PyPI upload race that surfaced during 2.2.10

## Background

The 2.2.10 release-auto run succeeded — all four wheels (`win_amd64`, `manylinux_2_17_x86_64`, `manylinux_2_17_aarch64`, `macosx_11_0_arm64.macosx_10_12_x86_64`) reached PyPI by 22:52:23 UTC. But `pypa/gh-action-pypi-publish` uploads wheels sequentially, so between 22:52:16 and 22:52:23 PyPI served a partial wheel set. Any `uv sync` that resolved in that window cached a "missing wheels" failure for Windows + Linux x86_64 even though the wheels arrived seconds later.

## Fix

Added a post-publish polling step that queries `https://pypi.org/pypi/fbuild/<version>/json` and waits up to 5 minutes for all four wheels to be visible before the workflow returns success. Pattern is inspired by zccache's preflight `check-registries` step.

## Test plan

- [ ] PR merges
- [ ] release-auto run is green end-to-end
- [ ] `pip install fbuild==2.2.11` succeeds on Windows, Linux x86_64, Linux aarch64, macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.2.11 across all project configuration files and package manifests
  * Release automation enhanced with pre-publication verification procedures that validate all distribution packages are properly indexed and available on the package repository before final publication, ensuring improved reliability and consistency in release cycles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FastLED/fbuild/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->