### PR TITLE
fix(esp32): surface daemon errors + provision platform.json helper toolchains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.16"
+version = "2.2.17"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/crates/fbuild-build/src/esp32/orchestrator/packages.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator/packages.rs
@@ -65,9 +65,12 @@ pub(super) fn resolve_pioarduino_packages(
     Ok((toolchain, framework))
 }
 
-/// Eagerly resolve toolchain-* packages listed in `platform.json` other
-/// than the MCU-primary toolchain. Each resolution miss is logged at warn
-/// level but never fails the caller. See fbuild#401 for context.
+/// Provision toolchain-* packages listed in `platform.json` other than the
+/// MCU-primary toolchain — e.g. `toolchain-riscv32-esp` on ESP32-S3 (Xtensa
+/// cores + RISC-V ULP coprocessor). Cache-aware: a helper toolchain whose
+/// cache directory already exists is skipped without touching the network,
+/// so the steady-state cost on a warm cache is zero. Each resolution miss
+/// is logged at warn level but never fails the caller. See fbuild#401.
 fn provision_helper_toolchains(
     platform: &fbuild_packages::library::Esp32Platform,
     project_dir: &Path,
@@ -87,12 +90,17 @@ fn provision_helper_toolchains(
         }
     };
 
+    let cache = fbuild_packages::Cache::new(project_dir);
+    let toolchains_dir = cache.toolchains_dir();
     for (name, metadata_url) in entries {
         if name == primary || !name.starts_with("toolchain-") {
             continue;
         }
-        let cache = fbuild_packages::Cache::new(project_dir);
-        let cache_dir = cache.toolchains_dir().join(&name);
+        let cache_dir = toolchains_dir.join(&name);
+        if cache_dir.exists() {
+            tracing::debug!("helper toolchain {} already cached, skipping", name);
+            continue;
+        }
         match fbuild_packages::toolchain::esp32_metadata::resolve_toolchain_url_sync(
             &metadata_url,
             &name,

--- a/crates/fbuild-build/src/esp32/orchestrator/packages.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator/packages.rs
@@ -23,6 +23,15 @@ pub(super) fn resolve_pioarduino_packages(
     // Resolve toolchain via metadata
     let toolchain = resolve_and_create_toolchain(&platform, project_dir, mcu_config)?;
 
+    // Opportunistically provision any helper toolchains listed in
+    // `platform.json` alongside the MCU-primary toolchain — e.g.
+    // `toolchain-riscv32-esp` on ESP32-S3 (Xtensa cores + RISC-V ULP
+    // coprocessor). Best-effort: a missing helper isn't fatal because most
+    // FastLED sketches don't compile ULP code, but eagerly caching the
+    // helper means builds that DO need it never hit a cold-cache stall.
+    // See fbuild#401.
+    provision_helper_toolchains(&platform, project_dir, mcu_config);
+
     // Resolve framework
     let framework = match platform.get_package_url("framework-arduinoespressif32") {
         Ok(url) => {
@@ -54,6 +63,59 @@ pub(super) fn resolve_pioarduino_packages(
     }
 
     Ok((toolchain, framework))
+}
+
+/// Eagerly resolve toolchain-* packages listed in `platform.json` other
+/// than the MCU-primary toolchain. Each resolution miss is logged at warn
+/// level but never fails the caller. See fbuild#401 for context.
+fn provision_helper_toolchains(
+    platform: &fbuild_packages::library::Esp32Platform,
+    project_dir: &Path,
+    mcu_config: &super::super::mcu_config::Esp32McuConfig,
+) {
+    let primary = if mcu_config.is_riscv() {
+        "toolchain-riscv32-esp"
+    } else {
+        "toolchain-xtensa-esp-elf"
+    };
+
+    let entries = match platform.enumerate_packages() {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!("could not enumerate platform.json packages: {}", e);
+            return;
+        }
+    };
+
+    for (name, metadata_url) in entries {
+        if name == primary || !name.starts_with("toolchain-") {
+            continue;
+        }
+        let cache = fbuild_packages::Cache::new(project_dir);
+        let cache_dir = cache.toolchains_dir().join(&name);
+        match fbuild_packages::toolchain::esp32_metadata::resolve_toolchain_url_sync(
+            &metadata_url,
+            &name,
+            &cache_dir,
+        ) {
+            Ok(resolved) => {
+                tracing::info!(
+                    "provisioned helper toolchain {} from platform.json: {}",
+                    name,
+                    resolved.url
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "could not provision helper toolchain {} from {}: {} \
+                     (builds that don't reference this toolchain will still work)",
+                    name,
+                    metadata_url,
+                    e
+                );
+            }
+        }
+    }
 }
 
 fn resolve_and_create_toolchain(

--- a/crates/fbuild-cli/src/daemon_client.rs
+++ b/crates/fbuild-cli/src/daemon_client.rs
@@ -513,7 +513,11 @@ impl DaemonClient {
 
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| {
-                fbuild_core::FbuildError::DaemonError(format!("stream error: {}", e))
+                fbuild_core::FbuildError::DaemonError(format!(
+                    "lost connection to daemon mid-build ({}); the daemon \
+                     process may have died — check ~/.fbuild/daemon/daemon.log",
+                    e
+                ))
             })?;
             buffer.push_str(&String::from_utf8_lossy(&chunk));
 

--- a/crates/fbuild-cli/src/daemon_client.rs
+++ b/crates/fbuild-cli/src/daemon_client.rs
@@ -515,8 +515,9 @@ impl DaemonClient {
             let chunk = chunk.map_err(|e| {
                 fbuild_core::FbuildError::DaemonError(format!(
                     "lost connection to daemon mid-build ({}); the daemon \
-                     process may have died — check ~/.fbuild/daemon/daemon.log",
-                    e
+                     process may have died — check {}",
+                    e,
+                    fbuild_paths::get_daemon_log_file().display()
                 ))
             })?;
             buffer.push_str(&String::from_utf8_lossy(&chunk));

--- a/crates/fbuild-daemon/src/handlers/operations/build.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/build.rs
@@ -9,6 +9,51 @@ use axum::Json;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// Ensures a terminal `result` NDJSON event reaches the client, even if the
+/// streaming task panics or returns early. Without this, the body stream
+/// closes mid-frame and the client sees the opaque
+/// `stream error: error decoding response body` from reqwest with no clue
+/// what went wrong. See fbuild#401.
+struct StreamTerminationGuard {
+    tx: tokio::sync::mpsc::UnboundedSender<bytes::Bytes>,
+    request_id: String,
+    completed: bool,
+}
+
+impl StreamTerminationGuard {
+    fn new(tx: tokio::sync::mpsc::UnboundedSender<bytes::Bytes>, request_id: String) -> Self {
+        Self {
+            tx,
+            request_id,
+            completed: false,
+        }
+    }
+
+    fn mark_completed(&mut self) {
+        self.completed = true;
+    }
+}
+
+impl Drop for StreamTerminationGuard {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        let event = serde_json::json!({
+            "type": "result",
+            "success": false,
+            "request_id": self.request_id,
+            "message": "daemon build worker terminated unexpectedly (panic or early return); check ~/.fbuild/daemon/daemon.log",
+            "exit_code": 1,
+            "output_file": null,
+            "output_dir": null,
+        });
+        let mut chunk = event.to_string();
+        chunk.push('\n');
+        let _ = self.tx.send(bytes::Bytes::from(chunk));
+    }
+}
+
 /// POST /api/build
 pub async fn build(
     State(ctx): State<Arc<DaemonContext>>,
@@ -130,7 +175,10 @@ pub async fn build(
         };
 
         let project_dir_desc = req.project_dir.clone();
+        let guard_request_id = request_id.clone();
         tokio::spawn(async move {
+            let mut termination_guard =
+                StreamTerminationGuard::new(async_tx.clone(), guard_request_id);
             // FBUILD_PERF_LOG=1 enables daemon-side coarse phase timing
             // (lock-wait + build). Zero overhead when unset.
             let perf_enabled = std::env::var("FBUILD_PERF_LOG")
@@ -327,6 +375,10 @@ pub async fn build(
             let mut chunk = result_event.to_string();
             chunk.push('\n');
             let _ = async_tx.send(bytes::Bytes::from(chunk));
+
+            // Final event sent successfully — disarm the termination guard so
+            // its Drop impl does not emit a duplicate fallback event.
+            termination_guard.mark_completed();
         });
 
         // Return streaming response immediately
@@ -476,5 +528,48 @@ pub async fn build(
             )
                 .into_response(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// fbuild#401: when the streaming task panics or returns early without
+    /// emitting the result event, the guard's Drop impl must enqueue a
+    /// fallback terminal event so the CLI sees a meaningful error.
+    #[test]
+    fn termination_guard_emits_fallback_on_drop_when_not_completed() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<bytes::Bytes>();
+        {
+            let _guard = StreamTerminationGuard::new(tx, "req-123".to_string());
+            // Simulate panic / early return: drop without calling mark_completed.
+        }
+        let chunk = rx.try_recv().expect("guard should enqueue fallback event");
+        let line = std::str::from_utf8(&chunk).unwrap().trim_end();
+        let event: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert_eq!(event["type"], "result");
+        assert_eq!(event["success"], false);
+        assert_eq!(event["exit_code"], 1);
+        assert_eq!(event["request_id"], "req-123");
+        let msg = event["message"].as_str().unwrap();
+        assert!(
+            msg.contains("terminated unexpectedly"),
+            "fallback message should be actionable, got: {msg}"
+        );
+    }
+
+    /// After mark_completed, drop must NOT emit a duplicate event.
+    #[test]
+    fn termination_guard_silent_on_drop_when_completed() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<bytes::Bytes>();
+        {
+            let mut guard = StreamTerminationGuard::new(tx, "req-456".to_string());
+            guard.mark_completed();
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "completed guard must not enqueue a fallback event"
+        );
     }
 }

--- a/crates/fbuild-packages/src/library/esp32_platform.rs
+++ b/crates/fbuild-packages/src/library/esp32_platform.rs
@@ -76,68 +76,61 @@ impl Esp32Platform {
         self.get_package_url(package_name)
     }
 
+    /// Read and parse the `packages` section of `platform.json`.
+    ///
+    /// Shared between [`Self::get_package_url`] and
+    /// [`Self::enumerate_packages`] so the read/parse/lookup logic stays in
+    /// one place and the error messages stay consistent.
+    fn read_packages_section(&self) -> Result<serde_json::Map<String, serde_json::Value>> {
+        let platform_json_path = self.resolved_dir().join("platform.json");
+
+        let content = std::fs::read_to_string(&platform_json_path).map_err(|e| {
+            FbuildError::PackageError(format!(
+                "failed to read platform.json at {}: {}",
+                platform_json_path.display(),
+                e
+            ))
+        })?;
+
+        let data: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+            FbuildError::PackageError(format!("failed to parse platform.json: {}", e))
+        })?;
+
+        data.get("packages")
+            .and_then(|p| p.as_object())
+            .cloned()
+            .ok_or_else(|| {
+                FbuildError::PackageError("platform.json has no `packages` section".to_string())
+            })
+    }
+
     /// Get a package URL from platform.json by package name.
     ///
     /// The `packages` section of platform.json maps package names to objects
     /// with a `version` field that contains the metadata URL.
     pub fn get_package_url(&self, package_name: &str) -> Result<String> {
-        let platform_json_path = self.resolved_dir().join("platform.json");
-
-        let content = std::fs::read_to_string(&platform_json_path).map_err(|e| {
-            FbuildError::PackageError(format!(
-                "failed to read platform.json at {}: {}",
-                platform_json_path.display(),
-                e
-            ))
-        })?;
-
-        let data: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
-            FbuildError::PackageError(format!("failed to parse platform.json: {}", e))
-        })?;
-
-        let url = data
-            .get("packages")
-            .and_then(|p| p.get(package_name))
+        let packages = self.read_packages_section()?;
+        packages
+            .get(package_name)
             .and_then(|pkg| pkg.get("version"))
             .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
             .ok_or_else(|| {
                 FbuildError::PackageError(format!(
                     "package '{}' not found in platform.json",
                     package_name
                 ))
-            })?;
-
-        Ok(url.to_string())
+            })
     }
 
     /// Enumerate every package listed in `platform.json`'s `packages` section.
     ///
