### PR TITLE
fix(ch32v): scope third-party OpenWCH warnings + remove duplicate CH32V30x_D8C define

### DIFF
--- a/crates/fbuild-build/src/ch32v/ch32v_compiler.rs
+++ b/crates/fbuild-build/src/ch32v/ch32v_compiler.rs
@@ -23,6 +23,12 @@ pub struct Ch32vCompiler {
     extra_pre_flags: Vec<String>,
     /// PlatformIO `build_unflags`. See FastLED/fbuild#37.
     build_unflags: Vec<String>,
+    /// Root of the third-party OpenWCH core install. Sources rooted under this
+    /// path get warnings silenced — we don't own that code, and the pinned
+    /// `arduino_core_ch32` 1.0.4 release does not build cleanly under our
+    /// `-Wall -Wextra` policy. User sketch sources and project libraries are
+    /// not affected. See FastLED/fbuild#382.
+    framework_root: Option<PathBuf>,
 }
 
 impl Ch32vCompiler {
@@ -54,12 +60,23 @@ impl Ch32vCompiler {
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
             extra_pre_flags,
             build_unflags: Vec::new(),
+            framework_root: None,
         }
     }
 
     /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
     pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
         self.build_unflags = build_unflags;
+        self
+    }
+
+    /// Scope warning suppressions to sources under `root`.
+    ///
+    /// Used to silence diagnostics from the pinned OpenWCH `arduino_core_ch32`
+    /// release without hiding warnings on user/sketch code. See
+    /// FastLED/fbuild#382.
+    pub fn with_framework_root(mut self, root: PathBuf) -> Self {
+        self.framework_root = Some(root);
         self
     }
 
@@ -78,6 +95,34 @@ impl Ch32vCompiler {
         flags.extend(self.base.build_include_flags());
         flags
     }
