### PR TITLE
[codex] fix windows fbuild stack size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ libiconv-2.dll
 .cargo/.global-cache
 .cargo/.package-cache
 .cargo/.package-cache-mutate
+.cargo/git/
 .cargo/registry/
 
 # Cargo lock is checked in for binaries

--- a/crates/fbuild-cli/build.rs
+++ b/crates/fbuild-cli/build.rs
@@ -1,0 +1,14 @@
+//! Build script for `fbuild`.
+//!
+//! On `*-pc-windows-msvc` we ask the linker to reserve an 8 MiB stack for the
+//! `fbuild.exe` binary (default is 1 MiB). The clap-generated argument-parser
+//! state machine has grown deep enough that debug builds overflow the default
+//! Windows stack when rendering `--help` (FastLED/fbuild#242). Release builds
+//! are unaffected; this only changes the PE header's reserved stack size.
+
+fn main() {
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.contains("pc-windows-msvc") {
+        println!("cargo:rustc-link-arg-bin=fbuild=/STACK:8388608");
+    }
+}


### PR DESCRIPTION
﻿## Summary

- Add a `fbuild-cli` build script that reserves an 8 MiB stack for the Windows MSVC `fbuild.exe` binary.
- Ignore `.cargo/git/`, matching the existing repo-local Cargo cache ignore rules.

## Why

Debug Windows MSVC builds can overflow the default 1 MiB PE stack while clap renders the expanded `--help` parser state. The build script only applies the larger stack reservation for `*-pc-windows-msvc`, leaving other targets unchanged.

## Validation

- `cargo run -p fbuild-cli -- --help > $null`
