### PR TITLE
chore(release): bump fbuild to 2.2.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.13"
+version = "2.2.14"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.13"
+version = "2.2.14"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.13"
+version = "2.2.14"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.13"
+version = "2.2.14"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },


### PR DESCRIPTION
## Summary
- bump fbuild package metadata and lockfiles to 2.2.14
- prepare the PyPI/GitHub release that includes merged Arduino UNO Q / STM32U5 board support from #365

## Context
FastLED/FastLED#2674 now has source support for Arduino UNO Q, but FastLED CI resolves the pinned PyPI fbuild wheel from its virtualenv. The current 2.2.13 wheel does not include the new built-in board defaults, so the native fbuild workflow still fails with unknown board 'arduino_uno_q'.

Refs FastLED/FastLED#2674
Refs #363
Refs #364
Refs #365

## Verification
- cargo check -p fbuild-cli -p fbuild-daemon
- uv lock
- cargo fmt --check
- cargo test -p fbuild-build stm32::mcu_config -- --nocapture
- cargo test -p fbuild-config test_from_board_id_arduino_uno_q -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Project version updated to 2.2.14

<!-- end of auto-generated comment: release notes by coderabbit.ai -->