+
+    /// Return `true` if `source` lives under the configured framework root.
+    fn is_framework_source(&self, source: &Path) -> bool {
+        let Some(root) = self.framework_root.as_ref() else {
+            return false;
+        };
+        match (
+            std::fs::canonicalize(source).ok(),
+            std::fs::canonicalize(root).ok(),
+        ) {
+            (Some(s), Some(r)) => s.starts_with(&r),
+            _ => source.starts_with(root),
+        }
+    }
+}
+
+/// Flags appended when compiling third-party OpenWCH core/variant sources.
+///
+/// fbuild's CH32V common flags include `-Wall -Wextra`, which the pinned
+/// upstream `arduino_core_ch32` 1.0.4 release does not build cleanly under.
+/// One of the diagnostics it emits — "excess elements in struct initializer"
+/// — has no dedicated `-Wno-*` toggle (it's hard-wired on in GCC, independent
+/// of `-Wall`/`-Wextra`), so the only way to make a clean build is the blanket
+/// `-w`. Scope: framework sources only. User sketch and project libraries
+/// still compile under the full `-Wall -Wextra` policy, so new diagnostics on
+/// user code are not hidden. See FastLED/fbuild#382.
+fn framework_suppression_flags() -> &'static [&'static str] {
+    &["-w"]
 }
 
 impl Compiler for Ch32vCompiler {
@@ -89,12 +134,32 @@ impl Compiler for Ch32vCompiler {
         flags: &[String],
         extra_flags: &[String],
     ) -> Result<CompileResult> {
+        // Append framework warning suppressions after user-provided flags so
+        // they override any earlier `-W` toggles. Scoped strictly to sources
+        // rooted in the OpenWCH core/variant install; sketch sources and
+        // project libraries continue to see the full `-Wall -Wextra` set.
+        let suppressed_extra: Vec<String>;
+        let effective_extra: &[String] = if self.is_framework_source(source) {
+            suppressed_extra = extra_flags
+                .iter()
+                .cloned()
+                .chain(
+                    framework_suppression_flags()
+                        .iter()
+                        .map(|s| (*s).to_string()),
+                )
+                .collect();
+            &suppressed_extra
+        } else {
+            extra_flags
+        };
+
         crate::compiler::compile_source(
             compiler_path,
             source,
             output,
             flags,
-            extra_flags,
+            effective_extra,
             &self.temp_dir,
             "ch32v",
             self.base.verbose,
@@ -121,6 +186,36 @@ impl Compiler for Ch32vCompiler {
 
     fn build_unflags(&self) -> &[String] {
         &self.build_unflags
+    }
+
+    /// Mirror the per-source suppression logic in [`Self::compile_one`] so the
+    /// rebuild fingerprint changes whenever the third-party flag set changes.
+    /// Otherwise an existing object compiled with the old flags would be
+    /// considered up-to-date after the suppressions move or expand.
+    fn rebuild_signature(&self, source: &Path, extra_flags: &[String]) -> String {
+        let ext = source
+            .extension()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_lowercase();
+        let (compiler_path, flags) = match ext.as_str() {
+            "c" | "s" => (self.gcc_path(), self.c_flags()),
+            _ => (self.gxx_path(), self.cpp_flags()),
+        };
+        let extra_owned: Vec<String> = if self.is_framework_source(source) {
+            extra_flags
+                .iter()
+                .cloned()
+                .chain(
+                    framework_suppression_flags()
+                        .iter()
+                        .map(|s| (*s).to_string()),
+                )
+                .collect()
+        } else {
+            extra_flags.to_vec()
+        };
+        crate::compiler::build_rebuild_signature(compiler_path, &flags, &[], &extra_owned)
     }
 }
 
@@ -187,5 +282,59 @@ mod tests {
         assert!(flags.contains(&"-std=gnu++17".to_string()));
         assert!(flags.contains(&"-fno-exceptions".to_string()));
         assert!(flags.contains(&"-fno-rtti".to_string()));
+    }
+
+    #[test]
+    fn test_is_framework_source_without_root() {
+        let compiler = test_compiler();
+        assert!(!compiler.is_framework_source(Path::new("/anywhere/foo.cpp")));
+    }
+
+    #[test]
+    fn test_is_framework_source_with_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let framework_root = tmp.path().join("openwch-core");
+        let core_dir = framework_root.join("cores/arduino/ch32");
+        std::fs::create_dir_all(&core_dir).unwrap();
+        let core_src = core_dir.join("analog.cpp");
+        std::fs::write(&core_src, "// stub").unwrap();
+        let user_dir = tmp.path().join("project/src");
+        std::fs::create_dir_all(&user_dir).unwrap();
+        let user_src = user_dir.join("main.cpp");
+        std::fs::write(&user_src, "// stub").unwrap();
+
+        let compiler = test_compiler().with_framework_root(framework_root);
+        assert!(compiler.is_framework_source(&core_src));
+        assert!(!compiler.is_framework_source(&user_src));
+    }
+
+    #[test]
+    fn test_framework_suppression_flags_silence_everything() {
+        // GCC's "excess elements in struct initializer" diagnostic has no
+        // dedicated `-Wno-*` toggle, so the OpenWCH 1.0.4 core can only be
+        // built cleanly with `-w`. Lock in the blanket-suppression policy so
+        // a future "let's just disable specific warnings" patch trips this
+        // test and re-reads the rationale in FastLED/fbuild#382.
+        assert_eq!(framework_suppression_flags(), &["-w"]);
+    }
+
+    #[test]
+    fn test_rebuild_signature_differs_for_framework_source() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let framework_root = tmp.path().join("openwch-core");
+        let core_dir = framework_root.join("cores/arduino/ch32");
+        std::fs::create_dir_all(&core_dir).unwrap();
+        let core_src = core_dir.join("analog.cpp");
+        std::fs::write(&core_src, "// stub").unwrap();
+        let user_src = tmp.path().join("main.cpp");
+        std::fs::write(&user_src, "// stub").unwrap();
+
+        let compiler = test_compiler().with_framework_root(framework_root);
+        let core_sig = compiler.rebuild_signature(&core_src, &[]);
+        let user_sig = compiler.rebuild_signature(&user_src, &[]);
+        assert_ne!(
+            core_sig, user_sig,
+            "framework signature must include the suppression flags"
+        );
     }
 }

--- a/crates/fbuild-build/src/ch32v/orchestrator.rs
+++ b/crates/fbuild-build/src/ch32v/orchestrator.rs
@@ -150,7 +150,10 @@ impl BuildOrchestrator for Ch32vOrchestrator {
             params.verbose,
             isystem_flags,
         )
-        .with_build_unflags(ctx.build_unflags.clone());
+        .with_build_unflags(ctx.build_unflags.clone())
+        // Scope third-party `-Wno-*` suppressions to the OpenWCH core/variant
+        // install only. See FastLED/fbuild#382.
+        .with_framework_root(framework_dir.clone());
 
         // 7. Create linker (resolve linker script from system dir)
         // CH32V linker scripts are in system/<SERIES>/SRC/Ld/, not in variants/