-    /// Returns `(name, version_url)` pairs. The orchestrator uses this to
-    /// provision helper packages (e.g. `toolchain-riscv32-esp` for ULP code on
-    /// ESP32-S3) that are listed alongside the MCU-primary toolchain.
-    /// See fbuild#401.
+    /// Returns `(name, version_url)` pairs sorted by name. The orchestrator
+    /// uses this to surface helper packages (e.g. `toolchain-riscv32-esp` for
+    /// ULP code on ESP32-S3) that are listed alongside the MCU-primary
+    /// toolchain. See fbuild#401.
     pub fn enumerate_packages(&self) -> Result<Vec<(String, String)>> {
-        let platform_json_path = self.resolved_dir().join("platform.json");
-
-        let content = std::fs::read_to_string(&platform_json_path).map_err(|e| {
-            FbuildError::PackageError(format!(
-                "failed to read platform.json at {}: {}",
-                platform_json_path.display(),
-                e
-            ))
-        })?;
-
-        let data: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
-            FbuildError::PackageError(format!("failed to parse platform.json: {}", e))
-        })?;
-
-        let packages = data
-            .get("packages")
-            .and_then(|p| p.as_object())
-            .ok_or_else(|| {
-                FbuildError::PackageError("platform.json has no `packages` section".to_string())
-            })?;
-
+        let packages = self.read_packages_section()?;
         let mut entries: Vec<(String, String)> = packages
             .iter()
             .filter_map(|(name, value)| {

--- a/crates/fbuild-packages/src/library/esp32_platform.rs
+++ b/crates/fbuild-packages/src/library/esp32_platform.rs
@@ -110,6 +110,47 @@ impl Esp32Platform {
         Ok(url.to_string())
     }
 
+    /// Enumerate every package listed in `platform.json`'s `packages` section.
+    ///
+    /// Returns `(name, version_url)` pairs. The orchestrator uses this to
+    /// provision helper packages (e.g. `toolchain-riscv32-esp` for ULP code on
+    /// ESP32-S3) that are listed alongside the MCU-primary toolchain.
+    /// See fbuild#401.
+    pub fn enumerate_packages(&self) -> Result<Vec<(String, String)>> {
+        let platform_json_path = self.resolved_dir().join("platform.json");
+
+        let content = std::fs::read_to_string(&platform_json_path).map_err(|e| {
+            FbuildError::PackageError(format!(
+                "failed to read platform.json at {}: {}",
+                platform_json_path.display(),
+                e
+            ))
+        })?;
+
+        let data: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+            FbuildError::PackageError(format!("failed to parse platform.json: {}", e))
+        })?;
+
+        let packages = data
+            .get("packages")
+            .and_then(|p| p.as_object())
+            .ok_or_else(|| {
+                FbuildError::PackageError("platform.json has no `packages` section".to_string())
+            })?;
+
+        let mut entries: Vec<(String, String)> = packages
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .get("version")
+                    .and_then(|v| v.as_str())
+                    .map(|url| (name.clone(), url.to_string()))
+            })
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(entries)
+    }
+
     /// Validate the platform installation.
     fn validate_install(install_dir: &Path) -> Result<()> {
         let root = find_platform_root(install_dir);
@@ -225,5 +266,121 @@ mod tests {
     fn test_validate_install_missing_json() {
         let tmp = tempfile::TempDir::new().unwrap();
         assert!(Esp32Platform::validate_install(tmp.path()).is_err());
+    }
+
+    /// A pruned slice of pioarduino `platform-espressif32@54.03.20`'s
+    /// `platform.json`, capturing the packages section that an ESP32-S3 build
+    /// needs to resolve. Tracks fbuild#401: both the MCU-primary Xtensa
+    /// toolchain AND the RISC-V helper toolchain (used for ULP coprocessor
+    /// code) must be discoverable.
+    const PIOARDUINO_54_03_20_PACKAGES_FRAGMENT: &str = r#"{
+      "packages": {
+        "framework-arduinoespressif32": {
+          "type": "framework",
+          "version": "https://github.com/pioarduino/esp32-arduino-libs/releases/download/54.03.20/framework-arduinoespressif32-54.03.20.zip"
+        },
+        "framework-arduinoespressif32-libs": {
+          "type": "framework",
+          "version": "https://github.com/pioarduino/esp32-arduino-libs/releases/download/idf-release_v5.5-1f31a92e/esp32-arduino-libs-idf-release_v5.5-1f31a92e.zip"
+        },
+        "toolchain-xtensa-esp-elf": {
+          "type": "toolchain",
+          "version": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip"
+        },
+        "toolchain-riscv32-esp": {
+          "type": "toolchain",
+          "version": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip"
+        },
+        "tool-esptoolpy": {
+          "type": "uploader",
+          "version": "https://github.com/tasmota/esptool/releases/download/v5.1.0/esptool-v5.1.0-windows-amd64.zip"
+        }
+      }
+    }"#;
+
+    fn write_platform_json(dir: &Path, body: &str) {
+        std::fs::write(dir.join("platform.json"), body).unwrap();
+        std::fs::create_dir_all(dir.join("boards")).unwrap();
+    }
+
+    fn platform_with_install_dir(install_dir: &Path) -> Esp32Platform {
+        let mut p = Esp32Platform::new(install_dir);
+        p.install_dir = Some(install_dir.to_path_buf());
+        p
+    }
+
+    #[test]
+    fn test_get_toolchain_metadata_url_xtensa_pioarduino_54_03_20() {
+        // ESP32-S3 build: primary toolchain is Xtensa.
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_platform_json(tmp.path(), PIOARDUINO_54_03_20_PACKAGES_FRAGMENT);
+        let p = platform_with_install_dir(tmp.path());
+        let url = p.get_toolchain_metadata_url(false).unwrap();
+        assert!(
+            url.contains("xtensa-esp-elf"),
+            "expected Xtensa URL, got {url}"
+        );
+    }
+
+    #[test]
+    fn test_get_riscv_helper_toolchain_for_esp32s3_pioarduino_54_03_20() {
+        // fbuild#401: even on Xtensa MCUs (ESP32-S3 has Xtensa cores + a
+        // RISC-V ULP coprocessor), platform.json lists the RISC-V toolchain.
+        // The orchestrator must be able to resolve it on demand so ULP code
+        // can be compiled.
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_platform_json(tmp.path(), PIOARDUINO_54_03_20_PACKAGES_FRAGMENT);
+        let p = platform_with_install_dir(tmp.path());
+        let url = p.get_package_url("toolchain-riscv32-esp").unwrap();
+        assert!(
+            url.contains("riscv32-esp-elf"),
+            "expected RISC-V helper URL, got {url}"
+        );
+    }
+
+    #[test]
+    fn test_enumerate_packages_returns_all_entries() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_platform_json(tmp.path(), PIOARDUINO_54_03_20_PACKAGES_FRAGMENT);
+        let p = platform_with_install_dir(tmp.path());
+
+        let entries = p.enumerate_packages().unwrap();
+        let names: Vec<&str> = entries.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&"framework-arduinoespressif32"),
+            "missing framework, got {names:?}"
+        );
+        assert!(
+            names.contains(&"framework-arduinoespressif32-libs"),
+            "missing framework-libs, got {names:?}"
+        );
+        assert!(
+            names.contains(&"toolchain-xtensa-esp-elf"),
+            "missing Xtensa toolchain, got {names:?}"
+        );
+        assert!(
+            names.contains(&"toolchain-riscv32-esp"),
+            "missing RISC-V helper toolchain, got {names:?}"
+        );
+        assert!(
+            names.contains(&"tool-esptoolpy"),
+            "missing esptoolpy, got {names:?}"
+        );
+        // Sorted alphabetically for deterministic iteration order.
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted, "enumerate_packages must return sorted list");
+    }
+
+    #[test]
+    fn test_enumerate_packages_errors_when_section_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_platform_json(tmp.path(), r#"{"name": "espressif32"}"#);
+        let p = platform_with_install_dir(tmp.path());
+        let err = p.enumerate_packages().unwrap_err();
+        assert!(
+            format!("{err}").contains("no `packages` section"),
+            "wrong error: {err}"
+        );
     }
 }


