### PR TITLE
ci: bump setup-soldr v0.9.57 -> v0.9.59

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.57
+      - uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.57
+        uses: zackees/setup-soldr@v0.9.59
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.57` to `v0.9.59`.

## What's in v0.9.58–v0.9.59
- **v0.9.58** — Eviction log splits foundation-protected vs age-floor-protected counts (diagnostic).
- **v0.9.59** — **PERF**: drops git SHA from cargo-registry cache key (closes setup-soldr#371). Same anti-pattern fix as #237 did for build-cache. Production-observed: every commit's cargo-registry exact-key probe missed (only matched same-SHA retries), and the action burned ~56 MB upload bandwidth saving a new entry that no future probe could hit. After this fix, exact-key hit rate climbs to ~100% per (lockHash, digest) generation, save status flips to `skipped-race` for subsequent matrix jobs, and per-CI-cycle redundant uploads drop by ~50 MB × matrix-job-count.

## Test plan
- [ ] CI green
- [ ] cargo-registry log shows `HIT` instead of `FALLBACK` on subsequent commits with same lockHash
- [ ] Per-layer save table shows cargo-registry status flipping to `skipped-race` for jobs after the first save


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and build infrastructure components across multiple continuous integration workflows to ensure compatibility and access to latest improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->