--- a/crates/fbuild-config/assets/boards/json/genericCH32V303VCT6.json
+++ b/crates/fbuild-config/assets/boards/json/genericCH32V303VCT6.json
@@ -8,7 +8,7 @@
     },
     "clock_source": "hsi+pll",
     "core": "openwch",
-    "extra_flags": "-DCH32V303VC -DCH32V30X -DCH32V30x -DCH32V303 -DCH32V30x_D8",
+    "extra_flags": "-DCH32V303VC -DCH32V30X -DCH32V30x -DCH32V303",
     "f_cpu": "144000000L",
     "mabi": "ilp32",
     "march": "rv32imacxw",

--- a/crates/fbuild-config/assets/boards/json/genericCH32V307VCT6.json
+++ b/crates/fbuild-config/assets/boards/json/genericCH32V307VCT6.json
@@ -8,7 +8,7 @@
     },
     "clock_source": "hsi+pll",
     "core": "openwch",
-    "extra_flags": "-DCH32V30x_C -DCH32V307VC -DCH32V30X -DCH32V30x -DCH32V307 -DCH32V30x_D8C",
+    "extra_flags": "-DCH32V30x_C -DCH32V307VC -DCH32V30X -DCH32V30x -DCH32V307",
     "f_cpu": "144000000L",
     "mabi": "ilp32",
     "march": "rv32imacxw",


### PR DESCRIPTION
Closes #382.

## Summary

The `Build CH32V307` workflow currently emits **104 warning lines** (52 unique
sites x quick + release) on every successful run. All of them come from the
pinned upstream `openwch/arduino_core_ch32` 1.0.4 release plus one redundant
local `-DCH32V30x_D8C` define in `genericCH32V307VCT6.json`.

This change drives the CH32V307 build to zero `warning:` lines without hiding
warnings on user/sketch code.

## Changes

* **Scoped warning suppression** for third-party OpenWCH sources only:
  * `Ch32vCompiler::with_framework_root(root)` — orchestrator now points
    the compiler at the OpenWCH install path.
  * `compile_one` and `rebuild_signature` detect sources rooted under that
    path and append `-w` to silence upstream diagnostics.
  * User sketch sources and project libraries are unaffected and continue
    to compile under the full `-Wall -Wextra` policy, so new diagnostics
    on user code still surface in CI.
  * Why `-w` (and not a specific `-Wno-*` allowlist): GCC's
    `excess elements in struct initializer` — the largest single bucket
    in #382 — has no dedicated `-Wno-*` toggle. A precise allowlist would
    still leak that diagnostic. `-w` is the only clean stance for code we
    don't own.

* **Removed duplicate `CH32V30x_D8C` / `CH32V30x_D8` defines**:
  * `genericCH32V307VCT6.json` no longer passes `-DCH32V30x_D8C`.
  * `genericCH32V303VCT6.json` no longer passes `-DCH32V30x_D8` (same
    pattern, same redefine warning).
  * OpenWCH's `ch32_def_build.h` derives both from `CH32V30x_C` and
    `CH32V30x` respectively; the board JSONs were duplicating them and
    producing redefinition warnings.

## Open questions in the issue, resolved here

* "Patch the core, or scope flag suppressions?" → **Scope flag
  suppressions.** Keeps the package install byte-for-byte upstream and
  doesn't bloat `Ch32vCores::patch_compatibility`.
* "Apply only to CH32V307, or to every CH32V board on
  `arduino_core_ch32`?" → **Apply broadly.** The orchestrator wires
  `with_framework_root(framework_dir)` unconditionally, so every CH32V
  board that consumes the OpenWCH core benefits.
* "Are the `setup-soldr` annotations in scope?" → **No, out of scope.**
  Those annotations are about the cache/linker policy and are not
  CH32V-specific. They should be tracked separately if we want to silence
  them.

## Test plan

- [x] `soldr cargo check --workspace --all-targets`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo test -p fbuild-build --lib ch32v` (25/25 pass, incl. 4 new tests)
- [x] Local fresh build `FBUILD_DEV_MODE=1 fbuild build tests/platform/ch32v307 -e ch32v307 --quick` -> **0 warnings**
- [x] Local fresh build `FBUILD_DEV_MODE=1 fbuild build tests/platform/ch32v307 -e ch32v307 --release` -> **0 warnings**
- [ ] `Build CH32V307` workflow on this PR -> expected 0 warnings (was 104)