### PR TITLE
ci: bump setup-soldr v0.9.55 -> v0.9.56

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.55
+      - uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.55
+        uses: zackees/setup-soldr@v0.9.56
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.55` to `v0.9.56`.

## What's in v0.9.56
Fixes v0.9.55's parentSha derivation on shallow checkouts (the default `actions/checkout` config with `fetch-depth: 1`). Production observation on zccache MSRV (run 26799669322):
```
parent-sha: unexpected git output "\n"; leaving empty
cook: layered keys ... (no parent-fallback — parentSha unavailable, #365)
cook-cache-delta MISS
```

`git log -1 --format=%P HEAD` returns empty for grafted root commits on shallow clones. v0.9.56 adds a `git cat-file -p HEAD` fallback that parses the raw commit object — its `parent` header line is preserved even when the parent commit isn't fetched. This finally activates the cook-cache-delta / target-cache / cargo-registry parent-SHA fallback restore keys.

## Test plan
- [ ] CI green
- [ ] Log shows `parent-sha: derived <sha> from cat-file (#365, shallow-safe)`
- [ ] `cook: layered keys ... delta-fallback=cook-delta-v2-...-g<parent-sha>` appears
- [ ] Second commit after this lands: cook-cache-delta should HIT against this commit's saved entry
