### PR TITLE
feat(stm32): add Arduino UNO Q STM32U5 support

### DIFF
--- a/crates/fbuild-build/src/stm32/configs/README.md
+++ b/crates/fbuild-build/src/stm32/configs/README.md
@@ -8,3 +8,4 @@ ARM Cortex-M variant used by STM32 microcontrollers.
 - `stm32f1.json` - STM32F1xx (Cortex-M3, no FPU)
 - `stm32f4.json` - STM32F4xx (Cortex-M4F, hardware FPU)
 - `stm32h7.json` - STM32H7xx (Cortex-M7, double-precision FPU)
+- `stm32u5.json` - STM32U5xx (Cortex-M33F, hardware FPU)

--- a/crates/fbuild-build/src/stm32/configs/stm32u5.json
+++ b/crates/fbuild-build/src/stm32/configs/stm32u5.json
@@ -1,0 +1,68 @@
+{
+  "name": "STM32U5",
+  "description": "STM32U5xx (ARM Cortex-M33F)",
+  "architecture": "arm-cortex-m33",
+
+  "compiler_flags": {
+    "common": [
+      "-mcpu=cortex-m33",
+      "-mthumb",
+      "-mfpu=fpv4-sp-d16",
+      "-mfloat-abi=hard",
+      "-Wall",
+      "-Wextra",
+      "-Wno-unused-parameter",
+      "-ffunction-sections",
+      "-fdata-sections",
+      "-MMD",
+      "--specs=nano.specs"
+    ],
+    "c": [
+      "-std=gnu11"
+    ],
+    "cxx": [
+      "-std=gnu++17",
+      "-fno-exceptions",
+      "-fno-rtti",
+      "-fno-threadsafe-statics"
+    ]
+  },
+
+  "linker_flags": [
+    "-mcpu=cortex-m33",
+    "-mthumb",
+    "-mfpu=fpv4-sp-d16",
+    "-mfloat-abi=hard",
+    "-Wl,--gc-sections",
+    "-Wl,--print-memory-usage",
+    "--specs=nano.specs",
+    "--specs=nosys.specs"
+  ],
+
+  "linker_libs": [
+    "-lgcc",
+    "-lstdc++",
+    "-lm",
+    "-lc"
+  ],
+
+  "objcopy": {
+    "output_format": "ihex",
+    "remove_sections": [".eeprom"]
+  },
+
+  "profiles": {
+    "release": {
+      "compile_flags": ["-Os", "-flto", "-fno-fat-lto-objects"],
+      "link_flags": ["-flto", "-fuse-linker-plugin"]
+    },
+    "quick": {
+      "compile_flags": ["-Os"],
+      "link_flags": []
+    }
+  },
+
+  "defines": [
+    ["ARDUINO", "10808"]
+  ]
+}

--- a/crates/fbuild-build/src/stm32/mcu_config.rs
+++ b/crates/fbuild-build/src/stm32/mcu_config.rs
@@ -1,7 +1,8 @@
 //! Data-driven STM32 MCU configuration from embedded JSON.
 //!
 //! Maps STM32 MCU names to the appropriate ARM Cortex-M configuration.
-//! STM32F1xx uses Cortex-M3, STM32F4xx uses Cortex-M4F, STM32H7xx uses Cortex-M7.
+//! STM32F1xx uses Cortex-M3, STM32F4xx uses Cortex-M4F, STM32H7xx uses Cortex-M7,
+//! and STM32U5xx uses Cortex-M33F.
 
 use fbuild_core::Result;
 
@@ -10,6 +11,7 @@ use crate::generic_arm::ArmMcuConfig;
 const STM32F1_JSON: &str = include_str!("configs/stm32f1.json");
 const STM32F4_JSON: &str = include_str!("configs/stm32f4.json");
 const STM32H7_JSON: &str = include_str!("configs/stm32h7.json");
+const STM32U5_JSON: &str = include_str!("configs/stm32u5.json");
 
 /// Load the STM32 MCU configuration for a specific MCU.
 ///
