### PR TITLE
fix(daemon): route fmt tracing layer to stderr so CLI captures it (#346)

### DIFF
--- a/crates/fbuild-daemon/src/main.rs
+++ b/crates/fbuild-daemon/src/main.rs
@@ -63,7 +63,14 @@ async fn main() {
             tracing_subscriber::EnvFilter::from_default_env()
                 .add_directive(tracing::Level::INFO.into()),
         )
-        .with(tracing_subscriber::fmt::layer())
+        // Route fmt layer to stderr — the CLI captures the daemon's
+        // stderr into ~/.fbuild/<env>/daemon/daemon.log (see
+        // daemon_client.rs spawn_daemon). The MakeWriter default is
+        // stdout, but the CLI sets stdout to Null, so without
+        // .with_writer(stderr) every `tracing::*` event in the daemon
+        // is silently dropped on Windows and we have zero visibility
+        // into daemon-side hangs. See FastLED/fbuild#346.
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
         .with(BroadcastLogLayer::new(log_tx))
         .init();
 


### PR DESCRIPTION
[#346 finding (1)](https://github.com/FastLED/fbuild/issues/346) — \`tracing_subscriber::fmt::layer()\` defaults to stdout via \`MakeWriter\`, but the CLI's daemon spawn sets the child's stdout to \`Null\` and only captures stderr into \`~/.fbuild/<env>/daemon/daemon.log\`. So every \`tracing::info!\` / \`tracing::warn!\` / \`tracing::error!\` emitted by the daemon was silently dropped — only explicit \`eprintln!\` and Rust panics made it through. That's what made the esp32c6 hang impossible to debug from logs.

Routes the fmt layer to \`std::io::stderr\` so events land on the handle the CLI is actually capturing.

This doesn't touch the actual hang (suspected to be \`zccache::ensure_running\` without a timeout, or a stuck per-project \`Mutex<()>\` — see [#346 finding (2)](https://github.com/FastLED/fbuild/issues/346)). With this in, the next time someone reproduces the hang, the daemon log will actually contain the per-phase trace events from the ESP32 orchestrator and localize whatever's blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)