### PR TITLE
chore: bump version to 2.2.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.16"
+version = "2.2.17"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.16"
+version = "2.2.17"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- bump workspace/package version from `2.2.16` to `2.2.17`
- bump Python project version to `2.2.17` so release-auto eligibility passes

This prepares a release containing #380 / #379.

## Validation

- `cargo metadata --no-deps --format-version 1`
- Python TOML check: `Cargo=2.2.17 pyproject=2.2.17 match=True`