@@ -17,6 +19,7 @@ const STM32H7_JSON: &str = include_str!("configs/stm32h7.json");
 /// - `stm32f103*` → STM32F1 (Cortex-M3)
 /// - `stm32f4*` → STM32F4 (Cortex-M4F)
 /// - `stm32h7*` → STM32H7 (Cortex-M7)
+/// - `stm32u5*` → STM32U5 (Cortex-M33F)
 pub fn get_stm32_config_for_mcu(mcu: &str) -> Result<ArmMcuConfig> {
     let mcu_lower = mcu.to_lowercase();
     let json = if mcu_lower.starts_with("stm32f103") {
@@ -25,9 +28,11 @@ pub fn get_stm32_config_for_mcu(mcu: &str) -> Result<ArmMcuConfig> {
         STM32F4_JSON
     } else if mcu_lower.starts_with("stm32h7") {
         STM32H7_JSON
+    } else if mcu_lower.starts_with("stm32u5") {
+        STM32U5_JSON
     } else {
         return Err(fbuild_core::FbuildError::ConfigError(format!(
-            "unsupported STM32 MCU: '{}' (supported prefixes: stm32f103, stm32f4, stm32h7)",
+            "unsupported STM32 MCU: '{}' (supported prefixes: stm32f103, stm32f4, stm32h7, stm32u5/stm32u585)",
             mcu
         )));
     };
@@ -62,6 +67,13 @@ mod tests {
         let config = get_stm32_config_for_mcu("stm32h743zi").unwrap();
         assert_eq!(config.name, "STM32H7");
         assert_eq!(config.architecture, "arm-cortex-m7");
+    }
+
+    #[test]
+    fn test_stm32u5_config_parses() {
+        let config = get_stm32_config_for_mcu("stm32u585zit6q").unwrap();
+        assert_eq!(config.name, "STM32U5");
+        assert_eq!(config.architecture, "arm-cortex-m33");
     }
 
     #[test]
@@ -105,6 +117,27 @@ mod tests {
             .compiler_flags
             .common
             .contains(&"-mfpu=fpv5-d16".to_string()));
+    }
+
+    #[test]
+    fn test_stm32u5_has_platformio_hard_float_flags() {
+        let config = get_stm32_config_for_mcu("stm32u585zit6q").unwrap();
+        for flag in [
+            "-mcpu=cortex-m33",
+            "-mthumb",
+            "-mfpu=fpv4-sp-d16",
+            "-mfloat-abi=hard",
+        ] {
+            let flag = flag.to_string();
+            assert!(
+                config.compiler_flags.common.contains(&flag),
+                "STM32U5 compiler flags missing {flag}"
+            );
+            assert!(
+                config.linker_flags.contains(&flag),
+                "STM32U5 linker flags missing {flag}"
+            );
+        }
     }
 
     #[test]
@@ -154,5 +187,11 @@ mod tests {
     fn test_stm32_case_insensitive() {
         let config = get_stm32_config_for_mcu("STM32F103C8").unwrap();
         assert_eq!(config.name, "STM32F1");
+    }
+
+    #[test]
+    fn test_stm32u5_case_insensitive() {
+        let config = get_stm32_config_for_mcu("STM32U585ZIT6Q").unwrap();
+        assert_eq!(config.name, "STM32U5");
     }
 }

--- a/crates/fbuild-config/assets/boards/json/arduino_uno_q.json
+++ b/crates/fbuild-config/assets/boards/json/arduino_uno_q.json
@@ -1,0 +1,45 @@
+{
+  "build": {
+    "arduino": {
+      "variant_h": "variant_NUCLEO_U575ZI_Q.h"
+    },
+    "board": "UNO_Q",
+    "core": "stm32",
+    "extra_flags": "-DSTM32U5 -DSTM32U5xx -DSTM32U585xx -DARDUINO_NUCLEO_U575ZI_Q -DCUSTOM_PERIPHERAL_PINS",
+    "f_cpu": "160000000L",
+    "mcu": "stm32u585zit6q",
+    "variant": "STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ",
+    "variant_h": "variant_NUCLEO_U575ZI_Q.h"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "tools": {
+      "blackmagic": {},
+      "cmsis-dap": {},
+      "jlink": {},
+      "stlink": {
+        "default": true,
+        "onboard": true
+      }
+    }
+  },
+  "fcpu": 160000000,
+  "frameworks": [
+    "arduino"
+  ],
+  "id": "arduino_uno_q",
+  "mcu": "STM32U585ZIT6Q",
+  "name": "Arduino UNO Q",
+  "platform": "ststm32",
+  "ram": 523624,
+  "rom": 1966080,
+  "upload": {
+    "maximum_ram_size": 523624,
+    "maximum_size": 1966080,
+    "protocol": "stlink"
+  },
+  "url": "https://docs.arduino.cc/hardware/uno-q/",
+  "vendor": "Arduino"
+}

--- a/crates/fbuild-config/src/board/db.rs
+++ b/crates/fbuild-config/src/board/db.rs
@@ -145,6 +145,9 @@ pub(super) fn get_board_defaults(board_id: &str) -> Option<HashMap<String, Strin
         if let Some(core) = build.get("core").and_then(|v| v.as_str()) {
             d.insert("core".into(), core.to_string());
         }
+        if let Some(board) = build.get("board").and_then(|v| v.as_str()) {
+            d.insert("board".into(), board.to_string());
+        }
         if let Some(variant) = build.get("variant").and_then(|v| v.as_str()) {
             d.insert("variant".into(), variant.to_string());
         }

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -35,6 +35,26 @@ fn test_from_board_id_uno() {
 }
 
 #[test]
+fn test_from_board_id_arduino_uno_q() {
+    let config = BoardConfig::from_board_id("arduino_uno_q", &HashMap::new()).unwrap();
+    assert_eq!(config.name, "Arduino UNO Q");
+    assert_eq!(config.mcu, "stm32u585zit6q");
+    assert_eq!(config.variant, "STM32U5xx/U575Z(G-I)TxQ_U585ZITxQ");
+    assert_eq!(
+        config.variant_h.as_deref(),
+        Some("variant_NUCLEO_U575ZI_Q.h")
+    );
+    assert_eq!(config.board, "UNO_Q");
+    let defines = config.get_defines();
+    assert_eq!(defines.get("ARDUINO_UNO_Q"), Some(&"1".to_string()));
+    assert_eq!(
+        defines.get("ARDUINO_NUCLEO_U575ZI_Q"),
+        Some(&"1".to_string())
+    );
+    assert!(!defines.contains_key("ARDUINO_ARDUINO_UNO_Q"));
+}
+
+#[test]
 fn test_from_board_id_mega() {
     let config = BoardConfig::from_board_id("mega", &HashMap::new()).unwrap();
     assert_eq!(config.mcu, "atmega2560");


### PR DESCRIPTION
## Summary
- add a built-in `arduino_uno_q` board definition and preserve `build.board = UNO_Q`
- add STM32U5/U585 native MCU config with Cortex-M33 hard-float flags
- add focused tests for UNO Q board metadata and STM32U5 config selection

Fixes #363.
Refs FastLED/FastLED#2674.
Refs #364.

## Verification
- `cargo fmt --check`
- `cargo test -p fbuild-build stm32::mcu_config -- --nocapture`
- `cargo test -p fbuild-config test_from_board_id_arduino_uno_q -- --nocapture`
- `cargo build -p fbuild-cli -p fbuild-daemon`
- direct native fbuild clean build of `C:\Users\niteris\dev\fastled3\.build\pio\arduino_uno_q` passed with local `target/debug/fbuild.exe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for STM32U5 MCU family (Cortex-M33F with hardware FPU).
  * Added support for Arduino Uno Q board.
  * Enhanced board configuration handling to support additional build parameters.

* **Documentation**
  * Updated STM32 MCU configuration documentation for STM32U5 family.

* **Tests**
  * Added comprehensive test coverage for STM32U5 and Arduino Uno Q configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->