### PR TITLE
test(avr): tracker fixtures + framework gap tripwires for #389

### DIFF
--- a/crates/fbuild-packages/src/library/avr_framework.rs
+++ b/crates/fbuild-packages/src/library/avr_framework.rs
@@ -397,4 +397,34 @@ mod tests {
         assert_eq!(entry.name, "digistump-avr-core");
         assert_eq!(entry.core_dir.as_deref(), Some("pro"));
     }
+
+    /// Tripwire: `MicroCore` (MCUdude/MicroCore, used by `attiny13` /
+    /// `attiny13a` board JSONs) is not yet wired into `avr_frameworks.json`.
+    /// Source issue FastLED/FastLED#581, tracker FastLED/fbuild#389. When
+    /// MicroCore lands in the registry, flip this assertion to
+    /// `is_ok()` and update the gap tracker in
+    /// `tests/platform/attiny13/README.md`.
+    #[test]
+    fn test_microcore_gap_tracked() {
+        assert!(
+            lookup_entry("MicroCore").is_err(),
+            "MicroCore lookup unexpectedly succeeded — see FastLED/fbuild#389; \
+             update test_microcore_gap_tracked and tests/platform/attiny13/README.md"
+        );
+    }
+
+    /// Tripwire: `dxcore` (SpenceKonde/DxCore, used by the AVR-Dx family —
+    /// `AVR128DA*`, `AVR128DB*`, `AVR64DA*`, `AVR64DB*`, `AVR64DD*`,
+    /// `AVR32DA*`, `AVR32DB*`) is not yet wired into `avr_frameworks.json`.
+    /// Source issue FastLED/FastLED#1307, tracker FastLED/fbuild#389. When
+    /// DxCore lands in the registry, flip this assertion to `is_ok()` and
+    /// update the gap tracker in `tests/platform/avr128da64/README.md`.
+    #[test]
+    fn test_dxcore_gap_tracked() {
+        assert!(
+            lookup_entry("dxcore").is_err(),
+            "dxcore lookup unexpectedly succeeded — see FastLED/fbuild#389; \
+             update test_dxcore_gap_tracked and tests/platform/avr128da64/README.md"
+        );
+    }
 }

--- a/tests/platform/README.md
+++ b/tests/platform/README.md
@@ -8,12 +8,15 @@ PlatformIO-compatible test projects for each supported hardware platform. Each s
 |-----------|-----|--------------|-----------|
 | `apollo3_red/` | Apollo3 Blue | ARM Cortex-M4F | Arduino |
 | `apollo3_thing_explorable/` | Apollo3 Blue | ARM Cortex-M4F | Arduino |
+| `atmega1284/` | ATmega1284P | AVR | Arduino |
 | `atmega8a/` | ATmega8A | AVR | Arduino |
 | `ATtiny1604/` | ATtiny1604 | MegaAVR | Arduino |
 | `ATtiny1616/` | ATtiny1616 | MegaAVR | Arduino |
+| `attiny13/` | ATtiny13 | AVR | Arduino (tracker — `MicroCore` unregistered) |
 | `attiny4313/` | ATtiny4313 | AVR | Arduino |
 | `attiny85/` | ATtiny85 | AVR | Arduino |
 | `attiny88/` | ATtiny88 | AVR | Arduino |
+| `avr128da64/` | AVR128DA64 | AVR-Dx | Arduino (tracker — `dxcore` unregistered) |
 | `ch32v003/` | CH32V003 | RISC-V | Arduino |
 | `esp32c2/` | ESP32-C2 | RISC-V | Arduino |
 | `esp32c3/` | ESP32-C3 | RISC-V | Arduino |
@@ -26,6 +29,7 @@ PlatformIO-compatible test projects for each supported hardware platform. Each s
 | `esp32s3/` | ESP32-S3 | Xtensa LX7 | Arduino |
 | `esp8266/` | ESP8266 | Xtensa L106 | Arduino |
 | `leonardo/` | ATmega32U4 | AVR | Arduino |
