### PR TITLE
fix(renesas): scope FSP -Wno-error= demotions to vendor C sources only

### DIFF
--- a/crates/fbuild-build/src/renesas/configs/ra4m1.json
+++ b/crates/fbuild-build/src/renesas/configs/ra4m1.json
@@ -4,7 +4,7 @@
   "architecture": "arm-cortex-m4",
   "compiler_flags": {
     "common": ["-mcpu=cortex-m4", "-mthumb", "-mfloat-abi=hard", "-mfpu=fpv4-sp-d16", "-w", "-ffunction-sections", "-fdata-sections", "-fno-strict-aliasing", "-fno-builtin", "-fsigned-char", "-nostdlib", "-MMD"],
-    "c": ["-std=gnu11", "-Wno-error=return-mismatch", "-Wno-error=implicit-function-declaration", "-Wno-error=int-conversion", "-Wno-error=incompatible-pointer-types"],
+    "c": ["-std=gnu11"],
     "cxx": ["-std=gnu++17", "-fno-exceptions", "-fno-rtti", "-fno-threadsafe-statics"]
   },
   "linker_flags": ["-mcpu=cortex-m4", "-mthumb", "-mfloat-abi=hard", "-mfpu=fpv4-sp-d16", "-Wl,--gc-sections", "-Wl,--print-memory-usage", "--specs=nano.specs", "--specs=nosys.specs"],

--- a/crates/fbuild-build/src/renesas/orchestrator.rs
+++ b/crates/fbuild-build/src/renesas/orchestrator.rs
@@ -199,7 +199,14 @@ impl BuildOrchestrator for RenesasOrchestrator {
             params.profile,
             params.verbose,
         )
-        .with_build_unflags(ctx.build_unflags.clone());
+        .with_build_unflags(ctx.build_unflags.clone())
+        // Scope the four FSP `-Wno-error=` C demotions to ArduinoCore-renesas
+        // sources only. FastLED and user-sketch C code stays under the
+        // stricter default `-Werror=` posture so those bug-class diagnostics
+        // (return-mismatch, implicit-function-declaration, int-conversion,
+        // incompatible-pointer-types) still fail the build when introduced
+        // in user code. See FastLED/fbuild#404.
+        .with_framework_root(framework_dir.clone());
 
         // 7. Create linker (resolve linker script from framework variant)
         let linker_script_path = framework.get_linker_script(&ctx.board.variant);

--- a/crates/fbuild-build/src/renesas/renesas_compiler.rs
+++ b/crates/fbuild-build/src/renesas/renesas_compiler.rs
@@ -2,6 +2,16 @@
 //!
 //! Compiles C/C++ source files using arm-none-eabi-gcc/g++ with appropriate
 //! flags for Renesas RA boards (ARM Cortex-M4, hardware FPU).
+//!
+//! ## FSP warning scope (FastLED/fbuild#404)
+//!
+//! Four critical-bug-class C diagnostics -- `return-mismatch`,
+//! `implicit-function-declaration`, `int-conversion`, and
+//! `incompatible-pointer-types` -- used to be demoted to warnings
+//! workspace-wide via `ra4m1.json`'s `compiler_flags.c` array. That hid
+//! real undefined behaviour in FastLED + user-sketch code. The demotion
+//! is now scoped to ArduinoCore-renesas vendor C sources only via
+//! [`RenesasCompiler::with_framework_root`].
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -21,6 +31,16 @@ pub struct RenesasCompiler {
     temp_dir: PathBuf,
     /// PlatformIO `build_unflags`. See FastLED/fbuild#37.
     build_unflags: Vec<String>,
+    /// Root of the ArduinoCore-renesas install. C sources rooted under this
+    /// path get the four upstream FSP C-bug-class diagnostics demoted from
+    /// errors to warnings -- those classes (`return-mismatch`,
+    /// `implicit-function-declaration`, `int-conversion`,
+    /// `incompatible-pointer-types`) are pre-existing in the pinned 1.2.2
+    /// release and cannot be fixed from here. FastLED + user sketch sources
+    /// stay under the stricter default `-Werror=` posture so those same bug
+    /// classes still fail the build when introduced in user code. See
+    /// FastLED/fbuild#404.
+    framework_root: Option<PathBuf>,
 }
 
 impl RenesasCompiler {
@@ -50,12 +70,25 @@ impl RenesasCompiler {
             profile,
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
             build_unflags: Vec::new(),
+            framework_root: None,
         }
     }
 
     /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
     pub fn with_build_unflags(mut self, build_unflags: Vec<String>) -> Self {
         self.build_unflags = build_unflags;
+        self
+    }
+
+    /// Scope FSP warning demotions to sources under `root`.
+    ///
+    /// Used to keep the four upstream-FSP C diagnostics
+    /// (`return-mismatch`, `implicit-function-declaration`, `int-conversion`,
+    /// `incompatible-pointer-types`) downgraded to warnings for vendor code
+    /// while still failing the build when FastLED or user-sketch sources
+    /// introduce one of the same bug classes. See FastLED/fbuild#404.
+    pub fn with_framework_root(mut self, root: PathBuf) -> Self {
+        self.framework_root = Some(root);
         self
     }
 
