### PR TITLE
ci(setup-soldr): silence noisy default-configuration annotations

### DIFF
--- a/.github/workflows/acceptance-205.yml
+++ b/.github/workflows/acceptance-205.yml
@@ -58,6 +58,15 @@ jobs:
           build-cache: true
           target-cache: true
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Acceptance gates compile a full test binary; payload may exceed
+          # the 512 MiB action default (issue #400). Raise the soft warn
+          # threshold; hard cap stays at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
 
       - name: Run ${{ matrix.gate }} acceptance gate
         run: |

--- a/.github/workflows/bench-205.yml
+++ b/.github/workflows/bench-205.yml
@@ -42,6 +42,16 @@ jobs:
           build-cache: true
           target-cache: true
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Bench builds compile release artifacts and their full
+          # dependency graph; payload may exceed the 512 MiB action
+          # default (issue #400). Raise the soft warn threshold; hard cap
+          # stays at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
 
       - name: "Run ${{ matrix.bench }} (target: ${{ matrix.target }})"
         run: |
@@ -72,6 +82,16 @@ jobs:
           build-cache: true
           target-cache: true
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Bench builds compile release artifacts and their full
+          # dependency graph; payload may exceed the 512 MiB action
+          # default (issue #400). Raise the soft warn threshold; hard cap
+          # stays at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
 
       - name: Checkout FastLED
         uses: actions/checkout@v6

--- a/.github/workflows/check-macos.yml
+++ b/.github/workflows/check-macos.yml
@@ -25,6 +25,16 @@ jobs:
           build-cache: true
           target-cache: true
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Realistic zccache payload for the workspace check job is
+          # ~1.5–2 GiB (issue #400). Raise the soft warn threshold above
+          # the steady-state size so the action only flags genuinely
+          # runaway caches. Hard cap stays at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
 
       - name: Check
         shell: bash

--- a/.github/workflows/check-ubuntu.yml
+++ b/.github/workflows/check-ubuntu.yml
@@ -26,6 +26,16 @@ jobs:
           build-cache: true
           target-cache: true
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Realistic zccache payload for the workspace check job is
+          # ~1.5–2 GiB (issue #400). Raise the soft warn threshold above
+          # the steady-state size so the action only flags genuinely
+          # runaway caches. Hard cap stays at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
 
       - name: Check
         run: soldr cargo check --workspace --all-targets

--- a/.github/workflows/check-windows.yml
+++ b/.github/workflows/check-windows.yml
@@ -25,6 +25,16 @@ jobs:
           build-cache: true
           target-cache: true
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Realistic zccache payload for the workspace check job is
+          # ~1.5–2 GiB (issue #400). Raise the soft warn threshold above
+          # the steady-state size so the action only flags genuinely
+          # runaway caches. Hard cap stays at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
 
       - name: Check
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,15 @@ jobs:
           build-cache: true
           target-cache: true
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Realistic zccache payload for the doc build can exceed the
+          # 512 MiB action default (issue #400). Raise the soft warn
+          # threshold; hard cap stays at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
 
       - name: Build docs
         run: soldr cargo doc --workspace --no-deps

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -28,6 +28,16 @@ jobs:
           toolchain: 1.94.1
           cache-key-suffix: dylint
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Dylint's build pulls in a full rustc-dev tree on first run
+          # which can push the build-cache past the 512 MiB action default
+          # (issue #400). Raise the soft warn threshold; hard cap stays
+          # at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
       - name: Install Dylint nightly toolchain
         # Pin matches `dylints/ban_raw_subprocess/rust-toolchain.toml`
         # and zccache's `ci/build_dylint_driver.py::TOOLCHAIN_CHANNEL`.

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -23,5 +23,11 @@ jobs:
           build-cache: true
           target-cache: false
           prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377). `cargo fmt` does not link anything so this
+          # is purely cosmetic, but it removes the annotation.
+          linker: platform-default
       - name: Check formatting
         run: soldr cargo fmt --all -- --check

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -24,6 +24,15 @@ jobs:
           target-cache: true
           prebuild-deps: none
           toolchain: 1.94.1
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge. Silences the routine
+          # "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Realistic zccache payload for the workspace check job is
+          # ~1.5–2 GiB (issue #400). Raise the soft warn threshold above
+          # the steady-state size. Hard cap stays at 6 GiB.
+          cache-payload-warn-bytes: 2GiB
 
       - name: Check MSRV
         run: soldr cargo check --workspace

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -50,6 +50,21 @@ jobs:
           # SHARED key across all boards (was ~462MiB × board × SHA before
           # #280 made it coarse).
           prebuild-deps-flags: ""