+| `mega/` | ATmega2560 | AVR | Arduino |
 | `mgm240/` | EFR32MG24 | ARM Cortex-M33 | Arduino |
 | `nano_every/` | ATmega4809 | MegaAVR | Arduino |
 | `nrf52840_dk/` | nRF52840 | ARM Cortex-M4F | Arduino |

--- a/tests/platform/atmega1284/README.md
+++ b/tests/platform/atmega1284/README.md
@@ -1,0 +1,29 @@
+# ATmega1284P Tracker Fixture
+
+Minimal ATmega1284P project (Microduino Core+ variant) used to track
+fbuild support for the ATmega644/1284 class. Source FastLED issue:
+FastLED/FastLED#1253. fbuild tracker: FastLED/fbuild#389.
+
+## Current fbuild status (2026-06-03)
+
+- **Board metadata**: present
+  (`crates/fbuild-config/assets/boards/json/1284p16m.json`,
+  `ATmega1284P.json`, `sanguino_atmega1284p.json`, `sanguino_atmega1284_8m.json`).
+- **Framework registry**: `MiniCore` IS mapped in
+  `crates/fbuild-packages/assets/avr_frameworks.json` (MCUdude/MiniCore
+  v2.2.2, `core_dir = MCUdude_corefiles`). The `1284p16m` JSON however
+  declares `core = arduino` and `variant = microduino_plus`, so the
+  build resolves through ArduinoCore-avr, not MiniCore.
+- **FastLED platform support**: ATmega1284 / ATmega1284P present in
+  `src/platforms/avr/atmega/common/fastpin_legacy_other.h` and
+  `fastpin_avr_legacy_dispatcher.h`.
+
+## Source-issue takeaway
+
+FastLED/FastLED#1253 is asking for alternative pin mappings (Bobuino
+pinout) on the ATmega1284. That's a FastLED-side change: the FastPin
+variant selector would need to look at the variant-specific macro the
+core defines and choose a different pin map. There's no fbuild-side
+blocker for the default ATmega1284P pin layout, so this fixture is
+intentionally minimal — it just proves the toolchain + framework wiring
+is healthy.

