### PR TITLE
ci: bump setup-soldr v0.9.61 -> v0.9.62

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
-      - uses: zackees/setup-soldr@v0.9.61
+      - uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           toolchain: 1.94.1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           # cache-preset: foundation expands to:
           #   build-cache: true, target-cache: false,

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup soldr
         id: setup-soldr
-        uses: zackees/setup-soldr@v0.9.61
+        uses: zackees/setup-soldr@v0.9.62
         with:
           cache: true
           build-cache: true


### PR DESCRIPTION
## Summary
Bump `zackees/setup-soldr` from `v0.9.61` to `v0.9.62`.

## What's in v0.9.62 — perf win
Drops per-job suffix from cargo-registry cache key (closes setup-soldr#375).

cargo-registry content is `$CARGO_HOME/registry/` + `.global-cache` + `git/` — keyed on Cargo.lock content, identical across matrix jobs (check, test, doc, msrv all download the same crates). Per-job suffix made each job save its own ~56 MB copy.

Production observation on zccache 9-job matrix: ~500 MB redundant uploads per CI cycle. After this fix: first job saves, rest exact-HIT (was FALLBACK with redundant save).

Mirrors #371 (drop SHA from same key) and #237 (drop SHA from build-cache). build-cache KEEPS suffix because target/ content differs per job; cargo-registry does not.

## Test plan
- [ ] CI green
- [ ] First cache-saving job in matrix shows cargo-registry SAVED; subsequent jobs show SKIPPED-RACE (instead of FALLBACK+SAVED)
- [ ] Aggregate cargo-registry uploads per CI cycle drops from ~500 MB to ~56 MB
