### PR TITLE
ci(setup): cache the installed fbuild binary, skip pip install on hit

### DIFF
--- a/.github/actions/setup/README.md
+++ b/.github/actions/setup/README.md
@@ -97,6 +97,7 @@ Use `steps.<id>.outputs.zccache-store-path` inside workflow expressions. The sam
 | `cache-key-extra` | `""` | String baked into the cache key. Use `hashFiles(...)` over your graph inputs so edits invalidate stale artifacts. |
 | `cache-version` | `v1` | Manual cache bump. Increment when you want to force-invalidate across your matrix. |
 | `cache-dir` | `$RUNNER_TEMP/fbuild-cache` | Override if you need a different cache root. |
+| `install-cache-key-extra` | `""` | Extra string for the **install** cache (separate from the build artifact cache). Pass `hashFiles('pyproject.toml')` so a fbuild pin bump invalidates the cached binary. The install cache is intentionally board/platform-independent so every job in a matrix shares it. |
 
 ## Outputs
 
@@ -112,9 +113,11 @@ Use `steps.<id>.outputs.zccache-store-path` inside workflow expressions. The sam
 1. Sets up Python.
 2. Resolves a stable fbuild cache directory under `$RUNNER_TEMP` (survives across steps of the same job; not a surprise `$HOME` path) and the zccache store path the job will use for compiler-object caching.
 3. Exports `FBUILD_CACHE_DIR` and `ZCCACHE_DIR` via `$GITHUB_ENV` so every later step inherits them, and exposes the zccache location as the `zccache-store-path` output.
-4. Installs fbuild from PyPI at the requested version.
-5. **Computes the installed fbuild's content hash** (sha256 of its dist-info `RECORD`) and bakes it into the cache key. This guarantees the cache is tied to the exact fbuild you're running, not just the PyPI version string, so `latest` is safe and a re-released wheel won't poison the cache.
-6. Restores (and on job-end, saves) the fbuild cache via `actions/cache@v5`.
+4. **Restores the install cache** (binary + dist-info) into `$RUNNER_TEMP/fbuild-install` keyed by os/arch/python/pip-spec/`install-cache-key-extra`. On hit, the install step is skipped entirely. The key intentionally omits anything matrix-specific (board, OS-tag, etc.) so every job in a repo's matrix shares the cached binary.
+5. Installs fbuild from PyPI at the requested version (skipped on install-cache hit). Install uses `pip install --target=$RUNNER_TEMP/fbuild-install` so the cached directory is the entire install surface.
+6. Activates the install dir by appending `bin/` (POSIX) and `Scripts/` (Windows) to `$GITHUB_PATH` and prepending `PYTHONPATH`.
+7. **Computes the installed fbuild's content hash** (sha256 of its dist-info `RECORD`) and bakes it into the **build artifact** cache key. This guarantees the artifact cache is tied to the exact fbuild you're running, not just the PyPI version string, so `latest` is safe and a re-released wheel won't poison the cache.
+8. Restores (and on job-end, saves) the fbuild build artifact cache via `actions/cache@v5`.
 
 ### Why hash-pinning matters
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Override the cache directory. Default: $RUNNER_TEMP/fbuild-cache (runner-stable, survives across steps of the same job)."
     required: false
     default: ""
+  install-cache-key-extra:
+    description: "Extra string baked into the install cache key (separate from the build artifact cache). Use hashFiles('pyproject.toml') so a pin bump invalidates the cached binary. The install cache is intentionally board/platform-independent so it's shared across every job in a repo's matrix."
+    required: false
+    default: ""
 
 outputs:
   cache-hit:
@@ -65,13 +69,19 @@ runs:
           CACHE_DIR="${RUNNER_TEMP}/fbuild-cache"
         fi
         ZCCACHE_DIR="${RUNNER_TEMP}/zccache"
-        mkdir -p "$CACHE_DIR" "$ZCCACHE_DIR"
+        # Isolated --target dir for the fbuild wheel install. Caching this
+        # directory directly (instead of the hosted Python's site-packages)
+        # keeps the cache scoped, deterministic, and immune to whatever
+        # else other steps install into the system interpreter.
+        INSTALL_DIR="${RUNNER_TEMP}/fbuild-install"
+        mkdir -p "$CACHE_DIR" "$ZCCACHE_DIR" "$INSTALL_DIR"
 
         # Exported for every subsequent step in the user's job.
         echo "FBUILD_CACHE_DIR=$CACHE_DIR" >> "$GITHUB_ENV"
         echo "ZCCACHE_DIR=$ZCCACHE_DIR" >> "$GITHUB_ENV"
         echo "cache-dir=$CACHE_DIR" >> "$GITHUB_OUTPUT"
         echo "zccache-store-path=$ZCCACHE_DIR" >> "$GITHUB_OUTPUT"
+        echo "install-dir=$INSTALL_DIR" >> "$GITHUB_OUTPUT"
 
         if [ "${{ inputs.fbuild-version }}" = "latest" ]; then
           echo "pip-spec=fbuild" >> "$GITHUB_OUTPUT"
@@ -79,13 +89,65 @@ runs:
           echo "pip-spec=fbuild==${{ inputs.fbuild-version }}" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Restore fbuild install cache