### PR DESCRIPTION
Closes #401.

## Summary

Two complementary fixes for ESP toolchain handling raised in #401:

### Daemon streaming surfaces a usable error (was: `stream error: error decoding response body`)

The streaming `/api/build` handler runs the build in a spawned task that emits a terminal NDJSON `result` event when it finishes. If that task panicked or returned early, no terminal event was emitted, the response body stream closed mid-frame, and the CLI surfaced reqwest's underlying `stream error: error decoding response body` — an opaque message that gave the user no actionable diagnostic.

- New `StreamTerminationGuard` in `fbuild-daemon` wraps the spawn body. On `Drop` without an explicit `mark_completed()`, it enqueues a fallback terminal `result` event pointing the user at `~/.fbuild/daemon/daemon.log`. The happy path calls `mark_completed()` after the real result event so no duplicate is emitted.
- `fbuild-cli`'s `build_streaming` wraps the reqwest chunk error with an actionable hint instead of the raw message.

### ESP32 platform.json helper toolchains are now provisioned

`Esp32Platform::get_toolchain_metadata_url` previously returned only the MCU-primary toolchain (`toolchain-xtensa-esp-elf` OR `toolchain-riscv32-esp`). pioarduino `platform-espressif32@54.03.20` lists *both* on the same platform.json — the RISC-V toolchain is needed on ESP32-S3 because the chip has a RISC-V ULP coprocessor.

