### PR TITLE
Fix response-file quoting for nRF52 BSP version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.14"
+version = "2.2.15"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.14"
+version = "2.2.15"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/fbuild-build/src/compiler_tests.rs
+++ b/crates/fbuild-build/src/compiler_tests.rs
@@ -208,6 +208,20 @@ fn test_prepare_flags_and_response_file_produce_same_define_value() {
 }
 
 #[test]
+fn test_response_file_preserves_bare_quoted_define_value() {
+    // nRF52 MCU config provides ARDUINO_BSP_VERSION as a bare quoted JSON
+    // value. Windows response files must preserve those quotes, otherwise
+    // GCC sees 1.6.1 as a numeric token and fails with "too many decimal
+    // points in number" in Adafruit nRF52 debug.cpp.
+    let input = r#"-DARDUINO_BSP_VERSION="1.6.1""#.to_string();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let rsp = write_response_file(&[input], tmp.path(), "test").unwrap();
+    let content = std::fs::read_to_string(rsp).unwrap();
+    assert_eq!(content, r#"'-DARDUINO_BSP_VERSION="1.6.1"'"#);
+}
+
+#[test]
 fn test_response_file_dir_prefers_output_sibling_tmp() {
     let output = Path::new("C:/work/build/src/main.cpp.o");
     let fallback = Path::new("C:/temp");

--- a/crates/fbuild-core/src/response_file.rs
+++ b/crates/fbuild-core/src/response_file.rs
@@ -121,9 +121,9 @@ pub fn replace_path_backslashes(s: &str) -> String {
 ///
 /// Returns the path to the response file.
 ///
-/// Flags containing `\"` (escaped quotes in define values) are wrapped in
-/// single quotes with `\"` converted to plain `"` — GCC's response file
-/// parser always preserves literal `"` inside single-quoted arguments.
+/// Flags containing either `\"` or bare `"` in define values are wrapped in
+/// single quotes with `\"` converted to plain `"`. GCC's response file
+/// parser preserves literal `"` inside single-quoted arguments.
 pub fn write_response_file(flags: &[String], temp_dir: &Path, prefix: &str) -> Result<PathBuf> {
     std::fs::create_dir_all(temp_dir).map_err(|e| {
         crate::FbuildError::BuildFailed(format!(
@@ -139,21 +139,25 @@ pub fn write_response_file(flags: &[String], temp_dir: &Path, prefix: &str) -> R
     // but preserve \" sequences which are intentional escape sequences (e.g., in
     // -DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\").
     //
-    // Flags containing \" (escaped quotes in define values like -DARDUINO_BOARD=\"...\")
-    // must be wrapped in single quotes with the \" converted to plain " — GCC's
-    // response file parser treats \" inconsistently across platforms, but single-quoted
-    // arguments always preserve literal " characters.
+    // Flags containing quoted define values need single-quote wrapping. Some
+    // define sources use escaped quotes (-DFOO=\"bar\"), while data-driven MCU
+    // configs can contain bare quotes (-DFOO="bar"). Normalize both forms to
+    // the response-file spelling GCC preserves as a string literal.
     let content = flags
         .iter()
         .map(|f| {
             let fwd = replace_path_backslashes(f);
-            if fwd.contains("\\\"") {
-                let unescaped = fwd.replace("\\\"", "\"");
-                format!("'{}'", unescaped)
-            } else if fwd.contains(' ') {
-                format!("\"{}\"", fwd)
+            let normalized = if fwd.contains("\\\"") {
+                fwd.replace("\\\"", "\"")
             } else {
                 fwd
+            };
+            if normalized.contains('"') {
+                format!("'{}'", normalized)
+            } else if normalized.contains(' ') {
+                format!("\"{}\"", normalized)
+            } else {
+                normalized
             }
         })
         .collect::<Vec<_>>()
@@ -230,6 +234,32 @@ mod tests {
         let second = write_response_file(&["-O3".to_string()], tmp.path(), "stable").unwrap();
 
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn test_write_response_file_wraps_escaped_quote_defines() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rsp = write_response_file(
+            &[r#"-DARDUINO_BOARD=\"ESP32_DEV\""#.to_string()],
+            tmp.path(),
+            "define",
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(rsp).unwrap();
+        assert_eq!(content, r#"'-DARDUINO_BOARD="ESP32_DEV"'"#);
+    }
+
+    #[test]
+    fn test_write_response_file_wraps_bare_quote_defines() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rsp = write_response_file(
+            &[r#"-DARDUINO_BSP_VERSION="1.6.1""#.to_string()],
+            tmp.path(),
+            "define",
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(rsp).unwrap();
+        assert_eq!(content, r#"'-DARDUINO_BSP_VERSION="1.6.1"'"#);
     }
 
     #[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.14"
+version = "2.2.15"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- preserve bare quoted define values in GCC response files, including `-DARDUINO_BSP_VERSION=1.6.1`
- keep escaped quoted define values normalized to literal quotes inside single-quoted response-file args
- bump fbuild to 2.2.15 for the FastLED nRF52 cascade release

## Verification
- `soldr cargo fmt --all`
- `soldr cargo test -p fbuild-core response_file`
- `soldr cargo test -p fbuild-build response_file`
- `soldr cargo test -p fbuild-build nrf52`
- `soldr cargo check -p fbuild-core -p fbuild-build -p fbuild-cli -p fbuild-daemon`
- FastLED probe with patched local fbuild: `uv run ci/ci-compile.py nrf52840_dk --examples Blink`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Version bumped to 2.2.15

* **Bug Fixes**
  * Enhanced response file handling for compiler flags containing quoted define values, ensuring proper escaping and preservation across different environments

* **Tests**
  * Added regression tests validating correct quote handling and escaping behavior in response file generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->