### PR TITLE
ci: bypass soldr cargo-zigbuild cache (fixes #331, unblocks 2.2.12)

### DIFF
--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -98,7 +98,11 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.target }}" == *-unknown-linux-musl ]]; then
-            soldr cargo zigbuild --release --target ${{ inputs.target }} \
+            # Direct `cargo zigbuild` (pip-installed wrapper) bypasses
+            # soldr's bin cache, which has been serving a corrupted
+            # cargo-zigbuild binary (`Syntax error: ")" unexpected` at
+            # line 10) and blocking PyPI publishes. See #331.
+            cargo zigbuild --release --target ${{ inputs.target }} \
               -p fbuild-cli \
               -p fbuild-daemon
           else
@@ -128,7 +132,8 @@ jobs:
             ARCH="${TARGET%%-*}"
             PYO3_TARGET="${ARCH}-unknown-linux-gnu"
             rustup target add "$PYO3_TARGET"
-            PYO3_NO_PYTHON=1 soldr cargo zigbuild --release \
+            # Direct `cargo zigbuild` (pip-installed wrapper) — see #331.
+            PYO3_NO_PYTHON=1 cargo zigbuild --release \
               --target-dir "${PYTHON_TARGET_DIR}" \
               --target "${PYO3_TARGET}.2.17" -p fbuild-python \
               --features extension-module

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.11"
+version = "2.2.12"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.11"
+version = "2.2.12"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Replace `soldr cargo zigbuild …` with direct `cargo zigbuild …` in `template_native_build.yml` at both call sites (musl CLI/daemon build + manylinux PyO3 extension build).
- Bypasses soldr's bin cache, which has been serving a corrupted `cargo-zigbuild-0.22.3` binary (`Syntax error: ")" unexpected` at line 10 when shell-interpreted) and reproducibly failing the release-auto workflow.
- The pip-installed `cargo-zigbuild` from the previous step (`pip install cargo-zigbuild` on Linux) takes over via PATH lookup; no other workflow change.

Closes #331. Unblocks 2.2.12 PyPI publish, which unblocks FastLED/FastLED#2631 and FastLED/FastLED#2633.

## Tradeoff
Loses soldr's build cache for those two specific zigbuild invocations. Acceptable because the release-auto workflow runs only on version bumps to main (rare). Other soldr-wrapped cargo invocations elsewhere in the file (line 105/141) keep their caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.2.12
  * Improved build process reliability for Linux and Python extension builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->