### PR TITLE
chore: bump version to 2.2.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.12"
+version = "2.2.13"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.12"
+version = "2.2.13"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.12"
+version = "2.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },


### PR DESCRIPTION
Triggers release-auto to cut **2.2.13** with the work from this session's perf sprint.

## What's in 2.2.13

**Perf:**
- [#337](https://github.com/FastLED/fbuild/pull/337) framework-archive sharing across compile-many stage-2 sketches — ~19× cold-cache speedup on uno locally
- [#336](https://github.com/FastLED/fbuild/pull/336) stage-2 jobs split — drop the jobs=1 hardcode
- [#342](https://github.com/FastLED/fbuild/pull/342) real-toolchain stage-2 perf regression test

**Reliability:**
- [#348](https://github.com/FastLED/fbuild/pull/348) daemon fmt tracing routed to stderr so CLI captures it
- [#349](https://github.com/FastLED/fbuild/pull/349) `zccache::ensure_running` bounded by a 30s timeout (\`FBUILD_ZCCACHE_START_TIMEOUT_SECS\`)
- [#350](https://github.com/FastLED/fbuild/pull/350) project lock acquire instrumented with info-before / warn-at-10s / info-on-acquire

**Setup:**
- [#334](https://github.com/FastLED/fbuild/pull/334) install cache for the setup action
- [#340](https://github.com/FastLED/fbuild/pull/340) zccache pin floor bumped to >=1.11.9

\`Cargo.toml\` and \`pyproject.toml\` bumped in sync (the release-auto workflow errors out if they don't match). \`Cargo.lock\` + \`uv.lock\` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.2.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->