+      id: fbuild-install-cache
+      uses: actions/cache@v5
+      with:
+        # Cache the entire isolated --target install directory. The fbuild
+        # wheel has zero PyPI deps (verified on PyPI), so caching this dir
+        # is enough — no separate dependency tree to track.
+        path: ${{ steps.resolve-paths.outputs.install-dir }}
+        # Key is intentionally board/platform-INDEPENDENT (no cache-key-extra)
+        # so every job in a repo's board matrix shares the same install cache.
+        # `install-cache-key-extra` is the consumer-supplied hash — typically
+        # hashFiles('pyproject.toml') — so a pin bump invalidates the cached
+        # binary across the whole repo at once.
+        key: fbuild-install-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-py${{ inputs.python-version }}-${{ steps.resolve-paths.outputs.pip-spec }}-${{ inputs.install-cache-key-extra }}
+        restore-keys: |
+          fbuild-install-${{ inputs.cache-version }}-${{ runner.os }}-${{ runner.arch }}-py${{ inputs.python-version }}-${{ steps.resolve-paths.outputs.pip-spec }}-
+
     - name: Install fbuild
+      if: steps.fbuild-install-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail
-        python -m pip install --upgrade pip
-        python -m pip install '${{ steps.resolve-paths.outputs.pip-spec }}'
-        fbuild --version || echo "fbuild --version not yet supported on this release" >&2
+        # --target installs into a single isolated dir we can cache cleanly.
+        # No --upgrade pip — that step alone took ~1s before and has zero
+        # functional impact on installing one wheel with no deps.
+        python -m pip install --target "${{ steps.resolve-paths.outputs.install-dir }}" '${{ steps.resolve-paths.outputs.pip-spec }}'
+
+    - name: Activate fbuild from install dir
+      shell: bash
+      run: |
+        set -euo pipefail
+        INSTALL_DIR="${{ steps.resolve-paths.outputs.install-dir }}"
+        # `pip install --target` drops console scripts in <target>/bin on
+        # POSIX and <target>/Scripts on Windows. Add both to GITHUB_PATH so
+        # the same action.yml works across runner.os without branching.
+        echo "$INSTALL_DIR/bin" >> "$GITHUB_PATH"
+        echo "$INSTALL_DIR/Scripts" >> "$GITHUB_PATH"
+        # Python needs to see the --target-installed package on import,
+        # otherwise `fbuild` (a console script) fails at module resolution
+        # despite being on PATH. Prepend, don't replace, any existing
+        # PYTHONPATH so downstream steps' Python imports keep working.
+        if [ -n "${PYTHONPATH:-}" ]; then
+          echo "PYTHONPATH=$INSTALL_DIR:$PYTHONPATH" >> "$GITHUB_ENV"
+        else
+          echo "PYTHONPATH=$INSTALL_DIR" >> "$GITHUB_ENV"
+        fi
+        # Smoke test using the resolved binary, not `fbuild` from PATH
+        # (GITHUB_PATH writes only take effect in subsequent steps).
+        if [ -x "$INSTALL_DIR/bin/fbuild" ]; then
+          PYTHONPATH="$INSTALL_DIR${PYTHONPATH:+:$PYTHONPATH}" "$INSTALL_DIR/bin/fbuild" --version \
+            || echo "fbuild --version not yet supported on this release" >&2
+        elif [ -x "$INSTALL_DIR/Scripts/fbuild.exe" ]; then
+          PYTHONPATH="$INSTALL_DIR${PYTHONPATH:+;$PYTHONPATH}" "$INSTALL_DIR/Scripts/fbuild.exe" --version \
+            || echo "fbuild --version not yet supported on this release" >&2
+        else
+          echo "::error::fbuild binary not found in $INSTALL_DIR/{bin,Scripts}; cache likely corrupt" >&2
+          ls -la "$INSTALL_DIR" >&2 || true
+          exit 1
+        fi
 
     - name: Resolve fbuild content hash
       id: fbuild-hash


### PR DESCRIPTION
## Summary

- The setup action runs \`pip install fbuild\` on every job. The wheel has zero PyPI deps so this is pure waste across a board matrix — each job paid ~2s plus a no-op \`pip install --upgrade pip\` step.
- Switch to \`pip install --target=\$RUNNER_TEMP/fbuild-install\` wrapped with \`actions/cache@v5\`. On hit the install step is skipped entirely; a downstream step activates the cached dir by appending its \`bin/\` (POSIX) and \`Scripts/\` (Windows) paths to \`GITHUB_PATH\` plus \`PYTHONPATH\`.
- Install-cache key intentionally omits anything matrix-specific so every job in a repo's matrix shares the same binary. New input \`install-cache-key-extra\` lets consumers pass \`hashFiles('pyproject.toml')\` so a fbuild pin bump invalidates the cached binary across the whole repo at once.

Asked for by user in [FastLED PR #2661 comment](https://github.com/FastLED/FastLED/pull/2661): *"setup fbuild (install + cache) is taking way too long, it's just a binary install from pypi… please cache this small binary too. this will be saved for all the other fastled builds and should be very fast. make sure it's hashed on pyproject.toml value. it should be the same for all fastled builds regardless of platform type."*

The build-artifact cache (the large 1.8GB one keyed on \`cache-key-extra\`) is untouched — only the install footprint is newly cached.

## Test plan

- [ ] CI green on this PR
- [ ] FastLED follow-up workflow change passes \`install-cache-key-extra: \${{ hashFiles('pyproject.toml') }}\`; observe second-run install step shows \"Cache hit\" + install step shows skipped via \`if:\`
- [ ] Confirm \`fbuild --version\` works in a step after the activation step (PATH + PYTHONPATH inheritance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)