### PR TITLE
ci: bump setup-soldr v0.9.49 -> v0.9.50

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.49
+      - uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.49
+        uses: zackees/setup-soldr@v0.9.50
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.49` to `v0.9.50`.

## What's in v0.9.50
Graduated age floor for `cache-eviction-policy` (closes setup-soldr#356).

v0.9.48's fixed 6h age floor became a no-op under heavy CI load. Observed on zccache MSRV at 13.63 GB usage where ALL 171 evictable entries were < 6h old — eviction deleted zero, leaving GitHub's non-deterministic LRU in charge of foundation entries.

New tier table:

| Overshoot (usage − trigger) | Floor (protect-foundations) | Floor (aggressive) |
|---|---|---|
| ≤ 1 GB        | 6h (baseline, #352 fix preserved)   | 2h |
| 1–3 GB        | 2h                                  | 2h |
| > 3 GB        | 0.5h (danger zone)                  | 0.5h |

Post-step log now emits `graduated age floor active — overshoot=X GB, floor=Y h` when the tier kicks in. No action-input changes; pure logic improvement that takes effect for repos already using `cache-eviction-policy: protect-foundations`.

## Test plan
- [ ] CI green
- [ ] Post-step log shows `deleted N entries` (N ≥ 1) when usage > +3 GB over trigger
