### PR TITLE
chore: bump zccache pin to >=1.11.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.2.12"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["zccache>=1.8.2"]
+dependencies = ["zccache>=1.11.9"]
 
 [dependency-groups]
 dev = ["fbuild-dev-tools"]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.11"
+version = "2.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },
@@ -16,7 +16,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "zccache", specifier = ">=1.8.2" }]
+requires-dist = [{ name = "zccache", specifier = ">=1.11.9" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "fbuild-dev-tools", editable = "ci/dev-tools" }]
@@ -28,13 +28,13 @@ source = { editable = "ci/dev-tools" }
 
 [[package]]
 name = "zccache"
-version = "1.8.2"
+version = "1.11.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/fb/40cfe8df8c2ac6c250b08845873f98eeca6352325d7af8f10bb28a6faa16/zccache-1.8.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b960c703d05e6bedace35be51db1cf477cd94aeba35afb93c919f1860233d4dd", size = 12400172, upload-time = "2026-05-22T14:27:25.927Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/38/78525b2f66d921e1042592300b24107b7f512082a62d00fa769c416cf0d7/zccache-1.8.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b9b7ce451e7a7c6696c7b8008dcde92dd8cb35fd20a978cc4afe0c05c2c85aa9", size = 11877951, upload-time = "2026-05-22T14:27:29.317Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/84/e3f73a89d89d7cd6d443e0de0f0b8d7fdaf50aa2f9ca8196b111b32ded37/zccache-1.8.2-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:c0d2e62faa7e994ca6889b2864092da6c6ce71de8aa2c2d0637c084434791883", size = 13982209, upload-time = "2026-05-22T14:27:32.007Z" },
-    { url = "https://files.pythonhosted.org/packages/03/9a/4a13ae46798ee1b7530ba3a0e9359a36829be7c0ea7b6cd52241bb55e5a4/zccache-1.8.2-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:cb75a827ea79d275d130775ea7c41a7d035faca4040fb0d8dbdba69f3222d588", size = 14414946, upload-time = "2026-05-22T14:27:35.551Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c9/1ab6c223d905320d8130a35bca39128c3950375607ba75beb571a1a8f333/zccache-1.8.2-py3-none-win_amd64.whl", hash = "sha256:6f21c6fb2ecad6b958723be4216127d1c5700bc9d9651d3ce2db57401ba8e88e", size = 11682901, upload-time = "2026-05-22T14:27:38.72Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/51/6b84d6f7145b844a01740d36db4cfbdc43aadb911df1a3439fb5f454910c/zccache-1.8.2-py3-none-win_arm64.whl", hash = "sha256:b607217557af61b876ff193b636c5d6165447d67628deefb2f67c0e0c6d8ffd5", size = 10879203, upload-time = "2026-05-22T14:27:41.741Z" },
+    { url = "https://files.pythonhosted.org/packages/91/27/113db19152e1906e17c7ec6c1e1a0af5b1b37e6e4cdc628cdba41980d9ab/zccache-1.11.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:260d28c234b051c07bb07acdc438899e7aa5d5ef38bf25c4dcc068f9e2c88688", size = 13486518, upload-time = "2026-05-31T19:30:19.125Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a2/41a41778dd827fa0523e2a83a1d8886039a4d9c285702109f7d821d8ed52/zccache-1.11.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:30c8121d1e1bccfe46aaaf41761d0b1854ac259de5fb100654fec1db8e25cad9", size = 12894995, upload-time = "2026-05-31T19:30:21.799Z" },
+    { url = "https://files.pythonhosted.org/packages/07/29/794258a721a33262db5de7ea1428e4bea4dc9f4c8c33bb1f321906d50497/zccache-1.11.9-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:c8b0d33281e092ddbe16168e6deac844d42cf6e1b1abfdd41e0be9f289aff268", size = 15293375, upload-time = "2026-05-31T19:30:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/c8cfb94dfc947efbde7b1529cb6b7238f2463d7778b6b8f9137dc68104ad/zccache-1.11.9-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:b346296904c78597edb9be1481ce77c989d26a5b30b18258f67de263c687169c", size = 17062669, upload-time = "2026-05-31T19:30:26.822Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a5/bf0836f4e16a431ce6df0441a706a926b2a094932d590ccd96d1d1a99c60/zccache-1.11.9-py3-none-win_amd64.whl", hash = "sha256:2d69d1cb0fe49860cc0d5fd1edb68b1847ece6460818596645292623c3c046f7", size = 13545304, upload-time = "2026-05-31T19:30:29.317Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c7/d2404c2a60213e8444e7790a01d03c3e434a4983c5893ff8fb3417097787/zccache-1.11.9-py3-none-win_arm64.whl", hash = "sha256:2613ea6efa970655cb5fc67814cec29cc47749ae5ed4736792637ec42e979ca1", size = 11946087, upload-time = "2026-05-31T19:30:32.132Z" },
 ]


### PR DESCRIPTION
zccache 1.11.9 went live on PyPI at 2026-05-31T19:29 UTC. It picks up [zackees/zccache#507](https://github.com/zackees/zccache/pull/507) which restores \`zccache analyze\` and \`zccache kv\` after the long-standing wrap-mode misroute (both were exiting with \`daemon error: failed to run compiler: program not found\` even on \`--help\`). \`soldr cache report\` shells out to \`zccache analyze\` and is now actually useful again.

\`Cargo.toml\` \`zccache-artifact = "1.9"\` is unchanged because that's a separate crate (artifact-metadata only) and didn't get a new release with 1.11.9.

\`uv.lock\` regenerated via \`uv lock --refresh --upgrade-package zccache\` — only the \`fbuild\`+\`zccache\` rows change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)