### PR TITLE
ci: bump setup-soldr v0.9.24 → v0.9.35 (~7s warm-run win)

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.24
+      - uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.24
+        uses: zackees/setup-soldr@v0.9.35
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
Bumps `zackees/setup-soldr` from `v0.9.24` to `v0.9.35` across all `.github/workflows/` pins.

## What's in v0.9.35 (vs v0.9.24)

### #304/#308 — FS-first rustup probe (the big win)
Eliminates the ~7s `rustup toolchain list` subprocess that fired on **every** warm CI run by reading `$RUSTUP_HOME/toolchains/` directly. Validated on zccache CI: linux/Test wall clock dropped **30.0s → 14.8s (-15.2s)**.

### #302/#303 — Sub-phase timing observability
Each setup phase now prints a `{sub=Xs sub=Ys}` breakdown inline, so the slow spots in resolve/toolchain phases are visible without enabling debug mode.

## Scope

Mechanical bump only — replaces `zackees/setup-soldr@v0.9.24` → `zackees/setup-soldr@v0.9.35` in 11 workflow files. No other changes.

## Test plan

- [ ] CI green on this PR (every workflow exercises the new action version)
- [ ] Confirm warm-run wall clock improvement matches the expected ~7-15s shave in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure with newer versions of development build tools across all continuous integration workflows to improve build reliability, enhance testing consistency, and support better development environment stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->