### PR TITLE
Fix ESP32-C2 skeleton SDK install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.15"
+version = "2.2.16"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.15"
+version = "2.2.16"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/fbuild-packages/src/library/esp32_framework/libs.rs
+++ b/crates/fbuild-packages/src/library/esp32_framework/libs.rs
@@ -1,7 +1,100 @@
 //! Logic for downloading and installing the ESP-IDF SDK libs and MCU skeleton libs.
 
+use std::path::{Path, PathBuf};
+
 use super::fs_utils::copy_dir_recursive;
 use super::Esp32Framework;
+
+const NEW_SDK_LAYOUT: &str = "esp32-arduino-libs";
+const OLD_SDK_LAYOUT: &str = "sdk";
+
+fn looks_like_mcu_sdk_dir(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    path.is_dir() && (name == "hosted" || name.starts_with("esp32"))
+}
+
+fn merge_sdk_archive_entries(temp_dir: &Path, tools_dir: &Path) -> fbuild_core::Result<()> {
+    let new_layout_dir = tools_dir.join(NEW_SDK_LAYOUT);
+
+    if let Ok(entries) = std::fs::read_dir(temp_dir) {
+        for entry in entries.flatten() {
+            let src = entry.path();
+            let file_name = entry.file_name();
+            let name = file_name.to_string_lossy();
+
+            if src.is_dir() && (name == NEW_SDK_LAYOUT || name == OLD_SDK_LAYOUT) {
+                copy_dir_recursive(&src, &tools_dir.join(&file_name))?;
+            } else if looks_like_mcu_sdk_dir(&src) {
+                copy_dir_recursive(&src, &new_layout_dir.join(&file_name))?;
+            } else if src.is_file() {
+                // Package metadata is useful for diagnostics but not part of the
+                // SDK include search. Keep it next to the merged SDK layout.
+                std::fs::create_dir_all(&new_layout_dir)?;
+                std::fs::copy(&src, new_layout_dir.join(&file_name))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn mcu_sdk_dir_candidates(tools_dir: &Path, mcu: &str) -> [PathBuf; 2] {
+    [
+        tools_dir.join(NEW_SDK_LAYOUT).join(mcu),
+        tools_dir.join(OLD_SDK_LAYOUT).join(mcu),
+    ]
+}
+
+fn mcu_sdk_complete(mcu_dir: &Path) -> bool {
+    mcu_dir
+        .join("include")
+        .join("freertos")
+        .join("FreeRTOS-Kernel")
+        .join("include")
+        .join("freertos")
+        .join("FreeRTOS.h")
+        .exists()
+        && mcu_dir.join("flags").join("includes").exists()
+        && mcu_dir.join("lib").join("libfreertos.a").exists()
+}
+
+fn sdk_layout_has_complete_mcu_sdk(sdk_dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(sdk_dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        looks_like_mcu_sdk_dir(&path) && mcu_sdk_complete(&path)
+    })
+}
+
+fn patch_mcu_compatibility(mcu_dir: &Path, mcu: &str) -> fbuild_core::Result<()> {
+    if mcu != "esp32c2" {
+        return Ok(());
+    }
+
+    let touch_header = mcu_dir
+        .join("include")
+        .join("hal")
+        .join("include")
+        .join("hal")
+        .join("touch_sensor_legacy_types.h");
+
+    if touch_header.exists() {
+        return Ok(());
+    }
+
+    if let Some(parent) = touch_header.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(
+        &touch_header,
+        "// ESP32-C2 has no touch sensor peripheral; Arduino-ESP32 3.3.x includes this unconditionally.\n",
+    )?;
+    Ok(())
+}
 
 impl Esp32Framework {
     /// Ensure the SDK libs are downloaded and extracted into the framework's `tools/` dir.
@@ -9,15 +102,12 @@ impl Esp32Framework {
         let root = self.resolved_dir();
         let tools_dir = root.join("tools");
 
-        // Already have SDK libs? Check both old (sdk/) and new (esp32-arduino-libs/) layouts
-        for dir_name in &["esp32-arduino-libs", "sdk"] {
+        // Already have SDK libs? Check both old (sdk/) and new
+        // (esp32-arduino-libs/) layouts.
+        for dir_name in &[NEW_SDK_LAYOUT, OLD_SDK_LAYOUT] {
             let sdk_dir = tools_dir.join(dir_name);
-            if sdk_dir.exists() && sdk_dir.is_dir() {
-                if let Ok(mut entries) = std::fs::read_dir(&sdk_dir) {
-                    if entries.next().is_some() {
-                        return Ok(());
-                    }
-                }
+            if sdk_dir.exists() && sdk_layout_has_complete_mcu_sdk(&sdk_dir) {
+                return Ok(());
             }
         }
 
@@ -44,12 +134,7 @@ impl Esp32Framework {
         }
 
         // Extract to a short temp path to avoid Windows MAX_PATH (260 char) limit.
-        // Then rename (atomic on same filesystem) to final location.
-        let temp_dir = std::env::temp_dir().join(format!("fbuild_sdk_{}", std::process::id()));
-        if temp_dir.exists() {
-            let _ = std::fs::remove_dir_all(&temp_dir);
-        }
-        std::fs::create_dir_all(&temp_dir)?;
+        let temp_dir = tempfile::Builder::new().prefix("fbuild_sdk_").tempdir()?;
 
         tracing::info!(
             "extracting ESP32 SDK libs ({} MB)",
@@ -58,23 +143,10 @@ impl Esp32Framework {
                 .map(|m| m.len() / 1_000_000)
                 .unwrap_or(0)
         );
-        crate::extractor::extract(&archive_path, &temp_dir)?;
+        crate::extractor::extract(&archive_path, temp_dir.path())?;
         let _ = std::fs::remove_file(&archive_path);
 
-        // Move extracted content to final tools/ dir (same filesystem = fast rename)
-        if let Ok(entries) = std::fs::read_dir(&temp_dir) {
-            for entry in entries.flatten() {
-                let src = entry.path();
-                let dest = tools_dir.join(entry.file_name());
-                if dest.exists() {
-                    let _ = std::fs::remove_dir_all(&dest);
-                }
-                if std::fs::rename(&src, &dest).is_err() {
-                    copy_dir_recursive(&src, &dest)?;
-                }
-            }
-        }
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        merge_sdk_archive_entries(temp_dir.path(), &tools_dir)?;
 
         tracing::info!("ESP32 SDK libs installed");
         Ok(())
@@ -90,10 +162,12 @@ impl Esp32Framework {
         let root = self.resolved_dir();
         let tools_dir = root.join("tools");
 
-        // Already have this MCU's SDK? Check both layouts.
-        for dir_name in &["esp32-arduino-libs", "sdk"] {
-            let mcu_dir = tools_dir.join(dir_name).join(mcu);
-            if mcu_dir.exists() && mcu_dir.is_dir() {
+        // The Arduino core archive can include a partial MCU SDK directory.
+        // ESP32-C2 has one such tree in Arduino-ESP32 3.3.x, but it lacks
+        // FreeRTOS headers, so existence alone is not a valid completion test.
+        for mcu_dir in mcu_sdk_dir_candidates(&tools_dir, mcu) {
+            if mcu_sdk_complete(&mcu_dir) {
+                patch_mcu_compatibility(&mcu_dir, mcu)?;
                 return Ok(());
             }
         }
@@ -119,31 +193,123 @@ impl Esp32Framework {
             }
         }
 
-        let temp_dir = std::env::temp_dir().join(format!("fbuild_skel_{}", std::process::id()));
-        if temp_dir.exists() {
-            let _ = std::fs::remove_dir_all(&temp_dir);
-        }
-        std::fs::create_dir_all(&temp_dir)?;
+        let temp_dir = tempfile::Builder::new().prefix("fbuild_skel_").tempdir()?;
 
         tracing::info!("extracting {} skeleton libs", mcu);
-        crate::extractor::extract(&archive_path, &temp_dir)?;
+        crate::extractor::extract(&archive_path, temp_dir.path())?;
         let _ = std::fs::remove_file(&archive_path);
 
-        // Merge into tools/ — use copy_dir_recursive so existing MCU dirs are preserved.
-        if let Ok(entries) = std::fs::read_dir(&temp_dir) {
-            for entry in entries.flatten() {
-                let src = entry.path();
-                let dest = tools_dir.join(entry.file_name());
-                if src.is_dir() {
-                    copy_dir_recursive(&src, &dest)?;
-                } else if std::fs::rename(&src, &dest).is_err() {
-                    std::fs::copy(&src, &dest)?;
-                }
+        // Skeleton archives such as c2_arduino_compile_skeleton.zip extract as
+        // a direct esp32c2/ directory. Merge direct MCU roots into the new SDK
+        // layout so sdk_mcu_dir() finds the completed tree.
+        merge_sdk_archive_entries(temp_dir.path(), &tools_dir)?;
+
+        for mcu_dir in mcu_sdk_dir_candidates(&tools_dir, mcu) {
+            if mcu_sdk_complete(&mcu_dir) {
+                patch_mcu_compatibility(&mcu_dir, mcu)?;
+                tracing::info!("{} skeleton libs installed", mcu);
+                return Ok(());
             }
         }
-        let _ = std::fs::remove_dir_all(&temp_dir);
 
-        tracing::info!("{} skeleton libs installed", mcu);
-        Ok(())
+        Err(fbuild_core::FbuildError::PackageError(format!(
+            "{} skeleton libs were extracted but required FreeRTOS SDK files are still missing",
+            mcu
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn seed_complete_mcu_sdk(mcu_dir: &Path) {
+        write(
+            &mcu_dir
+                .join("include")
+                .join("freertos")
+                .join("FreeRTOS-Kernel")
+                .join("include")
+                .join("freertos")
+                .join("FreeRTOS.h"),
+            "",
+        );
+        write(&mcu_dir.join("flags").join("includes"), "");
+        write(&mcu_dir.join("lib").join("libfreertos.a"), "");
+    }
+
+    #[test]
+    fn mcu_sdk_complete_requires_freertos_kernel_header() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mcu_dir = tmp.path().join("esp32c2");
+
+        write(&mcu_dir.join("flags").join("includes"), "");
+        write(&mcu_dir.join("lib").join("libfreertos.a"), "");
+        assert!(!mcu_sdk_complete(&mcu_dir));
+
+        seed_complete_mcu_sdk(&mcu_dir);
+        assert!(mcu_sdk_complete(&mcu_dir));
+    }
+
+    #[test]
+    fn sdk_layout_completion_ignores_metadata_only_layout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sdk_dir = tmp.path().join(NEW_SDK_LAYOUT);
+        write(&sdk_dir.join("package.json"), "{}");
+        assert!(!sdk_layout_has_complete_mcu_sdk(&sdk_dir));
+
+        std::fs::create_dir_all(sdk_dir.join("esp32c2")).unwrap();
+        assert!(!sdk_layout_has_complete_mcu_sdk(&sdk_dir));
+
+        seed_complete_mcu_sdk(&sdk_dir.join("esp32c2"));
+        assert!(sdk_layout_has_complete_mcu_sdk(&sdk_dir));
+    }
+
+    #[test]
+    fn merge_direct_mcu_archive_entries_under_new_sdk_layout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let archive = tmp.path().join("archive");
+        let tools = tmp.path().join("tools");
+        let source_mcu = archive.join("esp32c2");
+        seed_complete_mcu_sdk(&source_mcu);
+
+        merge_sdk_archive_entries(&archive, &tools).unwrap();
+
+        let merged = tools.join(NEW_SDK_LAYOUT).join("esp32c2");
+        assert!(mcu_sdk_complete(&merged));
+        assert!(!tools.join("esp32c2").exists());
+    }
+
+    #[test]
+    fn patch_esp32c2_missing_touch_header_creates_compat_header() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mcu_dir = tmp.path().join("esp32c2");
+
+        patch_mcu_compatibility(&mcu_dir, "esp32c2").unwrap();
+
+        assert!(mcu_dir
+            .join("include")
+            .join("hal")
+            .join("include")
+            .join("hal")
+            .join("touch_sensor_legacy_types.h")
+            .exists());
+    }
+
+    #[test]
+    fn patch_mcu_compatibility_leaves_other_mcus_untouched() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mcu_dir = tmp.path().join("esp32c3");
+
+        patch_mcu_compatibility(&mcu_dir, "esp32c3").unwrap();
+
+        assert!(!mcu_dir.exists());
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.15"
+version = "2.2.16"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
﻿## Summary
- merge direct MCU skeleton archive roots like `esp32c2/` into `tools/esp32-arduino-libs/<mcu>` so fbuild can find them
- require the MCU SDK tree to include the FreeRTOS kernel header, `flags/includes`, and `libfreertos.a` before treating skeleton libs as installed
- add an ESP32-C2 compatibility touch legacy header only when the skeleton package does not provide one
- bump fbuild to `2.2.16` so the merge triggers the auto-release workflow and FastLED can pin the fixed package

## Verification
- `soldr cargo test -p fbuild-packages`
- `soldr cargo check -p fbuild-packages`
- Clean FastLED ESP32-C2 build using this branch with isolated `FBUILD_CACHE_DIR` and `FBUILD_DAEMON_PORT` produced `firmware.bin` and `firmware.elf`

Addresses FastLED/FastLED#2637.
