### PR TITLE
Fix compile-many cache sharing and failure diagnostics

### DIFF
--- a/crates/fbuild-build/src/compile_many.rs
+++ b/crates/fbuild-build/src/compile_many.rs
@@ -20,8 +20,9 @@
 //!   workers. Each worker reuses the framework / library archives written
 //!   to disk by stage 1 (via the orchestrator's warm-build fast path and
 //!   zccache), and only pays for `sketch.cpp -> .o -> link` per sketch.
-//!   Each worker calls the orchestrator with `jobs = 1` since per-sketch
-//!   work is small and the outer thread pool already saturates cores.
+//!   Stage 2 splits the host's compile budget across the worker pool so
+//!   a cold per-sketch framework fallback can still make progress without
+//!   oversubscribing the machine.
 //!
 //! ## Concurrent-safety
 //!
@@ -223,6 +224,8 @@ pub struct CompileManyRequest {
     /// `BuildParams.pio_env`. Empty by default. Used by `fbuild ci` to
     /// surface `--lib` / `--project-conf` to the underlying orchestrator.
     pub pio_env: HashMap<String, String>,
+    /// Emit per-stage-2 worker diagnostics in the final result.
+    pub diag_stage2: bool,
 }
 
 /// Result for a single sketch.
@@ -246,6 +249,13 @@ pub struct SketchResult {
     pub message: String,
     /// Stage that produced this result.
     pub stage: Stage,
+    /// Stage-2 worker index, when this sketch was built by stage 2.
+    pub worker_index: Option<usize>,
+    /// Stage-2 framework seed wall-clock seconds. Zero for stage 1 and
+    /// stage-2 runs where seeding was unnecessary.
+    pub seed_time_secs: f64,
+    /// Whether the stage-2 core seed source existed for this sketch.
+    pub seed_applied: bool,
 }
 
 /// Which stage compiled a sketch.
@@ -397,6 +407,9 @@ fn build_one_sketch(inputs: SketchBuildInputs) -> SketchResult {
                 log_path,
                 message,
                 stage,
+                worker_index: None,
+                seed_time_secs: 0.0,
+                seed_applied: false,
             }
         }
         Err(e) => SketchResult {
@@ -409,6 +422,9 @@ fn build_one_sketch(inputs: SketchBuildInputs) -> SketchResult {
             log_path: None,
             message: format!("build error: {}", e),
             stage,
+            worker_index: None,
+            seed_time_secs: 0.0,
+            seed_applied: false,
         },
     }
 }
@@ -577,6 +593,7 @@ pub fn compile_many_with(
             &req.pio_env,
             stage1_core_seed.as_deref(),
             &stage1_env,
+            req.diag_stage2,
         )
     };
     let stage2_secs = stage2_start.elapsed().as_secs_f64();
