### PR TITLE
chore: bump version to 2.2.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.11"
+version = "2.2.12"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.11"
+version = "2.2.12"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cuts a release that includes the nRF52 alias-resolution fixes merged since 2.2.11.

### Changes since 2.2.11
- #326 — `fix(nrf52): emit alias-resolved variant include path` — nrf52840_dk, nrf52_xiaoblesense, adafruit_feather_nrf52840_sense now resolve their variant directory through `Nrf52Cores::get_variant_dir`, so board JSONs that track PIO/sandeepmistry naming find Adafruit's directories (`variants/pca10056/`, `variants/Seeed_XIAO_nRF52840_Sense/`, `variants/feather_nrf52840_sense/`) instead of failing with `fatal error: variant.h: No such file or directory`. Closes #325.
- #328 — `fix(nrf52): MCU-aware linker script alias for PIO-named nrf52_xxaa.ld` — Adafruit BSP ships only SoftDevice-flavored scripts. PIO-named `nrf52_xxaa.ld` now resolves to whichever `nrf52840_s140_v{N}.ld` / `nrf52832_s132_v{N}.ld` Adafruit's BSP actually shipped (globbed highest `_v{N}` available so future BSP bumps don't silently regress). Resolved linker script basename is fingerprinted into `metadata_hash` so the fast-path key invalidates correctly when resolution moves between files. Closes #327.

### Why now
FastLED/FastLED#2631 (nrf52840_dk) and FastLED/FastLED#2633 (nrf52_xiaoblesense) on FastLED master are red waiting for this release. Once 2.2.12 ships to PyPI, the FastLED ingestion PR bumps `fbuild==2.2.12` and those two workflows turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)