--- a/tests/platform/atmega1284/platformio.ini
+++ b/tests/platform/atmega1284/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+; ATmega1284P (MCUdude/MiniCore via Microduino variant) smoke fixture used
+; to track fbuild support state for the ATmega644/1284 class.
+;
+; Status (FastLED/fbuild#389, source FastLED/FastLED#1253):
+;   - Board metadata: present
+;     (`crates/fbuild-config/assets/boards/json/1284p16m.json`,
+;     `ATmega1284P.json`, `sanguino_atmega1284p.json`).
+;   - Framework registry: `MiniCore` IS mapped in
+;     `crates/fbuild-packages/assets/avr_frameworks.json` (MCUdude/MiniCore
+;     v2.2.2, core_dir = `MCUdude_corefiles`). The `1284p16m` JSON
+;     however declares `core = arduino` and `variant = microduino_plus`,
+;     so the build will go through ArduinoCore-avr, not MiniCore.
+;   - FastLED pin map: ATmega1284 / ATmega1284P present in
+;     `src/platforms/avr/atmega/common/fastpin_legacy_other.h`.
+;
+; Source issue is about Bobuino alternative pinout for ATmega1284 — that
+; needs a FastLED-side fix (FastPin variant selector) plus, ideally, a
+; separate board JSON that points at the Bobuino variant directory.
+
+[env:atmega1284]
+platform = atmelavr
+board = 1284p16m
+framework = arduino

--- a/tests/platform/atmega1284/src/README.md
+++ b/tests/platform/atmega1284/src/README.md
@@ -1,0 +1,3 @@
+# Source
+
+ATmega1284P (Microduino Core+ variant) test sketch source files.

--- a/tests/platform/atmega1284/src/main.ino
+++ b/tests/platform/atmega1284/src/main.ino
@@ -1,0 +1,18 @@
+// Minimal ATmega1284P (Microduino Core+ variant) sketch used as the fbuild
+// smoke fixture for FastLED/fbuild#389 (source: FastLED/FastLED#1253
+// "ATmega1284 alternative pin mappings").
+//
+// Kept as a bare setup()/loop() so the fbuild side proves out independently
+// of the FastLED-side Bobuino-pinout discussion in the source issue.
+#include <Arduino.h>
+
+void setup() {
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+}

--- a/tests/platform/attiny13/README.md
+++ b/tests/platform/attiny13/README.md
@@ -1,0 +1,33 @@
+# ATtiny13 (MicroCore) Tracker Fixture
+
+Minimal ATtiny13 project used to track fbuild support state for the smallest
+classic ATtiny class. Source FastLED issue: FastLED/FastLED#581. fbuild
+tracker: FastLED/fbuild#389.
+
+## Current fbuild status (2026-06-03)
+
+- **Board metadata**: present
+  (`crates/fbuild-config/assets/boards/json/attiny13.json`,
+  `attiny13a.json`). Both declare `core = MicroCore`.
+- **Framework registry**: `MicroCore` is NOT mapped in
+  `crates/fbuild-packages/assets/avr_frameworks.json`. The AVR
+  orchestrator will fail at `AvrFramework::for_core("MicroCore", ..)`
+  with "no AVR framework registered for core 'MicroCore'".
+- **FastLED pin map**: present
+  (`src/platforms/avr/attiny/pins/fastpin_attiny.h` has an
+  `__AVR_ATtiny13__` branch).
+
+## What this fixture proves
+
+This fixture intentionally does NOT `#include <FastLED.h>` — the fbuild
+framework-resolve step fails first, so adding FastLED would only mask the
+real blocker. Once `MicroCore` is added to `avr_frameworks.json` (github =
+`MCUdude/MicroCore`, validation_path = `cores/MicroCore/Arduino.h`), this
+directory can be flipped to a real FastLED smoke build with a single edit.
+
+## Why a 1 KiB flash chip matters
+
+The ATtiny13 has only 1 KiB of flash and 64 B of RAM. A realistic FastLED
+demo will not fit; the value of this fixture is verifying that the
+framework + toolchain wiring resolves at all, not that a useful sketch
+links.

--- a/tests/platform/attiny13/platformio.ini
+++ b/tests/platform/attiny13/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO Project Configuration File
+;
+; ATtiny13 (MCUdude/MicroCore) smoke fixture used to track fbuild support
+; state for the smallest classic ATtiny class.
+;
+; Status (FastLED/fbuild#389, source FastLED/FastLED#581):
+;   - Board metadata: present (`crates/fbuild-config/assets/boards/json/attiny13.json`)
+;     uses `core = MicroCore`.
+;   - Framework registry: `MicroCore` is NOT mapped in
+;     `crates/fbuild-packages/assets/avr_frameworks.json`. The AVR
+;     orchestrator will fail at `AvrFramework::for_core("MicroCore", ..)`
+;     with "no AVR framework registered for core 'MicroCore'".
+;   - FastLED pin map for `__AVR_ATtiny13__` exists in
+;     `src/platforms/avr/attiny/pins/fastpin_attiny.h`.
+;
+; Adding `MicroCore` to `avr_frameworks.json` (github =
+; "MCUdude/MicroCore", validation_path = "cores/MicroCore/Arduino.h")
+; is the minimum fbuild change needed to unblock this board.
+
+[env:attiny13]
+platform = atmelavr
+board = attiny13
+framework = arduino

--- a/tests/platform/attiny13/src/README.md
+++ b/tests/platform/attiny13/src/README.md
@@ -1,0 +1,3 @@
+# Source
+
+ATtiny13 (MCUdude/MicroCore) test sketch source files.

--- a/tests/platform/attiny13/src/main.ino
+++ b/tests/platform/attiny13/src/main.ino
@@ -1,0 +1,22 @@
+// Minimal ATtiny13 sketch used as the fbuild smoke fixture for
+// FastLED/fbuild#389 (source: FastLED/FastLED#581 "Need ATTiny13 support").
+//
+// Kept as a bare setup()/loop() rather than including FastLED because
+// (a) the MicroCore framework is not yet wired into
+// `crates/fbuild-packages/assets/avr_frameworks.json` so the build will
+// stop at the framework-resolve step regardless of FastLED inclusion,
+// and (b) the ATtiny13 has only 1 KiB of flash / 64 B of RAM, so the
+// representative FastLED smoke is "platform compiles" rather than a
+// real LED-driving program.
+#include <Arduino.h>
+
+void setup() {
+    pinMode(1, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(1, HIGH);
+    delay(500);
+    digitalWrite(1, LOW);
+    delay(500);
+}

--- a/tests/platform/avr128da64/README.md
+++ b/tests/platform/avr128da64/README.md
@@ -1,0 +1,44 @@
+# AVR128DA64 (DxCore) Tracker Fixture
+
+Minimal AVR128DA64 project used to track fbuild support state for the
+AVR-Dx (DA / DB / DD) family. Source FastLED issue:
+FastLED/FastLED#1307. fbuild tracker: FastLED/fbuild#389.
+
+## Current fbuild status (2026-06-03)
+
+- **Board metadata**: present for the full AVR-Dx matrix
+  (`crates/fbuild-config/assets/boards/json/AVR128DA*.json`,
+  `AVR128DB*.json`, `AVR64DA*.json`, `AVR64DB*.json`, `AVR64DD*.json`,
+  `AVR32DA*.json`, `AVR32DB*.json`, `AVR64DD14/20/28/32.json`).
+  All entries declare `platform = atmelmegaavr` and `core = dxcore`.
+- **Framework registry**: `dxcore` is NOT mapped in
+  `crates/fbuild-packages/assets/avr_frameworks.json`. The AVR
+  orchestrator will fail at `AvrFramework::for_core("dxcore", ..)`
+  with "no AVR framework registered for core 'dxcore'".
+- **FastLED platform support**: NO `AVR_DA` / `AVR128DA*` /
+  `__AVR_AVR128DA*__` branch in `src/platforms/avr/`. The user-supplied
+  pin map in FastLED/FastLED#1307 has not been merged into
+  `src/platforms/avr/atmega/` or similar.
+
+## What this fixture proves
+
+This fixture intentionally does NOT `#include <FastLED.h>` — fbuild fails
+at framework resolve first, and even if it didn't, FastLED would `#error`
+on the missing platform support. Both gaps must close before this
+directory can be flipped to a real FastLED smoke build.
+
+## Next steps (fbuild-side)
+
+Add a `dxcore` entry to `avr_frameworks.json` (github =
+`SpenceKonde/DxCore`, validation_path = `cores/dxcore/Arduino.h`,
+core_dir = `dxcore`). Possibly also gate the megaTinyCore-style toolchain
+on the newer AVR-LibC / GCC bundle that DxCore ships with.
+
+## Next steps (FastLED-side)
+
+Land an AVR-Dx pin map alongside `src/platforms/avr/atmega/m4809/` so
+that `__AVR_AVR128DA64__` / `__AVR_AVR128DB64__` / etc. resolve to
+`_FL_DEFPIN(...)` macros consistent with DxCore's port mapping. The pin
+table in FastLED/FastLED#1307 is a starting point. Hardware SPI defs
+need `SPI_DATA` / `SPI_CLOCK` constants for the AVR-Dx SPI peripheral
+(USART-based fallback is also an option).

--- a/tests/platform/avr128da64/platformio.ini
+++ b/tests/platform/avr128da64/platformio.ini
@@ -1,0 +1,24 @@
+; PlatformIO Project Configuration File
+;
+; AVR128DA64 (SpenceKonde/DxCore) smoke fixture used to track fbuild support
+; state for the AVR-Dx (DA / DB / DD) family.
+;
+; Status (FastLED/fbuild#389, source FastLED/FastLED#1307):
+;   - Board metadata: present for the full AVR-Dx matrix
+;     (`crates/fbuild-config/assets/boards/json/AVR128DA*.json`,
+;     `AVR128DB*.json`, `AVR64DA*.json`, `AVR64DB*.json`, `AVR64DD*.json`,
+;     `AVR32DA*.json`, `AVR32DB*.json`) — all declare `core = dxcore`.
+;   - Framework registry: `dxcore` is NOT mapped in
+;     `crates/fbuild-packages/assets/avr_frameworks.json`. The AVR
+;     orchestrator will fail at `AvrFramework::for_core("dxcore", ..)`.
+;   - FastLED pin map: NO `AVR_DA` / `AVR128DA*` / `__AVR_AVR128DA*__`
+;     support in `src/platforms/avr/`. The user-supplied pin map in
+;     FastLED/FastLED#1307 has not been merged.
+;
+; Both fbuild (DxCore framework wiring) and FastLED (AVR-Dx pin map +
+; HW SPI defs) need work before this fixture can build with FastLED.
+
+[env:avr128da64]
+platform = atmelmegaavr
+board = AVR128DA64
+framework = arduino

--- a/tests/platform/avr128da64/src/README.md
+++ b/tests/platform/avr128da64/src/README.md
@@ -1,0 +1,3 @@
+# Source
+
+AVR128DA64 (SpenceKonde/DxCore) test sketch source files.

--- a/tests/platform/avr128da64/src/main.ino
+++ b/tests/platform/avr128da64/src/main.ino
@@ -1,0 +1,21 @@
+// Minimal AVR128DA64 sketch used as the fbuild smoke fixture for
+// FastLED/fbuild#389 (source: FastLED/FastLED#1307 "AVR128DA64").
+//
+// Kept as a bare setup()/loop() rather than including FastLED because
+// (a) the DxCore framework is not yet wired into
+// `crates/fbuild-packages/assets/avr_frameworks.json`, and (b) FastLED's
+// `src/platforms/avr/` has no AVR-Dx pin support / hardware SPI defs.
+// Either gap would terminate the build before the AVR-Dx-specific code
+// path runs.
+#include <Arduino.h>
+
+void setup() {
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+}

--- a/tests/platform/mega/README.md
+++ b/tests/platform/mega/README.md
@@ -1,0 +1,13 @@
+# Arduino Mega 2560 Test Project
+
+Minimal blink + serial sketch for ATmega2560 (Arduino Mega) build validation.
+
+Referenced by `CLAUDE.md` and `README.md` as the `simavr` emulator example:
+
+```bash
+soldr cargo run -p fbuild-cli -- test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
+```
+
+Tracked under FastLED/fbuild#389 as the representative classic AVR megaAVR
+(8-bit AVR, 256 KiB flash, 8 KiB RAM) fixture. FastLED platform support for
+the m2560 family lives in `src/platforms/avr/atmega/m2560/`.

--- a/tests/platform/mega/platformio.ini
+++ b/tests/platform/mega/platformio.ini
@@ -1,0 +1,10 @@
+; PlatformIO Project Configuration File
+;
+; ATmega2560 / Arduino Mega smoke fixture for fbuild AVR validation.
+; Referenced by docs/CLAUDE.md and README.md as the simavr emulator target.
+; Tracked under FastLED/fbuild#389 (AVR / megaAVR / ATtiny build support).
+
+[env:megaatmega2560]
+platform = atmelavr
+board = megaatmega2560
+framework = arduino

--- a/tests/platform/mega/src/README.md
+++ b/tests/platform/mega/src/README.md
@@ -1,0 +1,3 @@
+# Source
+
+ATmega2560 (Arduino Mega) test sketch source files.

--- a/tests/platform/mega/src/main.ino
+++ b/tests/platform/mega/src/main.ino
@@ -1,0 +1,14 @@
+#include <Arduino.h>
+
+void setup() {
+    Serial.begin(115200);
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+    Serial.println("Hello from Mega 2560!");
+}


### PR DESCRIPTION
## Summary

Adds the missing-fixture half of FastLED/fbuild#389 (validate
AVR / megaAVR / ATtiny FastLED build support) and locks down the two
framework registry gaps that block AVR-Dx and MicroCore boards.

* `tests/platform/mega/` — ATmega2560 fixture for the `simavr`
  emulator example referenced by `CLAUDE.md` and `README.md`.
* `tests/platform/attiny13/` — tracker for FastLED/FastLED#581
  (needs `MicroCore` in `avr_frameworks.json`).
* `tests/platform/avr128da64/` — tracker for FastLED/FastLED#1307
  (needs `dxcore` in `avr_frameworks.json` AND FastLED-side AVR-Dx
  pin map / hardware SPI defs).
* `tests/platform/atmega1284/` — fixture for FastLED/FastLED#1253
  via the Microduino Core+ variant.

Two new tripwire tests in `crates/fbuild-packages/src/library/avr_framework.rs`
assert that `MicroCore` and `dxcore` lookups currently return errors.
When they're added to the registry the tests fail loudly and point at
the fixture READMEs that need to be flipped.

Source-issue mapping (rest is on the tracker issue itself):

| Source FastLED issue | Class | fbuild side | FastLED side |
|---|---|---|---|
| #536 attiny88 | ATTinyCore | OK | pin map exists |
| #581 attiny13 | MicroCore | **MicroCore missing in `avr_frameworks.json`** | pin map exists |
| #716 atmega4809 / nano_every | megaAVR | OK (`nano_every` fixture) | m4809 support exists |
| #960 ATTINY SCALE8 dead code | n/a | n/a | FastLED-side macro guard bug |
| #973 attiny412 / attiny1614 | megaTinyCore | OK (`ATtiny1604`, `ATtiny1616`) | pin maps exist |
| #1090 attiny2313a ColorPalette | ATTinyCore | OK (`attiny2313.json`) | RAM exhaustion on tiny |
| #1133 digispark | digistump-avr | OK (`digispark-tiny.json`, `dtiny` registered) | closed upstream |
| #1192 attiny88 mul opcode | ATTinyCore | OK | `LIB8_ATTINY` macro fix needed |
| #1253 atmega1284 Bobuino | MiniCore | OK (fixture added) | alt pin mappings needed |
| #1254 nano_every invalid pin | megaAVR | OK | m4809 pin map exists |
| #1307 AVR128DA64 | DxCore | **`dxcore` missing in `avr_frameworks.json`** | no AVR-Dx platform in FastLED |
| #1390 atmega664/A | MightyCore | **no `ATmega664A` board JSON**, MightyCore unregistered | no HW SPI defs |

## Test plan

- [x] `soldr cargo test -p fbuild-packages --lib library::avr_framework::tests::` (18 pass, includes 2 new tripwires)
- [ ] Build verification on each new fixture is **blocked** by a
      pre-existing main-branch break in
      `crates/fbuild-build/src/ch32v/orchestrator.rs` (calls
      removed `Ch32vCompiler::with_framework_root`). To be addressed
      in the in-flight `fix/ch32v-warnings-382` branch.

Closes: part of FastLED/fbuild#389

🤖 Generated with [Claude Code](https://claude.com/claude-code)