### PR TITLE
docs(tests): list adafruit_feather_nrf52840_sense fixture

### DIFF
--- a/tests/platform/README.md
+++ b/tests/platform/README.md
@@ -28,6 +28,7 @@ PlatformIO-compatible test projects for each supported hardware platform. Each s
 | `leonardo/` | ATmega32U4 | AVR | Arduino |
 | `mgm240/` | EFR32MG24 | ARM Cortex-M33 | Arduino |
 | `nano_every/` | ATmega4809 | MegaAVR | Arduino |
+| `adafruit_feather_nrf52840_sense/` | nRF52840 | ARM Cortex-M4F | Arduino |
 | `nrf52840_dk/` | nRF52840 | ARM Cortex-M4F | Arduino |
 | `supermini_nrf52840/` | nRF52840 | ARM Cortex-M4F | Arduino |
 | `nice_nano_nrf52840/` | nRF52840 | ARM Cortex-M4F | Arduino |


### PR DESCRIPTION
## Summary

- Adds the `adafruit_feather_nrf52840_sense/` row to the platform-tests README; the fixture exists on disk and builds clean, but was missing from the table.

Part of FastLED/fbuild#388 (validate nRF / mbed FastLED build support).

## Test plan

- [x] Verified the fixture builds: `fbuild build tests/platform/adafruit_feather_nrf52840_sense -e nrf52840_sense --quick` → Flash 32.27KB / 796KB, RAM 230KB / 243KB
- [x] All five nRF52840 fixtures (`adafruit_feather_nrf52840_sense`, `nrf52840_dk`, `supermini_nrf52840`, `nice_nano_nrf52840`, `nrfmicro_nrf52840`) build clean against the Adafruit nRF52 Arduino core

🤖 Generated with [Claude Code](https://claude.com/claude-code)