### PR TITLE
ci: bump setup-soldr v0.9.50 -> v0.9.53

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.50
+      - uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.50
+        uses: zackees/setup-soldr@v0.9.53
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.50` to `v0.9.53`.

## What's in v0.9.51–v0.9.53
- **v0.9.51** — Per-line `MM:SS` timestamps on `soldr cook` output (cargo's `Compiling`/`Downloading` lines), colors preserved (diagnostic).
- **v0.9.52** — Per-layer save table now splits `compress` vs `upload` wall-clock for cook-cache (diagnostic).
- **v0.9.53** — **PERF WIN**: cook-cache-base compression level dropped from zstd-19 → zstd-9. Cuts post-step compress wall-clock ~4× (~165s → ~40s on zccache observation) at the cost of ~25% larger archive (~280 MB instead of ~224 MB). zstd decompression is level-independent, so warm restores unaffected. Net: ~125s win per save-attempt, with multiplier on race-loss matrix scenarios.

## Test plan
- [ ] CI green
- [ ] Post-step `compress` column in save table shows ~40s instead of ~165s for cook-cache-base
- [ ] Setup phase total drops on cold-cook runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure tooling across all CI/CD workflows to the latest version for improved stability and performance across development, testing, and benchmarking environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->