### PR TITLE
ci: bump setup-soldr v0.9.47 -> v0.9.48 (cache-eviction age floor fix)

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.47
+      - uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.47
+        uses: zackees/setup-soldr@v0.9.48
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
Picks up setup-soldr#352/#353 — cache-eviction-policy age floor fix. This repo doesn't enable the policy, so no behavior change, but staying on latest is good hygiene.