### PR TITLE
test(stm32): add F0/L4 gap-tracking fixtures and document STM32 MCU coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ libiconv-2.dll
 
 # fbuild local build artifacts
 .fbuild/
+tests/platform/*/build_info*.json
 
 # Local cargo cache
 .cargo/.global-cache

--- a/crates/fbuild-build/src/stm32/mcu_config.rs
+++ b/crates/fbuild-build/src/stm32/mcu_config.rs
@@ -20,6 +20,10 @@ const STM32U5_JSON: &str = include_str!("configs/stm32u5.json");
 /// - `stm32f4*` → STM32F4 (Cortex-M4F)
 /// - `stm32h7*` → STM32H7 (Cortex-M7)
 /// - `stm32u5*` → STM32U5 (Cortex-M33F)
+///
+/// Known gaps tracked by FastLED/fbuild#385:
+/// - STM32F0xx (Cortex-M0): blocks FastLED/FastLED#750
+/// - STM32L4xx (Cortex-M4F, no DSP): blocks FastLED/FastLED#975
 pub fn get_stm32_config_for_mcu(mcu: &str) -> Result<ArmMcuConfig> {
     let mcu_lower = mcu.to_lowercase();
     let json = if mcu_lower.starts_with("stm32f103") {
@@ -32,7 +36,7 @@ pub fn get_stm32_config_for_mcu(mcu: &str) -> Result<ArmMcuConfig> {
         STM32U5_JSON
     } else {
         return Err(fbuild_core::FbuildError::ConfigError(format!(
-            "unsupported STM32 MCU: '{}' (supported prefixes: stm32f103, stm32f4, stm32h7, stm32u5/stm32u585)",
+            "unsupported STM32 MCU: '{}' (supported prefixes: stm32f103, stm32f4, stm32h7, stm32u5/stm32u585; gaps tracked by FastLED/fbuild#385: stm32f0*, stm32l4*)",
             mcu
         )));
     };

--- a/tests/platform/nucleo_f030r8/README.md
+++ b/tests/platform/nucleo_f030r8/README.md
@@ -1,0 +1,15 @@
+# Nucleo F030R8 Test Fixture
+
+ARM Cortex-M0 build validation project for the ST Nucleo F030R8 (STM32F030R8T6).
+Uses the Arduino framework on the `ststm32` platform.
+
+## Status
+
+**Currently fails to build** due to a known fbuild-owned gap: `crates/fbuild-build/src/stm32/mcu_config.rs`
+does not match STM32F0 MCUs (`stm32f0*`). Cortex-M0 needs its own `stm32f0.json`
+config (no FPU, `-mcpu=cortex-m0`). The fixture exists as a regression marker so
+that once F0 support is added the smoke build can be enabled in CI.
+
+Tracks coverage for FastLED/FastLED#750 (FastLED on STM32F030C8T6) via fbuild
+tracker FastLED/fbuild#385. STM32F030C8 and STM32F030R8 share the F030x8 die
+and the same fbuild MCU config family will cover both.

--- a/tests/platform/nucleo_f030r8/platformio.ini
+++ b/tests/platform/nucleo_f030r8/platformio.ini
@@ -1,0 +1,4 @@
+[env:nucleo_f030r8]
+platform = ststm32
+board = nucleo_f030r8
+framework = arduino

--- a/tests/platform/nucleo_f030r8/src/README.md
+++ b/tests/platform/nucleo_f030r8/src/README.md
@@ -1,0 +1,3 @@
+# Source
+
+Arduino sketch source for the STM32F030R8 Nucleo platform test.

--- a/tests/platform/nucleo_f030r8/src/main.ino
+++ b/tests/platform/nucleo_f030r8/src/main.ino
@@ -1,0 +1,14 @@
+#include <Arduino.h>
+
+void setup() {
+    Serial.begin(115200);
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+    Serial.println("Hello from STM32F030R8 Nucleo!");
+}

--- a/tests/platform/nucleo_l476rg/README.md
+++ b/tests/platform/nucleo_l476rg/README.md
@@ -1,0 +1,15 @@
+# Nucleo L476RG Test Fixture
+
+ARM Cortex-M4F build validation project for the ST Nucleo L476RG (STM32L476RGT6).
+Uses the Arduino framework on the `ststm32` platform.
+
+## Status
+
+**Currently fails to build** due to a known fbuild-owned gap: `stm32f4`
+prefix-based config selection in `crates/fbuild-build/src/stm32/mcu_config.rs`
+does not match STM32L4 MCUs (`stm32l4*`). The fixture exists as a regression
+marker so that once an `stm32l4.json` Cortex-M4F config (no DSP) is added, the
+build can be smoke-tested.
+
+Tracks coverage for FastLED/FastLED#975 (FastLED on STM32L4) via fbuild
+tracker FastLED/fbuild#385.

--- a/tests/platform/nucleo_l476rg/platformio.ini
+++ b/tests/platform/nucleo_l476rg/platformio.ini
@@ -1,0 +1,4 @@
+[env:nucleo_l476rg]
+platform = ststm32
+board = nucleo_l476rg
+framework = arduino

--- a/tests/platform/nucleo_l476rg/src/README.md
+++ b/tests/platform/nucleo_l476rg/src/README.md
@@ -1,0 +1,3 @@
+# Source
+
+Arduino sketch source for the STM32L476RG Nucleo platform test.

--- a/tests/platform/nucleo_l476rg/src/main.ino
+++ b/tests/platform/nucleo_l476rg/src/main.ino
@@ -1,0 +1,14 @@
+#include <Arduino.h>
+
+void setup() {
+    Serial.begin(115200);
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+    Serial.println("Hello from STM32L476RG Nucleo!");
+}


### PR DESCRIPTION
## Summary

Part of #385. Documents and adds regression coverage for the STM32 MCU support gaps surfaced when reconciling fbuild's current backend with the open FastLED STM32 issues (FastLED/FastLED#590, #750, #805, #975, #1134, #1304, #1312).

- Adds `tests/platform/nucleo_f030r8` (Cortex-M0) - currently fails to build; maps to FastLED/FastLED#750.
- Adds `tests/platform/nucleo_l476rg` (Cortex-M4F, no DSP) - currently fails to build; maps to FastLED/FastLED#975.
- Extends `crates/fbuild-build/src/stm32/mcu_config.rs` unsupported-MCU error so the gap is self-documenting and cross-links #385.
- `.gitignore` - drop transient `tests/platform/*/build_info*.json` produced by `fbuild build` runs.

Existing F1 (`bluepill_f103c8`, `maple_mini_b20`, `hy_tinystm103tb`), F4 (`blackpill_f411ce`, `nucleo_f429zi`), and H7 (`giga_r1_m7` - same `stm32h747xih6` as Portenta H7 M7) fixtures were verified to build cleanly with `soldr cargo run -p fbuild-cli -- build ... --quick`.

The two new fixtures will turn green once `stm32f0.json` (Cortex-M0, no FPU) and `stm32l4.json` (Cortex-M4F, no DSP) configs are added to `crates/fbuild-build/src/stm32/configs/` plus their prefix branches in `mcu_config.rs::get_stm32_config_for_mcu`.

## Test plan

- [x] `soldr cargo test -p fbuild-build mcu_config::` (139 passing)
- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/stm32f103c8 -e stm32f103c8 --quick` (17.7 KB flash)
- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/stm32f103cb -e stm32f103cb --quick` (17.7 KB flash)
- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/stm32f103tb -e stm32f103tb --quick` (17.5 KB flash)
- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/stm32f411ce -e stm32f411ce --quick` (18.4 KB flash)
- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/nucleo_f429zi -e nucleo_f429zi --quick` (20.6 KB flash)
- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/stm32h747xi -e stm32h747xi --quick` (94.1 KB flash, mbed framework)
- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/nucleo_l476rg -e nucleo_l476rg --quick` (fails as expected - documents fbuild gap)
- [x] `soldr cargo run -p fbuild-cli -- build tests/platform/nucleo_f030r8 -e nucleo_f030r8 --quick` (fails as expected - documents fbuild gap)
- [x] `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings`