### PR TITLE
fix(zccache): bound ensure_running with a 30s timeout (#346)

### DIFF
--- a/crates/fbuild-build/src/zccache.rs
+++ b/crates/fbuild-build/src/zccache.rs
@@ -126,7 +126,22 @@ fn find_zccache_in_venv(start: &Path, exe_name: &str) -> Option<PathBuf> {
 /// Start the zccache daemon if it's not already running.
 ///
 /// This is idempotent — `zccache start` is a no-op when the daemon is up.
+///
+/// Bounded by a wall-clock timeout: if `zccache start` doesn't return
+/// within `FBUILD_ZCCACHE_START_TIMEOUT_SECS` (default 30s), kill the
+/// child and continue without zccache. A wedged zccache daemon used to
+/// hang the orchestrator silently for the lifetime of the fbuild client
+/// because `.status()` had no timeout — see FastLED/fbuild#346 finding
+/// (2). Falling through here is safe: the orchestrator runs the
+/// compiler directly when `find_zccache` later returns None (the daemon
+/// has separate readiness signals we don't gate on here).
 pub fn ensure_running(zccache: &Path) {
+    let timeout = std::env::var("FBUILD_ZCCACHE_START_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(std::time::Duration::from_secs)
+        .unwrap_or(std::time::Duration::from_secs(30));
+
     // INTENTIONALLY DETACHED (FastLED/fbuild#32): zccache is itself a
     // long-running daemon with independent lifecycle management. `start`
     // is a no-op when it's already running, and either way the zccache
@@ -145,18 +160,54 @@ pub fn ensure_running(zccache: &Path) {
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
 
-    let result = cmd.status();
-
-    match result {
-        Ok(status) if status.success() => {
-            tracing::info!("zccache daemon running");
-        }
-        Ok(status) => {
-            tracing::warn!("zccache start exited with {}", status);
-        }
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
         Err(e) => {
-            tracing::warn!("failed to start zccache daemon: {}", e);
+            tracing::warn!("failed to spawn zccache daemon: {}", e);
+            return;
         }
+    };
+
+    // Poll `try_wait` with a short backoff rather than blocking on
+    // `wait()`. This is std-only (no extra dep) and keeps the loop
+    // responsive enough that the deadline lands within a poll interval.
+    let deadline = std::time::Instant::now() + timeout;
+    let mut interval = std::time::Duration::from_millis(50);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => {
+                tracing::info!("zccache daemon running");
+                return;
+            }
+            Ok(Some(status)) => {
+                tracing::warn!("zccache start exited with {}", status);
+                return;
+            }
+            Ok(None) => {
+                // Still running — back off and retry until the deadline.
+            }
+            Err(e) => {
+                tracing::warn!("failed to wait on zccache daemon: {}", e);
+                return;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            tracing::warn!(
+                "zccache start did not return within {:?} — killing child and \
+                 continuing without zccache (suspected wedged daemon, see \
+                 FastLED/fbuild#346). Set FBUILD_ZCCACHE_START_TIMEOUT_SECS to \
+                 override the timeout.",
+                timeout
+            );
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+        std::thread::sleep(interval);
+        // Gentle exponential backoff capped at ~500ms so a quick start
+        // returns immediately but a slow-but-eventual start doesn't burn
+        // a tight poll loop for 30s.
+        interval = (interval * 2).min(std::time::Duration::from_millis(500));
     }
 }
 


### PR DESCRIPTION
Safety net for the esp32c6 hang in [#346 finding (2)](https://github.com/FastLED/fbuild/issues/346).

\`ensure_running\` used \`cmd.status()\` which blocks indefinitely on the child. If the zccache daemon's IPC was wedged — observable on Windows per #346 — \`zccache start\` would itself block trying to talk to the wedged daemon, and the orchestrator's call to \`ensure_running\` would never return. The build hung silently for the lifetime of the fbuild client with no log line, no compiler workers spawned, and no recovery short of \`Stop-Process -Force\`.

Switch to a poll-based wait with a 30s deadline (overridable via \`FBUILD_ZCCACHE_START_TIMEOUT_SECS\`). On timeout, kill the child and fall through. \`find_zccache\` is checked again later in the orchestrator path and the compiler is invoked directly when zccache isn't available, so falling through is safe.

This is the safety net, not the fix for whatever wedged the upstream zccache daemon — that's still upstream's problem. The fbuild side just stops being a victim of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced zccache startup with timeout protection. The build system now waits a maximum of 30 seconds (configurable via environment variable) for zccache to become ready. If startup fails or times out, compilation continues without zccache rather than hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->