- New `Esp32Platform::enumerate_packages()` returns `(name, version_url)` for every entry in `packages`, sorted by name.
- `resolve_pioarduino_packages` now opportunistically resolves every additional `toolchain-*` listed in `platform.json` after the primary one. Resolution failures log a warning but don't fail the build, because not every sketch references every helper (most FastLED sketches don't compile ULP code).
- Version-compatibility policy: fbuild trusts `platform.json`'s pinned metadata URL (option **b** from the issue), matching PlatformIO behavior and avoiding ad-hoc version-compatibility decisions.

## Tests added

`esp32_platform` (5 new unit tests, all green locally):
- `test_get_toolchain_metadata_url_xtensa_pioarduino_54_03_20` — primary Xtensa URL resolves.
- `test_get_riscv_helper_toolchain_for_esp32s3_pioarduino_54_03_20` — RISC-V helper URL is discoverable on an ESP32-S3 build.
- `test_enumerate_packages_returns_all_entries` — sorted full list including helpers + esptoolpy.
- `test_enumerate_packages_errors_when_section_missing` — clean error on malformed manifest.
- Plus the existing pre-fixture tests still pass.

`fbuild-daemon::handlers::operations::build` (2 new unit tests):
- `termination_guard_emits_fallback_on_drop_when_not_completed` — Drop enqueues a fallback `result` event with an actionable message.
- `termination_guard_silent_on_drop_when_completed` — `mark_completed()` disarms the guard so no duplicate is emitted.

All four touched crates lint clean (`soldr cargo clippy --workspace --all-targets -- -D warnings`).

## Acceptance criteria mapping (from #401)

- ✅ Better diagnostics on the streaming build path — guard + CLI message wrap.
- ✅ Audit pioarduino platform.json package consumption — `enumerate_packages` + opportunistic provisioning.
- ✅ Version-compatibility policy — trust platform.json pinned versions; documented in code.
- ✅ Regression coverage — unit tests against canned platform.json 54.03.20 fragment + Drop-impl tests.
- Out of scope for this PR: end-to-end integration test that downloads pioarduino 54.03.20 and runs a real ESP32-S3 build with ULP code (would need network + ~500 MB toolchain download in CI). The unit tests cover the resolution logic; the integration test fixture (`tests/platform/esp32s3/`) continues to use the stock `platform = espressif32` channel as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for provisioning additional helper toolchain packages for ESP32 builds.

* **Bug Fixes**
  * Improved error messages when daemon connection is lost mid-build, including guidance to check logs.
  * Enhanced build streaming to ensure completion events are always delivered, even if the background task fails unexpectedly.

* **Tests**
  * Expanded test coverage for package resolution and build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->