### PR TITLE
ci: bump setup-soldr v0.9.35 → v0.9.38

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.35
+      - uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.35
+        uses: zackees/setup-soldr@v0.9.38
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
## Summary
Bumps the pinned `zackees/setup-soldr` version from `v0.9.35` to `v0.9.38` across all `.github/workflows/*.yml` (12 occurrences across 11 files).

Picks up:
- **#313/#314/#317/#319**: pre-save `lookupOnly` probes that skip wasted concurrent solo-toolchain-cache uploads (~3-4 min/cold-cycle on multi-job workflows).
- **#310**: solo-toolchain-cache default `zstd -19 → -9` (~92s/cold-save).
- **#316/#320**: plumbing for cache LRU pressure investigation.

## Test plan
- [ ] CI green across all workflows (acceptance-205, bench-205, check-{macos,ubuntu,windows}, docs, dylint, fmt, msrv, template_build, template_native_build)
- [ ] Verify solo-toolchain-cache pre-save lookupOnly probe behavior on a cold cache cycle
- [ ] Spot-check that cold-save wall-clock dropped for the toolchain layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow tooling versions across all testing, build, documentation, and platform-specific pipeline configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->