### PR TITLE
ci: bump setup-soldr v0.9.48 -> v0.9.49

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.48
+      - uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.48
+        uses: zackees/setup-soldr@v0.9.49
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.48` to `v0.9.49`.

## What's in v0.9.49
- `cache-eviction-policy: protect-foundations` thresholds raised from 9 GB / 8 GB to 9.5 GB / 9.0 GB.
- Reason: v0.9.48 was leaving ~2 GB of usable cache budget on the table. New thresholds keep 0.5 GB headroom under GitHub's 10 GB cap and fire eviction less eagerly while still beating GitHub's own non-deterministic LRU. The 6h age floor from v0.9.48 is unchanged.

No action input changes; this is a pure threshold tuning that takes effect for repos already using `cache-eviction-policy: protect-foundations`.

## Test plan
- [ ] CI green (warm restore + post-step eviction logs)
- [ ] Post-step eviction log shows new thresholds (`evicting toward 9 GB` when usage > 9.5 GB) — or no eviction at all if usage stays under 9.5 GB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded GitHub Actions setup-soldr dependency from v0.9.48 to v0.9.49 systematically across all continuous integration and deployment workflows for consistency. Updated workflows include acceptance tests, benchmarks, cross-platform verification (macOS, Ubuntu, Windows), documentation generation, code linting and formatting validation, minimum Rust version checks, and template build pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->