### PR TITLE
fix(nrf52): emit alias-resolved variant include path + MCU-aware linker script alias

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -327,3 +327,27 @@ jobs:
           packages-dir: dist
           attestations: true
           skip-existing: true
+
+      - name: Verify all wheels visible on PyPI
+        shell: bash
+        env:
+          PYPI_VERSION: ${{ needs.prepare.outputs.project_version }}
+        run: |
+          set -euo pipefail
+          expected=4
+          deadline=$(( $(date +%s) + 300 ))
+          while :; do
+            count="$(curl -fsSL "https://pypi.org/pypi/fbuild/${PYPI_VERSION}/json" \
+              | python -c 'import json,sys; print(len(json.load(sys.stdin).get("urls",[])))' 2>/dev/null \
+              || echo 0)"
+            echo "PyPI reports ${count}/${expected} files for fbuild ${PYPI_VERSION}"
+            if [ "$count" -ge "$expected" ]; then
+              echo "All wheels visible on PyPI"
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "Timed out waiting for ${expected} wheels on PyPI (saw ${count})" >&2
+              exit 1
+            fi
+            sleep 15
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.10"
+version = "2.2.11"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.10"
+version = "2.2.11"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/fbuild-build/src/nrf52/orchestrator.rs
+++ b/crates/fbuild-build/src/nrf52/orchestrator.rs
@@ -210,7 +210,14 @@ impl BuildOrchestrator for Nrf52Orchestrator {
         let mcu_config = super::mcu_config::get_nrf52_config_for_mcu(&mcu_lower)?;
         let mut defines = ctx.board.get_defines();
         defines.extend(mcu_config.defines_map());
-        let mut include_dirs = ctx.board.get_include_paths(&framework_dir);
+        // Reuse the alias-resolved core_dir/variant_dir computed at step 5.
+        // BoardConfig::get_include_paths joins variants/<self.variant> literally
+        // and would emit a non-existent path like variants/nRF52DK/ when the
+        // board JSON uses a PIO/sandeepmistry variant name that aliases to a
+        // different Adafruit directory (e.g. nRF52DK -> pca10056, see #321).
+        // That would surface as `fatal error: variant.h: No such file or
+        // directory` when compiling cores/nRF5/{Uart,delay}.h.
+        let mut include_dirs = vec![core_dir.clone(), variant_dir.clone()];
         include_dirs.push(ctx.src_dir.clone());
         pipeline::discover_project_includes(&params.project_dir, &mut include_dirs);
         // Toolchain sysroot includes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.10"
+version = "2.2.11"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.9"
+version = "2.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },


### PR DESCRIPTION
## Summary
Two related fixes for nRF52 boards whose board JSON tracks PIO/sandeepmistry upstream naming while the installed framework is Adafruit's BSP. Same shape of bug — literal-vs-alias gap — applied to two different artifacts.

### 1. Variant include path (closes #325, original PR)
- `BoardConfig::get_include_paths` joins `variants/<self.variant>` literally, emitting a non-existent path like `variants/nRF52DK/` when the JSON variant aliases to a different Adafruit directory (e.g. `nRF52DK → pca10056`, see #321).
- Fix: nrf52 orchestrator now reuses the alias-resolved `variant_dir` from step 5 for include_dirs at step 6, instead of going through `get_include_paths`. Symptom resolved: `fatal error: variant.h: No such file or directory` for `cores/nRF5/{Uart,delay}.h`.

### 2. Linker script (closes #327, follow-up commit)
- After fix 1 lands, the `tests/platform/nrf52840_dk` integration test reaches the link step and fails with `ld: cannot open linker script file .../cores/nRF5/linker/nrf52_xxaa.ld: No such file or directory`.
- Adafruit's BSP only ships SoftDevice-flavored scripts: `nrf52840_s140_v6.ld`, `nrf52832_s132_v6.ld`, `nrf52_common.ld`.
- Fix: add an MCU-keyed alias resolver mirroring `resolve_nrf52_variant_dir` — `nrf52_xxaa.ld → nrf52840_s140_v6.ld | nrf52832_s132_v6.ld` based on `board.mcu`. Literal wins when present, so existing callers passing already-resolved names are unaffected.
- Orchestrator now uses `Nrf52Cores::get_linker_script_with_mcu(name, mcu)`. The pre-fix `get_linker_script(name)` method is preserved for direct callers that have already resolved the name themselves.

Closes #325 and #327. Unblocks FastLED/FastLED#2631 and FastLED/FastLED#2633 once a new release is cut and ingested.

## Test plan
- [x] `cargo build --release -p fbuild-build` clean.
- [x] `cargo test --release -p fbuild-packages --lib library::nrf52_core` — 16 tests pass, including 5 new tests for ldscript alias (52840 hit, 52832 hit, literal preferred, unknown name returns literal, unknown MCU does NOT pick up 52840 default).
- [ ] CI green on the PR branch.
- [ ] `tests/platform/nrf52840_dk/` integration test turns green (was red on main from both bugs in sequence).
- [ ] Existing supermini / nice_nano / nrfmicro orchestrator paths unaffected: their JSON `variant`/`ldscript` match literal Adafruit names, so both resolvers are no-ops for them.

## Why this fix shape
`get_include_paths` and `get_linker_script` are shared / orthogonal APIs respectively — changing their signatures to take resolvers would ripple. The minimal, localized fix lives in nrf52-specific code where the PIO↔Adafruit naming mismatch actually exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)