+          # Override foundation's default `prebuild-deps: soldr-cook` — the
+          # cook recorded only misses (0 hits) in practice (issue #400 /
+          # setup-soldr#377), so skipping it removes a noisy warning and
+          # shaves ~20s off cold runs. The build-cache layer still warms
+          # the actual `soldr cargo build` step.
+          prebuild-deps: none
+          # Opt out of the implicit `SOLDR_LINKER=fast` injection so cargo /
+          # rust-toolchain.toml stays in charge of linker selection. Silences
+          # the routine "defaulting SOLDR_LINKER=fast" warning (issue #400 /
+          # setup-soldr#377).
+          linker: platform-default
+          # Raise the soft warn threshold above the realistic ~1.5–2 GiB
+          # zccache payload for this debug build (issue #400). Hard cap
+          # `cache-payload-max-bytes` still defaults to 6 GiB.
+          cache-payload-warn-bytes: 2GiB
           cache-key-suffix: fbuild-rust-debug
 
       - name: Reset zccache daemon after cache warm

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -67,6 +67,10 @@ jobs:
           # with "file in wrong format" on the cross crt1.o). Disable the
           # injection and let cargo + the toolchain decide.
           linker: platform-default
+          # Native release builds produce a payload larger than the
+          # 512 MiB action default (issue #400). Raise the soft warn
+          # threshold; hard cap stays at the action default (6 GiB).
+          cache-payload-warn-bytes: 2GiB
           cache-key-suffix: native-${{ inputs.target }}
 
       - uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

- Add `linker: platform-default`, `cache-payload-warn-bytes: 2GiB`, and (for `template_build.yml`) `prebuild-deps: none` across every workflow that calls `zackees/setup-soldr@v0.9.62` to silence three routine warning annotations that fbuild's CI was emitting on every run.
- The annotations are configuration signals from the action itself, not from fbuild's build pipeline. Upstream tracker: [zackees/setup-soldr#377](https://github.com/zackees/setup-soldr/issues/377) (proposing these become opt-in / `::notice::`); this is the caller-side fix.

## What changed

| Annotation | Fix | Files |
|---|---|---|
| `defaulting SOLDR_LINKER=fast ... Set `linker: platform-default` to opt out` | Pass `linker: platform-default` so cargo / `rust-toolchain.toml` stays in charge of linker selection. (Already set on `template_native_build.yml`; now consistent across every caller.) | `acceptance-205`, `bench-205`, `check-{macos,ubuntu,windows}`, `docs`, `dylint`, `fmt`, `msrv`, `template_build` |
| `build-cache cache payload is 1.65GB before compression (>512.0MB)` | Raise the **soft** warn threshold `cache-payload-warn-bytes: 2GiB`. Hard cap (`cache-payload-max-bytes`) stays at the action default of **6 GiB** so genuinely runaway caches still trip. | `acceptance-205`, `bench-205`, `check-{macos,ubuntu,windows}`, `docs`, `dylint`, `msrv`, `template_{native_,}build` (skipped on `fmt.yml` — no link step) |
| `soldr cook prebuilt dependencies, but ... 0 hits ... set prebuild-deps: none to skip` | Explicitly opt out with `prebuild-deps: none`. Foundation preset enabled `prebuild-deps: soldr-cook` but the cook was never paying off here — the debug `cargo build -p fbuild-cli -p fbuild-daemon` step was hitting the build-cache directly. | `template_build` (other workflows already had this set) |

## Why these values

- **`linker: platform-default`** — matches the existing intent on `template_native_build.yml` and surfaces no behavior change vs. the implicit `fast` default for any job that already has working linker config from `rust-toolchain.toml` / `.cargo/config.toml`.
- **`cache-payload-warn-bytes: 2GiB`** — observed steady-state cache on a recent main-branch `check-ubuntu` run was 1.65 GB before compression (run [26919150100](https://github.com/FastLED/fbuild/actions/runs/26919150100)). 2 GiB sits above the steady-state size but well below the 6 GiB hard cap. Set per-workflow rather than globally because some jobs (e.g. fmt) have no realistic chance of hitting it.
- **`prebuild-deps: none`** on `template_build.yml` — matches the issue's recommendation (`"set prebuild-deps: none to skip the unused cook"`) and removes ~20s of cold-run cook overhead that produced 0 cache hits.

## Evidence the annotations were real

From PR #399 run [26915267711](https://github.com/FastLED/fbuild/actions/runs/26915267711):

```
##[warning]setup-soldr: defaulting SOLDR_LINKER=fast ...
##[warning]soldr cook prebuilt dependencies, but this job's compile cache recorded 1 miss(es) and 0 hit(s) ...
```

From main-branch run [26919150100](https://github.com/FastLED/fbuild/actions/runs/26919150100):

```
##[warning]setup-soldr: build-cache cache payload is 1.65GB before compression (>512.0MB)
```

## Test plan

- [ ] Open PR, verify all CI jobs go green
- [ ] Spot-check one `check-*` run, the `Build *` template_build run, and a `template_native_build` run for absence of the three `setup-soldr:` warning annotations
- [ ] Verify `cache-payload-warn-bytes: 2GiB` is logged and no new warning replaces the silenced one

Closes #400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows across acceptance, benchmarking, documentation, linting, and format checks to configure linker behavior and cache warning thresholds for consistency and to accommodate larger build artifacts without triggering false warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->