### PR TITLE
test(ch559): add intel_mcs51 smoke fixture tracking FastLED CH55x

### DIFF
--- a/tests/platform/ch559/README.md
+++ b/tests/platform/ch559/README.md
@@ -1,0 +1,28 @@
+## CH559 (WCH 8051) Smoke Fixture
+
+Minimal CH559 / `intel_mcs51` project used to track fbuild support state
+for the WCH CH55x family from FastLED/fbuild#384 (source issue:
+FastLED/FastLED#1432).
+
+### Current fbuild status (2026-06-03)
+
+- Board metadata: present (`crates/fbuild-config/assets/boards/json/CH559.json`,
+  along with ~250 other 8051 boards in the same directory).
+- Platform string `intel_mcs51`: NOT mapped in `Platform::from_platform_str`
+  (`crates/fbuild-core/src/lib.rs`), so any build/deploy/install_deps request
+  for this fixture fails at the daemon boundary with
+  `unsupported platform: intel_mcs51`
+  (see `crates/fbuild-daemon/src/handlers/operations/build.rs`).
+- `BuildOrchestrator` for 8051/SDCC: not implemented in `fbuild-build`. Even
+  with a `Platform::IntelMcs51` variant, `get_platform_support` would return
+  "native orchestrator for ... not yet implemented"
+  (`crates/fbuild-build/src/lib.rs`).
+- FastLED platform header for 8051: missing. `src/led_sysdefs.h` has no
+  `__SDCC__` / `__SDCC_mcs51` / `defined(__C51__)` branch, so even with a
+  working backend FastLED itself bails out with
+  `#error "This platform isn't recognized by FastLED... yet."`.
+
+This fixture intentionally does NOT `#include <FastLED.h>` — the FastLED-side
+blocker would mask any backend progress. It exists so that, once both an
+8051 orchestrator lands in fbuild and FastLED ships a CH55x platform header,
+this directory can be flipped to a real FastLED smoke build with a single edit.

--- a/tests/platform/ch559/ch559.ino
+++ b/tests/platform/ch559/ch559.ino
@@ -1,0 +1,9 @@
+// Minimal CH559 (WCH 8051) sketch used as the fbuild smoke fixture for
+// FastLED/fbuild#384. Kept as a bare setup()/loop() instead of pulling in
+// FastLED because FastLED's `led_sysdefs.h` has no 8051/SDCC branch yet, so
+// any `#include <FastLED.h>` would terminate at the platform-not-recognized
+// `#error` regardless of toolchain state.
+
+void setup() {}
+
+void loop() {}

--- a/tests/platform/ch559/platformio.ini
+++ b/tests/platform/ch559/platformio.ini
@@ -1,0 +1,11 @@
+; PlatformIO Project Configuration File
+;
+; CH559 (WCH 8051) smoke fixture for fbuild support tracking.
+;
+; Status: fbuild has board metadata + intel_mcs51 board JSON, but no native
+; build orchestrator and no FastLED-side platform header. Tracked by
+; FastLED/fbuild#384 (and source FastLED/FastLED#1432).
+
+[env:ch559]
+platform = intel_mcs51
+board = CH559


### PR DESCRIPTION
## Summary

Adds a minimal CH559 / `intel_mcs51` smoke fixture under `tests/platform/ch559/` to make the fbuild backend status for the WCH CH55x / 8051 family concretely reproducible, per FastLED/fbuild#384 (source: FastLED/FastLED#1432).

Running fbuild against the fixture exposes the exact gap:

```
$ fbuild build tests/platform/ch559 -e ch559 --quick
unsupported platform: intel_mcs51
```

That error originates in `crates/fbuild-daemon/src/handlers/operations/build.rs` because `Platform::from_platform_str` in `crates/fbuild-core/src/lib.rs` has no `intel_mcs51` arm. Even with a `Platform::IntelMcs51` variant, `crates/fbuild-build/src/lib.rs::get_platform_support` would fall through to "native orchestrator for ... not yet implemented" — no SDCC compiler/linker/orchestrator exists yet.

The fixture intentionally does **not** `#include <FastLED.h>`: FastLED's own `src/led_sysdefs.h` has no 8051/SDCC branch, so `FastLED.h` would terminate at `#error "This platform isn't recognized by FastLED... yet."` regardless of fbuild backend progress. The README documents both blockers so this directory can be flipped to a real FastLED smoke build with a single edit once both ends land.

Closes #384

## Test plan

- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/ch559 -e ch559 --quick` returns the documented `unsupported platform: intel_mcs51` error (verified locally).
- [x] Board metadata loads: `soldr cargo test -p fbuild-config --lib test_non_nrf52_sweep_arduino_macros` passes (includes `AT89S51` / `NAKED_ARCH_MCS51` 8051 case).
- [ ] CI passes on Linux/macOS/Windows.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added CH559 platform support test fixtures for tracking framework compatibility and build status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->