### PR TITLE
test(samd): add QT Py M0 and Matrix Portal M4 fixtures

### DIFF
--- a/.github/workflows/build-matrix_portal_m4.yml
+++ b/.github/workflows/build-matrix_portal_m4.yml
@@ -1,0 +1,17 @@
+name: Build Matrix Portal M4
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "Matrix Portal M4"
+      test-dir: "tests/platform/matrix_portal_m4"
+      env-name: "matrix_portal_m4"
+      firmware-ext: "bin"

--- a/.github/workflows/build-qtpy_m0.yml
+++ b/.github/workflows/build-qtpy_m0.yml
@@ -1,0 +1,17 @@
+name: Build QT Py M0
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "QT Py M0"
+      test-dir: "tests/platform/qtpy_m0"
+      env-name: "qtpy_m0"
+      firmware-ext: "bin"

--- a/docs/BOARD_STATUS.md
+++ b/docs/BOARD_STATUS.md
@@ -69,8 +69,10 @@ Live per-platform CI status and supported-board reference for fbuild.
 [![Build Arduino Due](https://github.com/fastled/fbuild/actions/workflows/build-sam3x8e_due.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-sam3x8e_due.yml)
 [![Build SAMD21](https://github.com/fastled/fbuild/actions/workflows/build-samd21.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd21.yml)
 [![Build Arduino Zero](https://github.com/fastled/fbuild/actions/workflows/build-samd21_zero.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd21_zero.yml)
+[![Build QT Py M0](https://github.com/fastled/fbuild/actions/workflows/build-qtpy_m0.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-qtpy_m0.yml)
 [![Build SAMD51J](https://github.com/fastled/fbuild/actions/workflows/build-samd51j.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd51j.yml)
 [![Build SAMD51P](https://github.com/fastled/fbuild/actions/workflows/build-samd51p.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd51p.yml)
+[![Build Matrix Portal M4](https://github.com/fastled/fbuild/actions/workflows/build-matrix_portal_m4.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-matrix_portal_m4.yml)
 
 ### RP2040 / RP2350
 [![Build RP2040](https://github.com/fastled/fbuild/actions/workflows/build-rp2040.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rp2040.yml)
@@ -377,8 +379,10 @@ STM32 is STMicroelectronics' extensive family of ARM Cortex-M microcontrollers, 
 - **Arduino Due** (SAM3X8E) - Supported
 - **SAMD21** (Adafruit Feather M0) - Supported
 - **SAMD21** (Arduino Zero) - Supported
+- **SAMD21E** (Adafruit QT Py M0) - Supported
 - **SAMD51J** (Adafruit Feather M4) - Supported
 - **SAMD51P** (Adafruit Grand Central M4) - Supported
+- **SAMD51J** (Adafruit Matrix Portal M4) - Supported
 
 <details>
 <summary><strong>About the SAM / SAMD Family</strong></summary>

--- a/tests/platform/README.md
+++ b/tests/platform/README.md
@@ -39,8 +39,10 @@ PlatformIO-compatible test projects for each supported hardware platform. Each s
 | `sam3x8e_due/` | SAM3X8E | ARM Cortex-M3 | Arduino |
 | `samd21/` | SAMD21G18A | ARM Cortex-M0+ | Arduino |
 | `samd21_zero/` | SAMD21G18A | ARM Cortex-M0+ | Arduino |
+| `qtpy_m0/` | SAMD21E18A | ARM Cortex-M0+ | Arduino |
 | `samd51j/` | SAMD51J19A | ARM Cortex-M4F | Arduino |
 | `samd51p/` | SAMD51P20A | ARM Cortex-M4F | Arduino |
+| `matrix_portal_m4/` | SAMD51J19A | ARM Cortex-M4F | Arduino |
 | `stm32f103c8/` | STM32F103C8 | ARM Cortex-M3 | Arduino |
 | `stm32f103cb/` | STM32F103CB | ARM Cortex-M3 | Arduino |
 | `stm32f103tb/` | STM32F103TB | ARM Cortex-M3 | Arduino |

--- a/tests/platform/matrix_portal_m4/README.md
+++ b/tests/platform/matrix_portal_m4/README.md
@@ -1,0 +1,5 @@
+# Adafruit Matrix Portal M4 Test Fixture
+
+ARM Cortex-M4F build validation project for the Adafruit Matrix Portal M4 (SAMD51J19A, the same MCU as the Feather M4 but with the `matrixportal_m4` variant and `-DARDUINO_MATRIXPORTAL_M4` / `-DADAFRUIT_MATRIXPORTAL_M4_EXPRESS` defines). Uses the Arduino framework on the `atmelsam` platform.
+
+Tracks FastLED issue #1196 — Arduino IDE build failures on this board. fbuild's role here is to prove the board's toolchain + Arduino core + variant compile cleanly; any remaining failures are FastLED-side example/pin-map issues.

--- a/tests/platform/matrix_portal_m4/platformio.ini
+++ b/tests/platform/matrix_portal_m4/platformio.ini
@@ -1,0 +1,4 @@
+[env:matrix_portal_m4]
+platform = atmelsam
+board = adafruit_matrix_portal_m4
+framework = arduino

--- a/tests/platform/matrix_portal_m4/src/README.md
+++ b/tests/platform/matrix_portal_m4/src/README.md
@@ -1,0 +1,3 @@
+# Source
+
+Arduino sketch source for the Adafruit Matrix Portal M4 platform test.

--- a/tests/platform/matrix_portal_m4/src/main.ino
+++ b/tests/platform/matrix_portal_m4/src/main.ino
@@ -1,0 +1,14 @@
+#include <Arduino.h>
+
+void setup() {
+    Serial.begin(115200);
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+    Serial.println("Hello from Adafruit Matrix Portal M4!");
+}

--- a/tests/platform/qtpy_m0/README.md
+++ b/tests/platform/qtpy_m0/README.md
@@ -1,0 +1,5 @@
+# Adafruit QT Py M0 Test Fixture
+
+ARM Cortex-M0+ build validation project for the Adafruit QT Py M0 (SAMD21E18A, the smaller `E` variant of the SAMD21 family). Uses the Arduino framework on the `atmelsam` platform.
+
+Tracks FastLED issues #1354 and #1381 — both report runtime/pin-map problems on the QT Py M0. fbuild's role here is to prove the board's toolchain + Arduino core compile cleanly; FastLED's `platforms/arm/d21` headers handle the pin map.

--- a/tests/platform/qtpy_m0/platformio.ini
+++ b/tests/platform/qtpy_m0/platformio.ini
@@ -1,0 +1,4 @@
+[env:qtpy_m0]
+platform = atmelsam
+board = adafruit_qt_py_m0
+framework = arduino

--- a/tests/platform/qtpy_m0/src/README.md
+++ b/tests/platform/qtpy_m0/src/README.md
@@ -1,0 +1,3 @@
+# Source
+
+Arduino sketch source for the Adafruit QT Py M0 platform test.

--- a/tests/platform/qtpy_m0/src/main.ino
+++ b/tests/platform/qtpy_m0/src/main.ino
@@ -1,0 +1,14 @@
+#include <Arduino.h>
+
+void setup() {
+    Serial.begin(115200);
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+    Serial.println("Hello from Adafruit QT Py M0!");
+}


### PR DESCRIPTION
## Summary

Adds two new platform test fixtures for SAMD boards named in long-standing FastLED issues, completing fbuild's smoke coverage for the SAMD family.

- `tests/platform/qtpy_m0` — Adafruit QT Py M0 (**SAMD21E18A**, the small `E` variant). Covers FastLED [#1354](https://github.com/FastLED/FastLED/issues/1354) and [#1381](https://github.com/FastLED/FastLED/issues/1381). The existing generic `samd21` fixture targets the SAMD21**G**18A on the Feather M0, so it does not exercise the `E` SKU or the QTPY-specific `-DARDUINO_QTPY_M0` / `-DADAFRUIT_QTPY_M0` / `-DCRYSTALLESS` extra flags.
- `tests/platform/matrix_portal_m4` — Adafruit Matrix Portal M4 (**SAMD51J19A** + `matrixportal_m4` variant). Covers FastLED [#1196](https://github.com/FastLED/FastLED/issues/1196). The existing `samd51j` fixture targets the Feather M4 variant, so it does not exercise the Matrix Portal variant or its `-DARDUINO_MATRIXPORTAL_M4` / `-DADAFRUIT_MATRIXPORTAL_M4_EXPRESS` extra flags.

Both fixtures build clean locally against the bundled `adafruit-ArduinoCore-samd 1.7.16` + `CMSIS-Atmel 1.2.2` + `arm-none-eabi-gcc 15.2.1`:

| Fixture | Flash | RAM | Build time |
|---|---|---|---|
| `qtpy_m0` (quick) | 10.35 KB / 256 KB | 2.98 KB / 32 KB | 8.3s |
| `matrix_portal_m4` (quick) | 11.64 KB / 496 KB | 3.79 KB / 192 KB | 6.2s |

Per-board GitHub Actions workflows + `docs/BOARD_STATUS.md` + `tests/platform/README.md` updated.

Part of #386.

## Test plan

- [x] `fbuild build tests/platform/qtpy_m0 -e qtpy_m0 --quick` succeeds locally
- [x] `fbuild build tests/platform/matrix_portal_m4 -e matrix_portal_m4 --quick` succeeds locally
- [x] Pre-existing `fbuild build tests/platform/samd21 -e samd21 --quick` still succeeds (regression check)
- [ ] CI workflows `build-qtpy_m0` and `build-matrix_portal_m4` go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)