@@ -73,6 +106,55 @@ impl RenesasCompiler {
         flags.extend(self.base.build_include_flags());
         flags
     }
+
+    /// Return `true` if `source` lives under the configured framework root.
+    fn is_framework_source(&self, source: &Path) -> bool {
+        let Some(root) = self.framework_root.as_ref() else {
+            return false;
+        };
+        match (
+            std::fs::canonicalize(source).ok(),
+            std::fs::canonicalize(root).ok(),
+        ) {
+            (Some(s), Some(r)) => s.starts_with(&r),
+            _ => source.starts_with(root),
+        }
+    }
+}
+
+/// Flags appended when compiling third-party Renesas FSP / ArduinoCore-renesas
+/// C sources.
+///
+/// The pinned ArduinoCore-renesas 1.2.2 release ships FSP C code that GCC
+/// rejects under the default `-Werror=` posture for four specific bug-class
+/// diagnostics. We can't fix the upstream code from here, so we demote those
+/// four -- and only those four -- back to warnings for vendor sources. The
+/// same diagnostics still fail the build when introduced in FastLED or user
+/// sketch code, which is the whole point: these classes (return-type
+/// mismatch, implicit function decl, int/pointer conversion, incompatible
+/// pointer types) catch real undefined behaviour and the audit in
+/// FastLED/fbuild#404 found they were previously silenced workspace-wide.
+///
+/// Scope: framework C sources only (`*.c`). The relevant diagnostics don't
+/// apply to C++ and the upstream FSP code is C, so this list is
+/// intentionally C-only. See FastLED/fbuild#404.
+fn framework_c_suppression_flags() -> &'static [&'static str] {
+    &[
+        "-Wno-error=return-mismatch",
+        "-Wno-error=implicit-function-declaration",
+        "-Wno-error=int-conversion",
+        "-Wno-error=incompatible-pointer-types",
+    ]
+}
+
+/// `true` when `source` is a C source file (`.c`). Assembly and C++ sources
+/// don't get the FSP demotion set.
+fn is_c_source(source: &Path) -> bool {
+    source
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("c"))
+        .unwrap_or(false)
 }
 
 impl Compiler for RenesasCompiler {
@@ -84,12 +166,34 @@ impl Compiler for RenesasCompiler {
         flags: &[String],
         extra_flags: &[String],
     ) -> Result<CompileResult> {
+        // Append FSP warning demotions after user-provided flags so they
+        // override any earlier `-Werror=` toggles. Scoped strictly to C
+        // sources rooted in the ArduinoCore-renesas install; sketch sources
+        // and project libraries continue to see the full default `-Werror=`
+        // posture for these four bug classes. See FastLED/fbuild#404.
+        let suppressed_extra: Vec<String>;
+        let effective_extra: &[String] = if is_c_source(source) && self.is_framework_source(source)
+        {
+            suppressed_extra = extra_flags
+                .iter()
+                .cloned()
+                .chain(
+                    framework_c_suppression_flags()
+                        .iter()
+                        .map(|s| (*s).to_string()),
+                )
+                .collect();
+            &suppressed_extra
+        } else {
+            extra_flags
+        };
+
         crate::compiler::compile_source(
             compiler_path,
             source,
             output,
             flags,
-            extra_flags,
+            effective_extra,
             &self.temp_dir,
             "renesas",
             self.base.verbose,
@@ -116,6 +220,37 @@ impl Compiler for RenesasCompiler {
 
     fn build_unflags(&self) -> &[String] {
         &self.build_unflags
+    }
+
+    /// Mirror the per-source suppression logic in [`Self::compile_one`] so
+    /// the rebuild fingerprint changes whenever the FSP demotion set moves
+    /// or expands. Without this, an object compiled with the old flags would
+    /// be considered up-to-date after the suppressions change. See
+    /// FastLED/fbuild#404.
+    fn rebuild_signature(&self, source: &Path, extra_flags: &[String]) -> String {
+        let ext = source
+            .extension()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_lowercase();
+        let (compiler_path, flags) = match ext.as_str() {
+            "c" | "s" => (self.gcc_path(), self.c_flags()),
+            _ => (self.gxx_path(), self.cpp_flags()),
+        };
+        let extra_owned: Vec<String> = if is_c_source(source) && self.is_framework_source(source) {
+            extra_flags
+                .iter()
+                .cloned()
+                .chain(
+                    framework_c_suppression_flags()
+                        .iter()
+                        .map(|s| (*s).to_string()),
+                )
+                .collect()
+        } else {
+            extra_flags.to_vec()
+        };
+        crate::compiler::build_rebuild_signature(compiler_path, &flags, &[], &extra_owned)
     }
 }
 
@@ -184,5 +319,127 @@ mod tests {
         assert!(flags.contains(&"-fno-exceptions".to_string()));
         assert!(flags.contains(&"-fno-rtti".to_string()));
         assert!(flags.contains(&"-fno-threadsafe-statics".to_string()));
+    }
+
+    /// Regression guard for FastLED/fbuild#404: the four FSP-bug-class
+    /// `-Wno-error=` flags MUST NOT be in the workspace-wide C flag set. If
+    /// they leak back into `ra4m1.json`'s `compiler_flags.c` array, every C
+    /// translation unit -- including the user sketch -- will silently demote
+    /// these errors to warnings and the original audit finding returns.
+    #[test]
+    fn test_c_flags_do_not_contain_fsp_suppressions_globally() {
+        let compiler = test_compiler();
+        let flags = compiler.c_flags();
+        for sup in framework_c_suppression_flags() {
+            assert!(
+                !flags.iter().any(|f| f == *sup),
+                "{} must not be in the workspace-wide C flag set; \
+                 it belongs to the per-FSP-source scope only \
+                 (see FastLED/fbuild#404)",
+                sup
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_framework_source_without_root() {
+        let compiler = test_compiler();
+        assert!(!compiler.is_framework_source(Path::new("/anywhere/foo.c")));
+    }
+
+    #[test]
+    fn test_is_framework_source_with_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let framework_root = tmp.path().join("ArduinoCore-renesas");
+        let fsp_dir = framework_root.join("variants/UNOWIFIR4/includes/ra/fsp/src");
+        std::fs::create_dir_all(&fsp_dir).unwrap();
+        let fsp_src = fsp_dir.join("r_ioport.c");
+        std::fs::write(&fsp_src, "// stub").unwrap();
+        let user_dir = tmp.path().join("project/src");
+        std::fs::create_dir_all(&user_dir).unwrap();
+        let user_src = user_dir.join("main.c");
+        std::fs::write(&user_src, "// stub").unwrap();
+
+        let compiler = test_compiler().with_framework_root(framework_root);
+        assert!(compiler.is_framework_source(&fsp_src));
+        assert!(!compiler.is_framework_source(&user_src));
+    }
+
+    /// Lock in the precise set of FSP warning demotions. Each one disables
+    /// a real-undefined-behaviour diagnostic -- adding a new entry should
+    /// make a reviewer re-read FastLED/fbuild#404 and explain why the new
+    /// flag is safe for vendor code.
+    #[test]
+    fn test_framework_c_suppression_set_is_locked_in() {
+        assert_eq!(
+            framework_c_suppression_flags(),
+            &[
+                "-Wno-error=return-mismatch",
+                "-Wno-error=implicit-function-declaration",
+                "-Wno-error=int-conversion",
+                "-Wno-error=incompatible-pointer-types",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_is_c_source_classification() {
+        assert!(is_c_source(Path::new("foo.c")));
+        assert!(is_c_source(Path::new("FOO.C")));
+        assert!(!is_c_source(Path::new("foo.cpp")));
+        assert!(!is_c_source(Path::new("foo.cc")));
+        assert!(!is_c_source(Path::new("foo.S")));
+        assert!(!is_c_source(Path::new("foo.s")));
+        assert!(!is_c_source(Path::new("foo")));
+    }
+
+    /// FastLED/fbuild#404 acceptance: rebuild signature for an FSP C source
+    /// must differ from a user-sketch C source, because the per-file flag
+    /// set differs. If they collide, an old object compiled with the wrong
+    /// flag set would be reused after this scoping change ships.
+    #[test]
+    fn test_rebuild_signature_differs_for_framework_c_source() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let framework_root = tmp.path().join("ArduinoCore-renesas");
+        let fsp_dir = framework_root.join("variants/UNOWIFIR4/includes/ra/fsp/src");
+        std::fs::create_dir_all(&fsp_dir).unwrap();
+        let fsp_src = fsp_dir.join("r_ioport.c");
+        std::fs::write(&fsp_src, "// stub").unwrap();
+        let user_src = tmp.path().join("main.c");
+        std::fs::write(&user_src, "// stub").unwrap();
+
+        let compiler = test_compiler().with_framework_root(framework_root);
+        let fsp_sig = compiler.rebuild_signature(&fsp_src, &[]);
+        let user_sig = compiler.rebuild_signature(&user_src, &[]);
+        assert_ne!(
+            fsp_sig, user_sig,
+            "FSP C signature must include the four -Wno-error= flags; \
+             user-sketch C signature must not. See FastLED/fbuild#404."
+        );
+    }
+
+    /// FastLED/fbuild#404 scope guard: a C++ source under the framework root
+    /// MUST NOT receive the C-only FSP demotions, because the relevant
+    /// diagnostics don't apply to C++ and the FSP upstream code is C. This
+    /// keeps the suppression surface as small as possible.
+    #[test]
+    fn test_framework_cpp_source_does_not_get_c_suppressions() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let framework_root = tmp.path().join("ArduinoCore-renesas");
+        let core_dir = framework_root.join("cores/arduino");
+        std::fs::create_dir_all(&core_dir).unwrap();
+        let cpp_src = core_dir.join("Serial.cpp");
+        std::fs::write(&cpp_src, "// stub").unwrap();
+        let baseline_cpp = tmp.path().join("Serial.cpp");
+        std::fs::write(&baseline_cpp, "// stub").unwrap();
+
+        let compiler = test_compiler().with_framework_root(framework_root);
+        let framework_cpp_sig = compiler.rebuild_signature(&cpp_src, &[]);
+        let baseline_cpp_sig = compiler.rebuild_signature(&baseline_cpp, &[]);
+        assert_eq!(
+            framework_cpp_sig, baseline_cpp_sig,
+            "framework C++ sources must not pick up the C-only FSP \
+             suppressions (FastLED/fbuild#404)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #404.

The four C-bug-class diagnostics that `ra4m1.json` was demoting workspace-wide -- `return-mismatch`, `implicit-function-declaration`, `int-conversion`, `incompatible-pointer-types` -- catch real undefined behaviour: UB returns, ABI-mismatched implicit decls, pointer corruption, and strict-aliasing breakage. They were added so the pinned ArduinoCore-renesas 1.2.2 FSP release would build, but the side effect was that FastLED + any user sketch on `uno_r4_wifi` could ship the same bug classes silently.

## What changed

- `crates/fbuild-build/src/renesas/configs/ra4m1.json`: remove the four `-Wno-error=` flags from the global `compiler_flags.c` array.
- `crates/fbuild-build/src/renesas/renesas_compiler.rs`:
  - add `framework_root: Option<PathBuf>` + `with_framework_root(...)` builder
  - add `framework_c_suppression_flags()` returning the four flags
  - `compile_one` appends those flags only when the source is `.c` AND lives under the framework root
  - `rebuild_signature` mirrors the per-source logic so artifact reuse stays correct after the suppressions move
- `crates/fbuild-build/src/renesas/orchestrator.rs`: wire `.with_framework_root(framework_dir.clone())` onto the constructed `RenesasCompiler`.

Mirrors the CH32V scoping precedent from #399 (`Ch32vCompiler::with_framework_root` / `compile_one` + suppression-flags helper).

## Scope rationale

- C sources rooted under the ArduinoCore-renesas install still build (FSP demotion preserved).
- FastLED + user-sketch C code is held to the default `-Werror=` posture for these four diagnostics, so a sketch with `int *p = 42;` now fails the `uno_r4_wifi` build instead of silently shipping.
- C++ does not get the demotion -- the relevant diagnostics are C-only and the FSP upstream code is C.

## Test plan

- [x] `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings` -- clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` -- clean
- [x] `soldr cargo test -p fbuild-build --lib renesas` -- 27/27 pass, including 6 new tests:
  - `test_c_flags_do_not_contain_fsp_suppressions_globally` (regression guard: flags must NOT leak back into the global C set)
  - `test_framework_c_suppression_set_is_locked_in` (locks the exact 4-flag set so any addition trips review)
  - `test_is_c_source_classification`
  - `test_is_framework_source_with_root`
  - `test_rebuild_signature_differs_for_framework_c_source` (so old objects compiled with the old flag set are NOT reused)
  - `test_framework_cpp_source_does_not_get_c_suppressions` (scope-tightness guard)
- [ ] CI green on Linux, macOS, Windows
- [ ] CodeRabbit comments addressed