@@ -620,6 +637,7 @@ fn run_stage2(
     pio_env: &HashMap<String, String>,
     stage1_core_seed: Option<&Path>,
     stage1_env: &str,
+    diag_stage2: bool,
 ) -> Vec<SketchResult> {
     let total = rest.len();
     let cap = sketch_jobs.min(total).max(1);
@@ -644,7 +662,7 @@ fn run_stage2(
 
     std::thread::scope(|scope| {
         let handles: Vec<_> = (0..cap)
-            .map(|_| {
+            .map(|worker_index| {
                 let next = &next;
                 let results_slot = &results_slot;
                 scope.spawn(move || loop {
@@ -661,10 +679,13 @@ fn run_stage2(
                     // board across many FastLED examples). Errors are
                     // logged and ignored — orchestrator falls back to a
                     // full framework recompile, no worse than pre-#335.
+                    let seed_started = Instant::now();
+                    let mut seed_applied = false;
                     if let Some(seed) = stage1_core_seed {
                         if env_name == stage1_env {
                             let target_core =
                                 project_build_dir(sketch, env_name, profile).join("core");
+                            seed_applied = seed.is_dir();
                             if let Err(e) = seed_stage2_core_from_stage1(seed, &target_core) {
                                 tracing::warn!(
                                     "compile-many stage 2: failed to seed core/ \
@@ -676,7 +697,8 @@ fn run_stage2(
                             }
                         }
                     }
-                    let res = builder.build(SketchBuildInputs {
+                    let seed_time_secs = seed_started.elapsed().as_secs_f64();
+                    let mut res = builder.build(SketchBuildInputs {
                         sketch: sketch.clone(),
                         env_name: env_name.clone(),
                         platform,
@@ -686,6 +708,22 @@ fn run_stage2(
                         stage: Stage::Stage2Sketch,
                         pio_env: pio_env.clone(),
                     });
+                    res.worker_index = Some(worker_index);
+                    res.seed_time_secs = seed_time_secs;
+                    res.seed_applied = seed_applied;
+                    if diag_stage2 {
+                        tracing::info!(
+                            "compile-many stage2 diag worker={} index={} sketch={} env={} seed_applied={} seed_secs={:.6} build_secs={:.6} success={}",
+                            worker_index,
+                            idx,
+                            sketch.display(),
+                            env_name,
+                            seed_applied,
+                            seed_time_secs,
+                            res.build_time_secs,
+                            res.success
+                        );
+                    }
                     *results_slot[idx].lock().unwrap() = Some(res);
                 })
             })
@@ -847,6 +885,7 @@ mod tests {
             profile: BuildProfile::Release,
             verbose: false,
             pio_env: HashMap::new(),
+            diag_stage2: false,
         };
         assert!(compile_many(req).is_err());
     }
@@ -863,6 +902,7 @@ mod tests {
             profile: BuildProfile::Release,
             verbose: false,
             pio_env: HashMap::new(),
+            diag_stage2: false,
         };
         assert!(compile_many(req).is_err());
     }
@@ -883,6 +923,7 @@ mod tests {
             profile: BuildProfile::Release,
             verbose: false,
             pio_env: HashMap::new(),
+            diag_stage2: false,
         };
         assert!(compile_many(req).is_err());
     }

--- a/crates/fbuild-build/src/esp32/orchestrator/build.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator/build.rs
@@ -597,6 +597,42 @@ impl BuildOrchestrator for Esp32Orchestrator {
 
         // Compile core + variant sources in parallel
         let build_log_mutex = std::sync::Mutex::new(ctx.build_log);
+        let core_cache = if params.clean {
+            None
+        } else {
+            Some(crate::framework_core_cache::FrameworkCoreCache::new(
+                &params.project_dir,
+                "esp32",
+                &params.env_name,
+                params.profile,
+                &compiler,
+                &all_core_sources,
+                &user_overlay,
+            ))
+        };
+        if let Some(cache) = core_cache.as_ref() {
+            let _g = perf.phase("core-cache-hydrate");
+            match cache.hydrate(core_build_dir) {
+                Ok(stats) if stats.copied > 0 || stats.skipped > 0 => tracing::info!(
+                    "framework core cache hydrate key={} copied={} skipped={} from {}",
+                    cache.key(),
+                    stats.copied,
+                    stats.skipped,
+                    cache.path().display()
+                ),
+                Ok(_) => tracing::debug!(
+                    "framework core cache miss key={} at {}",
+                    cache.key(),
+                    cache.path().display()
+                ),
+                Err(e) => tracing::warn!(
+                    "framework core cache hydrate failed key={} at {}: {}",
+                    cache.key(),
+                    cache.path().display(),
+                    e
+                ),
+            }
+        }
         let core_result = {
             let _g = perf.phase("compile-core-variant");
             crate::parallel::compile_sources_parallel(
@@ -608,6 +644,27 @@ impl BuildOrchestrator for Esp32Orchestrator {
                 Some(&build_log_mutex),
             )?
         };
+        if let Some(cache) = core_cache.as_ref() {
+            let _g = perf.phase("core-cache-store");
+            match cache.store(core_build_dir) {
+                Ok(stats) if stats.copied > 0 => tracing::info!(
+                    "framework core cache store key={} copied={} to {}",
+                    cache.key(),
+                    stats.copied,
+                    cache.path().display()
+                ),
+                Ok(_) => tracing::debug!(
+                    "framework core cache store key={} had no new artifacts",
+                    cache.key()
+                ),
+                Err(e) => tracing::warn!(
+                    "framework core cache store failed key={} at {}: {}",
+                    cache.key(),
+                    cache.path().display(),
+                    e
+                ),
+            }
+        }
 
         // Compile sketch sources in parallel
         let sketch_result = {

--- a/crates/fbuild-build/src/framework_core_cache.rs
+++ b/crates/fbuild-build/src/framework_core_cache.rs
@@ -1,0 +1,403 @@
+//! Cross-run framework core artifact cache.
+//!
+//! Per-project `core/` build directories are intentionally local to a project,
+//! but CI wants the expensive framework objects to survive across runs. This
+//! module stores only the reusable core artifacts under
+//! `~/.fbuild/{dev|prod}/cache/core/<hash>/` and hydrates project `core/` dirs
+//! before normal incremental rebuild checks run.
+
+use std::path::{Path, PathBuf};
+
+use fbuild_core::BuildProfile;
+use sha2::{Digest, Sha256};
+
+use crate::compiler::Compiler;
+use crate::flag_overlay::LanguageExtraFlags;
+
+const CORE_CACHE_VERSION: &str = "fbuild-core-artifacts-v1";
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ArtifactCopyStats {
+    pub copied: usize,
+    pub skipped: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct FrameworkCoreCache {
+    key: String,
+    path: PathBuf,
+}
+
+impl FrameworkCoreCache {
+    pub fn new(
+        project_dir: &Path,
+        platform_label: &str,
+        env_name: &str,
+        profile: BuildProfile,
+        compiler: &dyn Compiler,
+        core_sources: &[PathBuf],
+        extra_flags: &LanguageExtraFlags,
+    ) -> Self {
+        let key = core_cache_key(
+            platform_label,
+            env_name,
+            profile,
+            compiler,
+            core_sources,
+            extra_flags,
+        );
+        let path = fbuild_packages::Cache::new(project_dir)
+            .core_artifacts_dir()
+            .join(&key);
+        Self { key, path }
+    }
+
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn hydrate(&self, core_build_dir: &Path) -> std::io::Result<ArtifactCopyStats> {
+        if !self.path.is_dir() {
+            return Ok(ArtifactCopyStats::default());
+        }
+        copy_artifacts(&self.path, core_build_dir, false)
+    }
+
+    pub fn store(&self, core_build_dir: &Path) -> std::io::Result<ArtifactCopyStats> {
+        if !core_build_dir.is_dir() {
+            return Ok(ArtifactCopyStats::default());
+        }
+        std::fs::create_dir_all(&self.path)?;
+        copy_artifacts(core_build_dir, &self.path, true)
+    }
+}
+
+fn core_cache_key(
+    platform_label: &str,
+    env_name: &str,
+    profile: BuildProfile,
+    compiler: &dyn Compiler,
+    core_sources: &[PathBuf],
+    extra_flags: &LanguageExtraFlags,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(CORE_CACHE_VERSION.as_bytes());
+    hasher.update([0]);
+    hasher.update(env!("CARGO_PKG_VERSION").as_bytes());
+    hasher.update([0]);
+    hasher.update(platform_label.as_bytes());
+    hasher.update([0]);
+    hasher.update(env_name.as_bytes());
+    hasher.update([0]);
+    hasher.update(profile.as_dir_name().as_bytes());
+    hasher.update([0]);
+
+    let mut source_entries: Vec<_> = core_sources
+        .iter()
+        .map(|source| {
+            let source_path = source.to_string_lossy().replace('\\', "/");
+            let source_flags = extra_flags.for_source(source);
+            let signature = compiler.rebuild_signature(source, &source_flags);
+            let content = file_content_digest(source);
+            (source_path, signature, content)
+        })
+        .collect();
+    source_entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (source_path, signature, content) in source_entries {
+        hasher.update(source_path.as_bytes());
+        hasher.update([0]);
+        hasher.update(signature.as_bytes());
+        hasher.update([0]);
+        hasher.update(content.as_bytes());
+        hasher.update([0xff]);
+    }
+
+    format!("{:x}", hasher.finalize())
+}
+
+fn file_content_digest(path: &Path) -> String {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let mut hasher = Sha256::new();
+            hasher.update(bytes);
+            format!("sha256:{:x}", hasher.finalize())
+        }
+        Err(e) => format!("unreadable:{}", e.kind()),
+    }
+}
+
+fn copy_artifacts(
+    src_dir: &Path,
+    dst_dir: &Path,
+    overwrite: bool,
+) -> std::io::Result<ArtifactCopyStats> {
+    std::fs::create_dir_all(dst_dir)?;
+    let mut stats = ArtifactCopyStats::default();
+    for entry in std::fs::read_dir(src_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let src = entry.path();
+        if !is_core_artifact(&src) {
+            continue;
+        }
+        let dst = dst_dir.join(entry.file_name());
+        if dst.exists() {
+            if !overwrite {
+                stats.skipped += 1;
+                continue;
+            }
+            std::fs::remove_file(&dst)?;
+        }
+        copy_preserving_mtime(&src, &dst)?;
+        stats.copied += 1;
+    }
+    Ok(stats)
+}
+
+fn is_core_artifact(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("o" | "d" | "cmdhash")
+    )
+}
+
+fn copy_preserving_mtime(src: &Path, dst: &Path) -> std::io::Result<u64> {
+    let bytes = std::fs::copy(src, dst)?;
+    if let (Ok(meta), Ok(file)) = (
+        src.metadata(),
+        std::fs::File::options().write(true).open(dst),
+    ) {
+        if let Ok(mtime) = meta.modified() {
+            let _ = file.set_modified(mtime);
+        }
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::{CompileResult, Compiler};
+
+    struct FakeCompiler {
+        gcc: PathBuf,
+        gxx: PathBuf,
+    }
+
+    impl FakeCompiler {
+        fn new() -> Self {
+            Self {
+                gcc: PathBuf::from("/toolchain/bin/gcc"),
+                gxx: PathBuf::from("/toolchain/bin/g++"),
+            }
+        }
+    }
+
+    impl Compiler for FakeCompiler {
+        fn compile_one(
+            &self,
+            _compiler_path: &Path,
+            _source: &Path,
+            output: &Path,
+            _flags: &[String],
+            _extra_flags: &[String],
+        ) -> fbuild_core::Result<CompileResult> {
+            Ok(CompileResult {
+                success: true,
+                object_file: output.to_path_buf(),
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: 0,
+            })
+        }
+
+        fn gcc_path(&self) -> &Path {
+            &self.gcc
+        }
+
+        fn gxx_path(&self) -> &Path {
+            &self.gxx
+        }
+
+        fn c_flags(&self) -> Vec<String> {
+            vec!["-Os".to_string()]
+        }
+
+        fn cpp_flags(&self) -> Vec<String> {
+            vec!["-Os".to_string(), "-std=gnu++17".to_string()]
+        }
+
+        fn rebuild_signature(&self, source: &Path, extra_flags: &[String]) -> String {
+            let mut hasher = Sha256::new();
+            hasher.update(source.to_string_lossy().as_bytes());
+            for flag in extra_flags {
+                hasher.update([0]);
+                hasher.update(flag.as_bytes());
+            }
+            format!("{:x}", hasher.finalize())
+        }
+    }
+
+    #[test]
+    fn key_changes_when_source_flags_change() {
+        let compiler = FakeCompiler::new();
+        let sources = vec![PathBuf::from("/framework/core/main.cpp")];
+        let plain = LanguageExtraFlags {
+            common: Vec::new(),
+            c: Vec::new(),
+            cxx: Vec::new(),
+            asm: Vec::new(),
+        };
+        let flagged = LanguageExtraFlags {
+            common: vec!["-DARDUINO=10819".to_string()],
+            c: Vec::new(),
+            cxx: Vec::new(),
+            asm: Vec::new(),
+        };
+        let a = core_cache_key(
+            "avr",
+            "uno",
+            BuildProfile::Release,
+            &compiler,
+            &sources,
+            &plain,
+        );
+        let b = core_cache_key(
+            "avr",
+            "uno",
+            BuildProfile::Release,
+            &compiler,
+            &sources,
+            &flagged,
+        );
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn key_is_independent_of_source_order() {
+        let compiler = FakeCompiler::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let a_source = tmp.path().join("a.cpp");
+        let b_source = tmp.path().join("b.cpp");
+        std::fs::write(&a_source, b"a").unwrap();
+        std::fs::write(&b_source, b"b").unwrap();
+        let plain = LanguageExtraFlags {
+            common: Vec::new(),
+            c: Vec::new(),
+            cxx: Vec::new(),
+            asm: Vec::new(),
+        };
+
+        let a = core_cache_key(
+            "avr",
+            "uno",
+            BuildProfile::Release,
+            &compiler,
+            &[a_source.clone(), b_source.clone()],
+            &plain,
+        );
+        let b = core_cache_key(
+            "avr",
+            "uno",
+            BuildProfile::Release,
+            &compiler,
+            &[b_source, a_source],
+            &plain,
+        );
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn key_changes_when_source_content_changes() {
+        let compiler = FakeCompiler::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("main.cpp");
+        let plain = LanguageExtraFlags {
+            common: Vec::new(),
+            c: Vec::new(),
+            cxx: Vec::new(),
+            asm: Vec::new(),
+        };
+
+        std::fs::write(&source, b"first").unwrap();
+        let first = core_cache_key(
+            "avr",
+            "uno",
+            BuildProfile::Release,
+            &compiler,
+            std::slice::from_ref(&source),
+            &plain,
+        );
+        std::fs::write(&source, b"second").unwrap();
+        let second = core_cache_key(
+            "avr",
+            "uno",
+            BuildProfile::Release,
+            &compiler,
+            std::slice::from_ref(&source),
+            &plain,
+        );
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn hydrate_and_store_only_core_artifact_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let cache = FrameworkCoreCache::new(
+            &project,
+            "avr",
+            "uno",
+            BuildProfile::Release,
+            &FakeCompiler::new(),
+            &[PathBuf::from("/framework/core/main.cpp")],
+            &LanguageExtraFlags {
+                common: Vec::new(),
+                c: Vec::new(),
+                cxx: Vec::new(),
+                asm: Vec::new(),
+            },
+        );
+
+        let core = tmp.path().join("core");
+        std::fs::create_dir_all(&core).unwrap();
+        std::fs::write(core.join("main.cpp.o"), b"obj").unwrap();
+        std::fs::write(core.join("main.cpp.d"), b"dep").unwrap();
+        std::fs::write(core.join("main.cpp.cmdhash"), b"hash").unwrap();
+        std::fs::write(core.join("note.txt"), b"ignore").unwrap();
+
+        let stored = cache.store(&core).unwrap();
+        assert_eq!(stored.copied, 3);
+        assert!(cache.path().join("main.cpp.o").exists());
+        assert!(!cache.path().join("note.txt").exists());
+
+        let hydrated = tmp.path().join("hydrated");
+        let stats = cache.hydrate(&hydrated).unwrap();
+        assert_eq!(stats.copied, 3);
+        assert_eq!(std::fs::read(hydrated.join("main.cpp.o")).unwrap(), b"obj");
+    }
+
+    #[test]
+    fn hydrate_skips_existing_project_artifacts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dst = tmp.path().join("dst");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(src.join("main.cpp.o"), b"cache").unwrap();
+        std::fs::write(dst.join("main.cpp.o"), b"project").unwrap();
+
+        let stats = copy_artifacts(&src, &dst, false).unwrap();
+        assert_eq!(stats.copied, 0);
+        assert_eq!(stats.skipped, 1);
+        assert_eq!(std::fs::read(dst.join("main.cpp.o")).unwrap(), b"project");
+    }
+}

--- a/crates/fbuild-build/src/lib.rs
+++ b/crates/fbuild-build/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) mod eh_frame_policy_compute;
 pub mod esp32;
 pub mod esp8266;
 pub mod flag_overlay;
+pub mod framework_core_cache;
 pub mod framework_libs;
 pub mod generic_arm;
 pub mod linker;

--- a/crates/fbuild-build/src/pipeline/sequential.rs
+++ b/crates/fbuild-build/src/pipeline/sequential.rs
@@ -115,6 +115,43 @@ pub fn run_sequential_build_with_libs(
     let jobs = crate::parallel::effective_jobs(params.jobs);
     let build_log_mutex = std::sync::Mutex::new(ctx.build_log);
 
+    let core_cache = if params.clean {
+        None
+    } else {
+        Some(crate::framework_core_cache::FrameworkCoreCache::new(
+            &params.project_dir,
+            platform_label,
+            &params.env_name,
+            params.profile,
+            compiler,
+            &core_and_variant,
+            &user_overlay,
+        ))
+    };
+    if let Some(cache) = core_cache.as_ref() {
+        let _g = perf.phase("core-cache-hydrate");
+        match cache.hydrate(&ctx.core_build_dir) {
+            Ok(stats) if stats.copied > 0 || stats.skipped > 0 => tracing::info!(
+                "framework core cache hydrate key={} copied={} skipped={} from {}",
+                cache.key(),
+                stats.copied,
+                stats.skipped,
+                cache.path().display()
+            ),
+            Ok(_) => tracing::debug!(
+                "framework core cache miss key={} at {}",
+                cache.key(),
+                cache.path().display()
+            ),
+            Err(e) => tracing::warn!(
+                "framework core cache hydrate failed key={} at {}: {}",
+                cache.key(),
+                cache.path().display(),
+                e
+            ),
+        }
+    }
+
     // Compile core + variant
     let mut core_objects = {
         let _g = perf.phase("compile-core");
@@ -139,6 +176,27 @@ pub fn run_sequential_build_with_libs(
         )?
     };
     core_objects.extend(variant_objects);
+    if let Some(cache) = core_cache.as_ref() {
+        let _g = perf.phase("core-cache-store");
+        match cache.store(&ctx.core_build_dir) {
+            Ok(stats) if stats.copied > 0 => tracing::info!(
+                "framework core cache store key={} copied={} to {}",
+                cache.key(),
+                stats.copied,
+                cache.path().display()
+            ),
+            Ok(_) => tracing::debug!(
+                "framework core cache store key={} had no new artifacts",
+                cache.key()
+            ),
+            Err(e) => tracing::warn!(
+                "framework core cache store failed key={} at {}: {}",
+                cache.key(),
+                cache.path().display(),
+                e
+            ),
+        }
+    }
 
     // Compile sketch
     let sketch_objects = {

--- a/crates/fbuild-build/tests/compile_many_stage2_perf.rs
+++ b/crates/fbuild-build/tests/compile_many_stage2_perf.rs
@@ -68,6 +68,7 @@ fn stage2_per_sketch_wall_is_a_fraction_of_stage1() {
         profile: BuildProfile::Release,
         verbose: false,
         pio_env: Default::default(),
+        diag_stage2: true,
     };
 
     let result = compile_many(req).expect("compile_many should not error");

--- a/crates/fbuild-build/tests/compile_many_two_stage.rs
+++ b/crates/fbuild-build/tests/compile_many_two_stage.rs
@@ -147,6 +147,9 @@ impl SketchBuilder for MockBuilder {
             log_path: None,
             message: "mock build ok".to_string(),
             stage: inputs.stage,
+            worker_index: None,
+            seed_time_secs: 0.0,
+            seed_applied: false,
         }
     }
 }
@@ -164,6 +167,7 @@ fn make_request(
         profile: BuildProfile::Release,
         verbose: false,
         pio_env: std::collections::HashMap::new(),
+        diag_stage2: false,
     }
 }
 
@@ -314,6 +318,9 @@ fn stage1_failure_skips_stage2() {
                 log_path: None,
                 message: "mock failure".to_string(),
                 stage: inputs.stage,
+                worker_index: None,
+                seed_time_secs: 0.0,
+                seed_applied: false,
             }
         }
     }
@@ -419,4 +426,34 @@ fn stage2_jobs_per_worker_splits_cores_across_workers() {
         cores.max(1),
         "stage2_jobs_per_worker(0) must not panic and should treat 0 as 1"
     );
+}
+
+#[test]
+fn stage2_results_report_worker_and_seed_diagnostics() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sketches: Vec<PathBuf> = (0..4)
+        .map(|i| make_sketch(tmp.path(), &format!("diag{i}"), "uno"))
+        .collect();
+
+    let mock = MockBuilder::new();
+    let mut req = make_request(sketches, 1, 2);
+    req.diag_stage2 = true;
+    let result = compile_many_with(req, &mock).expect("compile_many");
+
+    let stage2: Vec<_> = result
+        .results
+        .iter()
+        .filter(|r| r.stage == Stage::Stage2Sketch)
+        .collect();
+    assert_eq!(stage2.len(), 3);
+    for r in stage2 {
+        assert!(
+            r.worker_index.is_some(),
+            "stage-2 result should report worker index"
+        );
+        assert!(
+            r.seed_time_secs >= 0.0,
+            "stage-2 result should report seed timing"
+        );
+    }
 }

--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -332,6 +332,9 @@ pub enum Commands {
         /// Verbose compiler output.
         #[arg(short, long)]
         verbose: bool,
+        /// Emit JSONL per stage-2 worker with seed/build timing.
+        #[arg(long)]
+        diag_stage2: bool,
         /// Sketch project directories (each must contain `platformio.ini`).
         #[arg(required = true)]
         sketches: Vec<String>,
@@ -375,6 +378,9 @@ pub enum Commands {
         /// Verbose compiler output.
         #[arg(short, long)]
         verbose: bool,
+        /// Emit JSONL per stage-2 worker with seed/build timing.
+        #[arg(long)]
+        diag_stage2: bool,
         /// Sketches to build. Each entry is either a project directory
         /// containing `platformio.ini` or a `.ino` file whose parent
         /// directory is the project. Matches `pio ci` positional args.

--- a/crates/fbuild-cli/src/cli/build.rs
+++ b/crates/fbuild-cli/src/cli/build.rs
@@ -63,6 +63,9 @@ pub async fn run_build(
     }
 
     let client = DaemonClient::new();
+    if verbose {
+        eprintln!("{}", daemon_client::runtime_diagnostic());
+    }
 
     let profile = if release {
         Some("release".to_string())
@@ -120,6 +123,9 @@ pub async fn run_build(
         eprintln!("{}", summary);
     }
     if !resp.success {
+        if !verbose {
+            eprintln!("{}", daemon_client::runtime_diagnostic());
+        }
         std::process::exit(resp.exit_code);
     }
     if generate_compiledb {

--- a/crates/fbuild-cli/src/cli/compile_many.rs
+++ b/crates/fbuild-cli/src/cli/compile_many.rs
@@ -84,6 +84,7 @@ pub struct CompileManyArgs {
     pub quick: bool,
     pub release: bool,
     pub verbose: bool,
+    pub diag_stage2: bool,
     pub sketches: Vec<String>,
     pub pio_env: std::collections::HashMap<String, String>,
 }
@@ -98,6 +99,7 @@ pub async fn run_compile_many(args: CompileManyArgs) -> fbuild_core::Result<()> 
         quick,
         release,
         verbose,
+        diag_stage2,
         sketches,
         pio_env,
     } = args;
@@ -123,6 +125,7 @@ pub async fn run_compile_many(args: CompileManyArgs) -> fbuild_core::Result<()> 
         profile,
         verbose,
         pio_env,
+        diag_stage2,
     };
 
     let effective_framework = req
@@ -180,6 +183,28 @@ pub async fn run_compile_many(args: CompileManyArgs) -> fbuild_core::Result<()> 
         result.stage2_secs,
         result.total_secs,
     );
+    if diag_stage2 {
+        for r in result
+            .results
+            .iter()
+            .filter(|r| r.stage == Stage::Stage2Sketch)
+        {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "type": "stage2",
+                    "worker": r.worker_index,
+                    "sketch": r.sketch.display().to_string(),
+                    "env": &r.env_name,
+                    "success": r.success,
+                    "seed_applied": r.seed_applied,
+                    "seed_secs": r.seed_time_secs,
+                    "build_secs": r.build_time_secs,
+                    "log": r.log_path.as_ref().map(|p| p.display().to_string()),
+                })
+            );
+        }
+    }
 
     if !result.all_success {
         return Err(fbuild_core::FbuildError::BuildFailed(format!(

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -317,6 +317,7 @@ pub async fn async_main() {
             quick,
             release,
             verbose,
+            diag_stage2,
             sketches,
         }) => {
             run_compile_many(CompileManyArgs {
@@ -326,6 +327,7 @@ pub async fn async_main() {
                 quick,
                 release,
                 verbose,
+                diag_stage2,
                 sketches,
                 pio_env: std::collections::HashMap::new(),
             })
@@ -342,6 +344,7 @@ pub async fn async_main() {
             quick,
             release,
             verbose,
+            diag_stage2,
             sketches,
         }) => {
             if let Some(bd) = &build_dir {
@@ -359,6 +362,7 @@ pub async fn async_main() {
                 quick,
                 release,
                 verbose,
+                diag_stage2,
                 sketches: normalized,
                 pio_env,
             })

--- a/crates/fbuild-cli/src/cli/tests.rs
+++ b/crates/fbuild-cli/src/cli/tests.rs
@@ -138,3 +138,22 @@ fn ci_quick_and_release_are_mutually_exclusive() {
     let argv = ["fbuild", "ci", "-b", "uno", "--quick", "--release", "."];
     assert!(Cli::try_parse_from(argv).is_err());
 }
+
+#[test]
+fn compile_many_diag_stage2_flag_is_accepted() {
+    let argv = [
+        "fbuild",
+        "compile-many",
+        "--board",
+        "uno",
+        "--diag-stage2",
+        "examples/Blink",
+    ];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::CompileMany { diag_stage2, .. }) => {
+            assert!(diag_stage2);
+        }
+        _ => panic!("expected CompileMany subcommand"),
+    }
+}

--- a/crates/fbuild-cli/src/daemon_client.rs
+++ b/crates/fbuild-cli/src/daemon_client.rs
@@ -185,6 +185,37 @@ pub fn capture_pio_env() -> BTreeMap<String, String> {
         .collect()
 }
 
+pub fn runtime_diagnostic() -> String {
+    let exe = std::env::current_exe()
+        .ok()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let daemon_exe = daemon_executable_hint();
+    format!(
+        "fbuild executable: {}\nfbuild version: {}\nfbuild-daemon executable: {}\ndaemon endpoint: {}",
+        exe,
+        env!("CARGO_PKG_VERSION"),
+        daemon_exe,
+        fbuild_paths::get_daemon_url()
+    )
+}
+
+fn daemon_executable_hint() -> String {
+    let Some(parent) = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    else {
+        return "fbuild-daemon".to_string();
+    };
+    let stem = parent.join("fbuild-daemon");
+    for candidate in [stem.clone(), stem.with_extension("exe")] {
+        if candidate.exists() {
+            return candidate.display().to_string();
+        }
+    }
+    "fbuild-daemon".to_string()
+}
+
 #[derive(Debug, Deserialize)]
 pub struct OperationResponse {
     pub success: bool,

--- a/crates/fbuild-daemon/src/handlers/operations/build.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/build.rs
@@ -305,6 +305,16 @@ pub async fn build(
 
             let _ = bridge.await;
 
+            if !success && !msg.is_empty() {
+                let log_event = serde_json::json!({
+                    "type": "log",
+                    "message": msg,
+                });
+                let mut chunk = log_event.to_string();
+                chunk.push('\n');
+                let _ = async_tx.send(bytes::Bytes::from(chunk));
+            }
+
             let result_event = serde_json::json!({
                 "type": "result",
                 "success": success,

--- a/crates/fbuild-daemon/tests/build_streaming.rs
+++ b/crates/fbuild-daemon/tests/build_streaming.rs
@@ -1,0 +1,100 @@
+//! Streaming build endpoint regression tests.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::routing::post;
+use axum::Router;
+use fbuild_daemon::context::DaemonContext;
+use fbuild_daemon::handlers::operations;
+
+fn build_test_app(ctx: Arc<DaemonContext>) -> Router {
+    Router::new()
+        .route("/api/build", post(operations::build))
+        .with_state(ctx)
+}
+
+fn make_test_context() -> Arc<DaemonContext> {
+    let (tx, _rx) = tokio::sync::watch::channel(false);
+    Arc::new(DaemonContext::new(
+        0,
+        tx,
+        "build-streaming-test".to_string(),
+    ))
+}
+
+async fn spawn_test_server(ctx: Arc<DaemonContext>) -> SocketAddr {
+    let app = build_test_app(ctx);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("axum::serve should not fail in test");
+    });
+    addr
+}
+
+#[tokio::test]
+async fn streaming_build_failure_emits_log_before_result() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("platformio.ini"),
+        "[env:bad]\nplatform = ststm32\nboard = definitely_unknown_board\nframework = arduino\n",
+    )
+    .unwrap();
+
+    let ctx = make_test_context();
+    let addr = spawn_test_server(ctx).await;
+    let body = serde_json::json!({
+        "project_dir": tmp.path().display().to_string(),
+        "environment": "bad",
+        "stream": true,
+        "verbose": false,
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{}/api/build", addr))
+        .json(&body)
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await
+        .expect("POST /api/build should not drop the connection");
+
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let text = resp.text().await.expect("read NDJSON body");
+    let events: Vec<serde_json::Value> = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("valid NDJSON event"))
+        .collect();
+
+    let log_index = events
+        .iter()
+        .position(|event| {
+            event.get("type").and_then(|v| v.as_str()) == Some("log")
+                && event
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|msg| msg.contains("build error:"))
+        })
+        .expect("stream should include a build-error log event");
+    let result_index = events
+        .iter()
+        .position(|event| event.get("type").and_then(|v| v.as_str()) == Some("result"))
+        .expect("stream should include a final result event");
+
+    assert!(
+        log_index < result_index,
+        "failure log must precede result event; events={events:?}"
+    );
+    assert_eq!(
+        events[result_index]
+            .get("success")
+            .and_then(|v| v.as_bool()),
+        Some(false)
+    );
+}

--- a/crates/fbuild-packages/src/cache.rs
+++ b/crates/fbuild-packages/src/cache.rs
@@ -7,6 +7,7 @@
 //!   toolchains/{stem}/{hash}/{version}/
 //!   platforms/{stem}/{hash}/{version}/
 //!   libraries/{stem}/{hash}/{version}/
+//!   core/{hash}/
 //!
 //! <project>/.fbuild/build/{env}/{profile}/
 //!   core/   (compiled core .o files)
@@ -61,6 +62,10 @@ impl Cache {
 
     pub fn libraries_dir(&self) -> PathBuf {
         self.cache_root.join("libraries")
+    }
+
+    pub fn core_artifacts_dir(&self) -> PathBuf {
+        self.cache_root.join("core")
     }
 
     // --- Package path resolution (stem/hash) ---
@@ -128,6 +133,7 @@ impl Cache {
         std::fs::create_dir_all(self.toolchains_dir())?;
         std::fs::create_dir_all(self.platforms_dir())?;
         std::fs::create_dir_all(self.libraries_dir())?;
+        std::fs::create_dir_all(self.core_artifacts_dir())?;
         Ok(())
     }
 

--- a/crates/fbuild-packages/src/lib.rs
+++ b/crates/fbuild-packages/src/lib.rs
@@ -18,9 +18,12 @@ pub use cache::Cache;
 pub use disk_cache::DiskCache;
 pub use lnk::{ExtractMode, LnkFile};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+static PACKAGE_TOUCHES: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 /// Recursively compute the total size of a directory in bytes.
 ///
@@ -269,6 +272,11 @@ impl PackageBase {
     fn touch_disk_cache(&self) {
         if let Some(ref dc) = self.disk_cache {
             let kind = self.cache_subdir.into();
+            let touch_key =
+                package_touch_key(kind, &self.cache_key, &self.version, &self.install_path());
+            if !mark_package_touch_needed(touch_key) {
+                return;
+            }
             if let Ok(Some(entry)) = dc.lookup(kind, &self.cache_key, &self.version) {
                 let _ = dc.touch(&entry);
             }
@@ -387,6 +395,34 @@ impl PackageBase {
     }
 }
 
+fn package_touch_key(
+    kind: disk_cache::Kind,
+    cache_key: &str,
+    version: &str,
+    install_path: &Path,
+) -> String {
+    format!(
+        "{}|{}|{}|{}",
+        kind.as_str(),
+        cache_key,
+        version,
+        install_path.display()
+    )
+}
+
+fn mark_package_touch_needed(key: String) -> bool {
+    let touched = PACKAGE_TOUCHES.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut touched = touched.lock().unwrap();
+    touched.insert(key)
+}
+
+#[cfg(test)]
+fn clear_package_touch_cache_for_tests() {
+    if let Some(touched) = PACKAGE_TOUCHES.get() {
+        touched.lock().unwrap().clear();
+    }
+}
+
 #[cfg(test)]
 mod toolchain_gcc_ar_tests {
     use super::*;
@@ -470,5 +506,50 @@ mod toolchain_gcc_ar_tests {
 
         let tc = TestToolchain { ar_path: ar };
         assert_eq!(tc.get_gcc_ar_path(), gcc_ar);
+    }
+
+    #[test]
+    fn package_cache_hit_touch_is_throttled_per_process() {
+        clear_package_touch_cache_for_tests();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache_root = tmp.path().join("cache");
+        let cache_key = "https://example.com/tool.tar.gz";
+        let base = PackageBase::with_cache_root(
+            "tool",
+            "1.0",
+            cache_key,
+            cache_key,
+            None,
+            CacheSubdir::Toolchains,
+            tmp.path(),
+            &cache_root,
+        );
+        let install_path = base.install_path();
+        std::fs::create_dir_all(&install_path).unwrap();
+
+        let disk_cache = DiskCache::open_at(&cache_root).unwrap();
+        let rel_path = install_path.strip_prefix(disk_cache.cache_root()).unwrap();
+        disk_cache
+            .record_install(
+                disk_cache::Kind::Toolchains,
+                cache_key,
+                "1.0",
+                &rel_path.to_string_lossy(),
+                1,
+            )
+            .unwrap();
+
+        assert!(base.is_cached());
+        assert!(base.is_cached());
+
+        let entry = disk_cache
+            .lookup(disk_cache::Kind::Toolchains, cache_key, "1.0")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            entry.use_count, 1,
+            "repeated cache hits for the same package should not repeatedly write the index"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add a content-addressed framework core artifact cache under the fbuild cache root and hydrate/store core artifacts for sequential platforms and ESP32
- throttle repeated package cache hit touches so compile-many stage-2 workers stop repeatedly writing the same SQLite cache index entries
- add `--diag-stage2` for per-worker stage-2 seed/build timing JSON lines
- stream early build failures as log events before the final result and print fbuild/daemon runtime diagnostics on verbose or failed CLI builds

Closes #335
Closes #341
Closes #361
Closes #362
Closes #364

## Tests

- `cargo test -p fbuild-packages`
- `cargo test -p fbuild-build --lib`
- `cargo test -p fbuild-build --test compile_many_two_stage -- --nocapture`
- `cargo test -p fbuild-build --test compile_many_stage2_perf`
- `cargo test -p fbuild-cli`
- `cargo test -p fbuild-daemon`
- `cargo check --workspace --all-targets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--diag-stage2` flag to `compile-many` and `ci` commands for enhanced worker diagnostics and timing information.
  * Implemented framework core artifact caching to accelerate subsequent rebuilds.

* **Improvements**
  * Enhanced build diagnostics output with worker-level and seed timing data.
  * Optimized package cache operations to reduce repeated disk updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->