### PR TITLE
ci: bump setup-soldr v0.9.56 -> v0.9.57

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.56
+      - uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.56
+        uses: zackees/setup-soldr@v0.9.57
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.56` to `v0.9.57`.

## What's in v0.9.57 — major perf win
Adds `cook-base-v2-` to `FOUNDATION_PREFIXES` so setup-soldr's controlled eviction skips cook-cache-base entries. Closes setup-soldr#368.

Production evidence on zccache:
- 08:17 UTC: cook-cache-base HIT (key `cook-base-v2-linux-x64-glibc-rustc1.94.1-fnone-l92559307b22cc1be-soldrv0.7.51`)
- 08:38 UTC: same lockfile hash on child commit — base **MISS** (evicted in 21 minutes by our own graduated age floor)

Cost of MISS: ~200s of cold cargo cook per affected job. With this change, the same base survives across commits and CI cycles.

GitHub's own LRU continues evicting truly-stale cook-base entries (~7 days unused), so unbounded growth is bounded. Worst case ~7 platforms × 300 MB = ~2.1 GB foundation footprint.

## Test plan
- [ ] CI green
- [ ] Cook-cache-base HIT rate climbs to >50% on consecutive commits with same lockfile
- [ ] Post-step eviction log shows cook-base entries protected from self-eviction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use the latest version of the setup action across all automation pipelines, including acceptance tests, benchmarks, platform checks, linting, formatting, documentation builds, and template builds. This ensures consistent tooling and access to recent improvements across the build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->