### PR TITLE
feat(platform): LPC804 + LPC845 bare-metal targets (Stage 1 of FastLED/FastLED#2836)

### DIFF
--- a/.github/workflows/build-lpc804.yml
+++ b/.github/workflows/build-lpc804.yml
@@ -1,0 +1,25 @@
+name: Build LPC804
+
+# Stage 1 of FastLED/FastLED#2836: build/toolchain wiring lands now, the
+# actual Stage-2 LPC8xx orchestrator lands in a follow-up FastLED-side PR.
+# Until Stage 2 lands, this workflow's `fbuild build` step fails fast with
+# a "Stage 2 required" error. `continue-on-error: true` keeps the overall
+# check status non-blocking on `main` while still surfacing red runs on the
+# Actions tab. Remove `continue-on-error` once Stage 2 lands.
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    continue-on-error: true
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "NXP LPC804"
+      test-dir: "tests/platform/lpc804"
+      env-name: "lpc804"
+      firmware-ext: "bin"

--- a/.github/workflows/build-lpc845.yml
+++ b/.github/workflows/build-lpc845.yml
@@ -1,0 +1,25 @@
+name: Build LPC845
+
+# Stage 1 of FastLED/FastLED#2836: build/toolchain wiring lands now, the
+# actual Stage-2 LPC8xx orchestrator lands in a follow-up FastLED-side PR.
+# Until Stage 2 lands, this workflow's `fbuild build` step fails fast with
+# a "Stage 2 required" error. `continue-on-error: true` keeps the overall
+# check status non-blocking on `main` while still surfacing red runs on the
+# Actions tab. Remove `continue-on-error` once Stage 2 lands.
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    continue-on-error: true
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "NXP LPC845"
+      test-dir: "tests/platform/lpc845"
+      env-name: "lpc845"
+      firmware-ext: "bin"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@
 [![Build Apollo3 RedBoard](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml)
 [![Build Apollo3 expLoRaBLE](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml)
 
+### NXP LPC (Cortex-M0+)
+[![Build LPC804](https://github.com/fastled/fbuild/actions/workflows/build-lpc804.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc804.yml)
+[![Build LPC845](https://github.com/fastled/fbuild/actions/workflows/build-lpc845.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc845.yml)
+
 ### Silicon Labs
 [![Build MGM240](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml)
 

--- a/crates/fbuild-build/src/lib.rs
+++ b/crates/fbuild-build/src/lib.rs
@@ -23,6 +23,7 @@ pub mod framework_libs;
 pub mod generic_arm;
 pub mod linker;
 pub mod nrf52;
+pub mod nxplpc;
 pub mod parallel;
 pub mod perf_log;
 pub mod pipeline;
@@ -74,6 +75,7 @@ pub fn get_platform_support(platform: Platform) -> Result<Box<dyn PlatformSuppor
         Platform::Ststm32 => Ok(Box::new(stm32::Stm32PlatformSupport)),
         Platform::RaspberryPi => Ok(Box::new(rp2040::Rp2040PlatformSupport)),
         Platform::NordicNrf52 => Ok(Box::new(nrf52::Nrf52PlatformSupport)),
+        Platform::NxpLpc => Ok(Box::new(nxplpc::NxpLpcPlatformSupport)),
         Platform::AtmelSam => Ok(Box::new(sam::SamPlatformSupport)),
         Platform::RenesasRa => Ok(Box::new(renesas::RenesasPlatformSupport)),
         Platform::SiliconLabs => Ok(Box::new(silabs::SilabsPlatformSupport)),

--- a/crates/fbuild-build/src/nxplpc/README.md
+++ b/crates/fbuild-build/src/nxplpc/README.md
@@ -1,0 +1,37 @@
+# NXP LPC8xx (Cortex-M0+) Build Support
+
+Bare-metal CMSIS support for NXP LPC804 and LPC845 microcontrollers.
+
+## Stage 1 / Stage 2
+
+This module is Stage 1 of FastLED/FastLED#2836. Stage 1 adds:
+
+- Board definitions (`lpc804`, `lpc845`)
+- `Platform::NxpLpc` enum entry, `nxplpc` platform string parsing
+- Cortex-M0+ MCU config JSON shared by both targets
+- Linker scripts (`assets/lpc804.ld`, `assets/lpc845.ld`)
+- Startup / vector table skeletons (`assets/startup_lpc804.S`, `assets/startup_lpc845.S`)
+- `PlatformSupport` shim wired to the ARM GCC toolchain installer
+
+Stage 2 (FastLED-side C++ port — separate repo, separate PR) will provide the
+actual clockless / SPI driver glue. Until that lands, the build orchestrator
+returns a clear "Stage 2 not landed" error and the per-platform CI workflows
+will fail at the link step.
+
+## Memory map (from NXP datasheets)
+
+| Part   | Flash origin | Flash size | RAM origin   | RAM size |
+| ------ | ------------ | ---------- | ------------ | -------- |
+| LPC804 | 0x00000000   | 32 KB      | 0x10000000   | 4 KB     |
+| LPC845 | 0x00000000   | 64 KB      | 0x10000000   | 16 KB    |
+
+References:
+
+- LPC804 datasheet: <https://www.nxp.com/docs/en/nxp/data-sheets/LPC804_DS.pdf>
+- LPC84x datasheet: <https://www.nxp.com/docs/en/data-sheet/LPC84x.pdf>
+
+## Upload
+
+Primary path: ISP-via-UART with the on-die boot ROM, driven by `lpc21isp`.
+Alternative: SWD via CMSIS-DAP / J-Link / pyOCD (entries in the board JSON
+`debug.tools` map).

--- a/crates/fbuild-build/src/nxplpc/assets/README.md
+++ b/crates/fbuild-build/src/nxplpc/assets/README.md
@@ -1,0 +1,17 @@
+# NXP LPC8xx linker / startup assets
+
+| File              | Purpose                                                    |
+| ----------------- | ---------------------------------------------------------- |
+| `lpc804.ld`       | GNU ld memory map for LPC804 (32 KB Flash / 4 KB RAM).     |
+| `lpc845.ld`       | GNU ld memory map for LPC845 (64 KB Flash / 16 KB RAM).    |
+| `startup_lpc804.S`| Reset_Handler + minimal vector table for LPC804.           |
+| `startup_lpc845.S`| Reset_Handler + minimal vector table for LPC845.           |
+
+All four files are embedded into the `fbuild-build` crate via `include_str!`
+in `mod.rs` so the Stage-2 orchestrator (FastLED/FastLED#2836) can emit them
+into the build directory at link time without an extra package download.
+
+Memory regions are taken from the NXP datasheets — verified against the
+datasheets cited in each file header. The IRQ vector tables are intentionally
+the ARMv6-M system-vector minimum; Stage 2 will expand to cover peripheral
+IRQs as drivers need them.

--- a/crates/fbuild-build/src/nxplpc/assets/lpc804.ld
+++ b/crates/fbuild-build/src/nxplpc/assets/lpc804.ld
@@ -1,0 +1,109 @@
+/*
+ * GNU ld linker script for NXP LPC804 (Cortex-M0+).
+ *
+ * Memory map taken from the LPC804 datasheet, table 5 ("Memory mapping"):
+ *   - Flash: 0x00000000, 32 KB
+ *   - SRAM:  0x10000000, 4 KB
+ *
+ * Reference: https://www.nxp.com/docs/en/nxp/data-sheets/LPC804_DS.pdf
+ *
+ * Stage 1 skeleton — verified against datasheet, but reviewers should
+ * sanity-check section ordering before flashing real hardware.
+ */
+
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 32K
+    RAM   (rwx) : ORIGIN = 0x10000000, LENGTH = 4K
+}
+
+/* Top of RAM — initial stack pointer. */
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } > FLASH
+
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)
+        *(.text*)
+        *(.rodata)
+        *(.rodata*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.eh_frame)
+        KEEP (*(.init))
+        KEEP (*(.fini))
+        . = ALIGN(4);
+        _etext = .;
+    } > FLASH
+
+    .ARM.extab : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > FLASH
+    .ARM : { __exidx_start = .; *(.ARM.exidx*) __exidx_end = .; } > FLASH
+
+    .preinit_array :
+    {
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP (*(.preinit_array*))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+    } > FLASH
+
+    .init_array :
+    {
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array*))
+        PROVIDE_HIDDEN (__init_array_end = .);
+    } > FLASH
+
+    .fini_array :
+    {
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(SORT(.fini_array.*)))
+        KEEP (*(.fini_array*))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+    } > FLASH
+
+    _sidata = LOADADDR(.data);
+
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > RAM AT > FLASH
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = _sbss;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = _ebss;
+    } > RAM
+
+    /DISCARD/ :
+    {
+        libc.a ( * )
+        libm.a ( * )
+        libgcc.a ( * )
+    }
+
+    .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/crates/fbuild-build/src/nxplpc/assets/lpc845.ld
+++ b/crates/fbuild-build/src/nxplpc/assets/lpc845.ld
@@ -1,0 +1,109 @@
+/*
+ * GNU ld linker script for NXP LPC845 (Cortex-M0+).
+ *
+ * Memory map taken from the LPC84x datasheet, section 7.6 ("Memory map"):
+ *   - Flash: 0x00000000, 64 KB
+ *   - SRAM:  0x10000000, 16 KB (single contiguous bank on LPC845)
+ *
+ * Reference: https://www.nxp.com/docs/en/data-sheet/LPC84x.pdf
+ *
+ * Stage 1 skeleton — verified against datasheet, but reviewers should
+ * sanity-check section ordering before flashing real hardware.
+ */
+
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x00000000, LENGTH = 64K
+    RAM   (rwx) : ORIGIN = 0x10000000, LENGTH = 16K
+}
+
+/* Top of RAM — initial stack pointer. */
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } > FLASH
+
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)
+        *(.text*)
+        *(.rodata)
+        *(.rodata*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.eh_frame)
+        KEEP (*(.init))
+        KEEP (*(.fini))
+        . = ALIGN(4);
+        _etext = .;
+    } > FLASH
+
+    .ARM.extab : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > FLASH
+    .ARM : { __exidx_start = .; *(.ARM.exidx*) __exidx_end = .; } > FLASH
+
+    .preinit_array :
+    {
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP (*(.preinit_array*))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+    } > FLASH
+
+    .init_array :
+    {
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array*))
+        PROVIDE_HIDDEN (__init_array_end = .);
+    } > FLASH
+
+    .fini_array :
+    {
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(SORT(.fini_array.*)))
+        KEEP (*(.fini_array*))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+    } > FLASH
+
+    _sidata = LOADADDR(.data);
+
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > RAM AT > FLASH
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        __bss_start__ = _sbss;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+        __bss_end__ = _ebss;
+    } > RAM
+
+    /DISCARD/ :
+    {
+        libc.a ( * )
+        libm.a ( * )
+        libgcc.a ( * )
+    }
+
+    .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/crates/fbuild-build/src/nxplpc/assets/startup_lpc804.S
+++ b/crates/fbuild-build/src/nxplpc/assets/startup_lpc804.S
@@ -1,0 +1,117 @@
+/*
+ * Minimal startup / vector table for NXP LPC804 (Cortex-M0+).
+ *
+ * Provides: Reset_Handler (copies .data, zeros .bss, calls SystemInit then main).
+ * All other vectors alias Default_Handler (weak; users may override).
+ *
+ * TODO(stage2): expand the IRQ table to cover the full LPC804 peripheral
+ * vector list (USART0..2, I2C0..3, SCT, PLU, ADC, etc.) once a driver
+ * needs an actual handler. The 16-entry skeleton below is the ARMv6-M
+ * system-vector minimum; bare-metal code that never enables an IRQ runs
+ * fine without the extras.
+ *
+ * Reference: LPC804 datasheet, table 6 ("Interrupt vector table").
+ *   https://www.nxp.com/docs/en/nxp/data-sheets/LPC804_DS.pdf
+ */
+
+    .syntax unified
+    .cpu cortex-m0plus
+    .thumb
+
+    .global g_pfnVectors
+    .global Default_Handler
+    .global Reset_Handler
+
+    .extern _estack
+    .extern _sidata
+    .extern _sdata
+    .extern _edata
+    .extern _sbss
+    .extern _ebss
+    .extern main
+
+/* Vector table (placed in flash at 0x00000000 via .isr_vector). */
+    .section .isr_vector, "a", %progbits
+    .type g_pfnVectors, %object
+    .size g_pfnVectors, . - g_pfnVectors
+
+g_pfnVectors:
+    .word _estack              /* 0x00 Initial stack pointer */
+    .word Reset_Handler        /* 0x04 Reset */
+    .word NMI_Handler          /* 0x08 NMI */
+    .word HardFault_Handler    /* 0x0C HardFault */
+    .word 0                    /* 0x10 reserved */
+    .word 0                    /* 0x14 reserved */
+    .word 0                    /* 0x18 reserved */
+    .word 0                    /* 0x1C reserved (was sign for App CRC) */
+    .word 0                    /* 0x20 reserved */
+    .word 0                    /* 0x24 reserved */
+    .word 0                    /* 0x28 reserved */
+    .word SVC_Handler          /* 0x2C SVCall */
+    .word 0                    /* 0x30 reserved */
+    .word 0                    /* 0x34 reserved */
+    .word PendSV_Handler       /* 0x38 PendSV */
+    .word SysTick_Handler      /* 0x3C SysTick */
+
+    .text
+    .thumb_func
+    .type Reset_Handler, %function
+Reset_Handler:
+    /* Copy .data from FLASH (LMA) to RAM (VMA). */
+    ldr     r0, =_sdata
+    ldr     r1, =_edata
+    ldr     r2, =_sidata
+    movs    r3, #0
+1:
+    cmp     r0, r1
+    bcs     2f
+    ldr     r4, [r2, r3]
+    str     r4, [r0, r3]
+    adds    r3, #4
+    adds    r0, #4
+    b       1b
+2:
+    /* Zero .bss. */
+    ldr     r0, =_sbss
+    ldr     r1, =_ebss
+    movs    r2, #0
+3:
+    cmp     r0, r1
+    bcs     4f
+    str     r2, [r0]
+    adds    r0, #4
+    b       3b
+4:
+    /* Call SystemInit (weak — default is a no-op).
+     * For LPC804 we keep the 15 MHz FRO default clock; Stage 2 may override. */
+    bl      SystemInit
+    bl      main
+LoopForever:
+    b       LoopForever
+    .size Reset_Handler, . - Reset_Handler
+
+    .thumb_func
+    .type Default_Handler, %function
+Default_Handler:
+    b       Default_Handler
+    .size Default_Handler, . - Default_Handler
+
+/* Weak default SystemInit — Stage 2 may override with real clock setup. */
+    .weak SystemInit
+    .thumb_func
+    .type SystemInit, %function
+SystemInit:
+    bx      lr
+    .size SystemInit, . - SystemInit
+
+/* Weak aliases for all system handlers. */
+    .macro def_irq_handler handler_name
+    .weak \handler_name
+    .thumb_set \handler_name, Default_Handler
+    .endm
+
+    def_irq_handler NMI_Handler
+    def_irq_handler HardFault_Handler
+    def_irq_handler SVC_Handler
+    def_irq_handler PendSV_Handler
+    def_irq_handler SysTick_Handler

--- a/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S
+++ b/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S
@@ -1,0 +1,121 @@
+/*
+ * Minimal startup / vector table for NXP LPC845 (Cortex-M0+).
+ *
+ * Provides: Reset_Handler (copies .data, zeros .bss, calls SystemInit then main).
+ * All other vectors alias Default_Handler (weak; users may override).
+ *
+ * TODO(stage2): expand the IRQ table to cover the full LPC845 peripheral
+ * vector list (USART0..4, I2C0..3, SPI0/1, SCT, ADC, DMA, etc.) once a
+ * driver needs an actual handler. The 16-entry skeleton below is the
+ * ARMv6-M system-vector minimum; bare-metal code that never enables an
+ * IRQ runs fine without the extras.
+ *
+ * TODO(stage2): LPC845 boots at 12 MHz IRC by default; SystemInit() is a
+ * placeholder. Stage 2 should configure FRO + PLL to reach the 30 MHz
+ * `f_cpu` advertised in the board JSON, and configure flash wait states
+ * via the FMC register block (see LPC84x UM section 4 — Flash and EEPROM).
+ *
+ * Reference: LPC84x user manual UM11029, table 5 ("Interrupt sources").
+ *   https://www.nxp.com/docs/en/data-sheet/LPC84x.pdf
+ */
+
+    .syntax unified
+    .cpu cortex-m0plus
+    .thumb
+
+    .global g_pfnVectors
+    .global Default_Handler
+    .global Reset_Handler
+
+    .extern _estack
+    .extern _sidata
+    .extern _sdata
+    .extern _edata
+    .extern _sbss
+    .extern _ebss
+    .extern main
+
+/* Vector table (placed in flash at 0x00000000 via .isr_vector). */
+    .section .isr_vector, "a", %progbits
+    .type g_pfnVectors, %object
+    .size g_pfnVectors, . - g_pfnVectors
+
+g_pfnVectors:
+    .word _estack              /* 0x00 Initial stack pointer */
+    .word Reset_Handler        /* 0x04 Reset */
+    .word NMI_Handler          /* 0x08 NMI */
+    .word HardFault_Handler    /* 0x0C HardFault */
+    .word 0                    /* 0x10 reserved */
+    .word 0                    /* 0x14 reserved */
+    .word 0                    /* 0x18 reserved */
+    .word 0                    /* 0x1C reserved (was sign for App CRC) */
+    .word 0                    /* 0x20 reserved */
+    .word 0                    /* 0x24 reserved */
+    .word 0                    /* 0x28 reserved */
+    .word SVC_Handler          /* 0x2C SVCall */
+    .word 0                    /* 0x30 reserved */
+    .word 0                    /* 0x34 reserved */
+    .word PendSV_Handler       /* 0x38 PendSV */
+    .word SysTick_Handler      /* 0x3C SysTick */
+
+    .text
+    .thumb_func
+    .type Reset_Handler, %function
+Reset_Handler:
+    /* Copy .data from FLASH (LMA) to RAM (VMA). */
+    ldr     r0, =_sdata
+    ldr     r1, =_edata
+    ldr     r2, =_sidata
+    movs    r3, #0
+1:
+    cmp     r0, r1
+    bcs     2f
+    ldr     r4, [r2, r3]
+    str     r4, [r0, r3]
+    adds    r3, #4
+    adds    r0, #4
+    b       1b
+2:
+    /* Zero .bss. */
+    ldr     r0, =_sbss
+    ldr     r1, =_ebss
+    movs    r2, #0
+3:
+    cmp     r0, r1
+    bcs     4f
+    str     r2, [r0]
+    adds    r0, #4
+    b       3b
+4:
+    /* Call SystemInit (weak — Stage 2 should override for 30 MHz PLL). */
+    bl      SystemInit
+    bl      main
+LoopForever:
+    b       LoopForever
+    .size Reset_Handler, . - Reset_Handler
+
+    .thumb_func
+    .type Default_Handler, %function
+Default_Handler:
+    b       Default_Handler
+    .size Default_Handler, . - Default_Handler
+
+/* Weak default SystemInit — boots at the 12 MHz IRC reset default. */
+    .weak SystemInit
+    .thumb_func
+    .type SystemInit, %function
+SystemInit:
+    bx      lr
+    .size SystemInit, . - SystemInit
+
+/* Weak aliases for all system handlers. */
+    .macro def_irq_handler handler_name
+    .weak \handler_name
+    .thumb_set \handler_name, Default_Handler
+    .endm
+
+    def_irq_handler NMI_Handler
+    def_irq_handler HardFault_Handler
+    def_irq_handler SVC_Handler
+    def_irq_handler PendSV_Handler
+    def_irq_handler SysTick_Handler

--- a/crates/fbuild-build/src/nxplpc/configs/README.md
+++ b/crates/fbuild-build/src/nxplpc/configs/README.md
@@ -1,0 +1,6 @@
+# NXP LPC8xx MCU config
+
+`nxplpc.json` is loaded by `super::mcu_config::get_nxplpc_config` and bakes
+the Cortex-M0+ compiler / linker flags shared by every LPC8xx target. Board
+JSON entries (lpc804.json, lpc845.json) supply the chip-specific defines via
+`extra_flags`.

--- a/crates/fbuild-build/src/nxplpc/configs/nxplpc.json
+++ b/crates/fbuild-build/src/nxplpc/configs/nxplpc.json
@@ -1,0 +1,65 @@
+{
+  "name": "NXP LPC8xx",
+  "description": "NXP LPC804 / LPC845 (ARM Cortex-M0+, bare-metal CMSIS)",
+  "architecture": "arm-cortex-m0plus",
+  "compiler_flags": {
+    "common": [
+      "-mcpu=cortex-m0plus",
+      "-mthumb",
+      "-mfloat-abi=soft",
+      "-fdata-sections",
+      "-ffunction-sections",
+      "-fmessage-length=0",
+      "-fno-exceptions",
+      "-fomit-frame-pointer",
+      "-funsigned-char",
+      "-Wall",
+      "-Wextra",
+      "-Wno-unused-parameter",
+      "-MMD"
+    ],
+    "c": [
+      "-std=gnu11"
+    ],
+    "cxx": [
+      "-std=gnu++17",
+      "-fno-rtti",
+      "-fno-threadsafe-statics"
+    ]
+  },
+  "linker_flags": [
+    "-mcpu=cortex-m0plus",
+    "-mthumb",
+    "-mfloat-abi=soft",
+    "-specs=nano.specs",
+    "-specs=nosys.specs",
+    "-Wl,--gc-sections",
+    "-Wl,--print-memory-usage",
+    "-nostartfiles"
+  ],
+  "linker_libs": [
+    "-Wl,--start-group",
+    "-lgcc",
+    "-lc_nano",
+    "-lm",
+    "-lnosys",
+    "-Wl,--end-group"
+  ],
+  "objcopy": {
+    "output_format": "binary",
+    "remove_sections": []
+  },
+  "profiles": {
+    "release": {
+      "compile_flags": ["-Os", "-flto", "-fno-fat-lto-objects"],
+      "link_flags": ["-flto", "-fuse-linker-plugin"]
+    },
+    "quick": {
+      "compile_flags": ["-Os"],
+      "link_flags": []
+    }
+  },
+  "defines": [
+    "__NXPLPC__"
+  ]
+}

--- a/crates/fbuild-build/src/nxplpc/mcu_config.rs
+++ b/crates/fbuild-build/src/nxplpc/mcu_config.rs
@@ -1,0 +1,125 @@
+//! Data-driven NXP LPC8xx MCU configuration from embedded JSON.
+//!
+//! Both LPC804 and LPC845 are Cortex-M0+ targets, share the same compiler/linker
+//! flag set, and differ only in memory map (carried by the board JSON) and
+//! linker script (selected in the Stage-2 orchestrator).
+
+use std::collections::HashMap;
+
+use fbuild_core::Result;
+use serde::Deserialize;
+
+use crate::compiler::{CompilerFlags, McuConfig, ObjcopyConfig, ProfileFlags};
+use crate::esp32::mcu_config::DefineEntry;
+
+const NXPLPC_JSON: &str = include_str!("configs/nxplpc.json");
+
+/// Complete NXP LPC8xx MCU configuration parsed from JSON.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NxpLpcMcuConfig {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub architecture: String,
+    pub compiler_flags: CompilerFlags,
+    pub linker_flags: Vec<String>,
+    pub linker_libs: Vec<String>,
+    pub objcopy: ObjcopyConfig,
+    pub profiles: HashMap<String, ProfileFlags>,
+    #[serde(default)]
+    pub defines: Vec<DefineEntry>,
+}
+
+impl NxpLpcMcuConfig {
+    /// Get profile flags for a given profile name.
+    pub fn get_profile(&self, name: &str) -> Option<&ProfileFlags> {
+        self.profiles.get(name)
+    }
+
+    /// Convert defines to a HashMap suitable for merging with board defines.
+    pub fn defines_map(&self) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+        for entry in &self.defines {
+            match entry {
+                DefineEntry::Simple(name) => {
+                    map.insert(name.clone(), "1".to_string());
+                }
+                DefineEntry::KeyValue(name, value) => {
+                    map.insert(name.clone(), value.clone());
+                }
+            }
+        }
+        map
+    }
+}
+
+impl McuConfig for NxpLpcMcuConfig {
+    fn compiler_flags(&self) -> &CompilerFlags {
+        &self.compiler_flags
+    }
+
+    fn get_profile(&self, name: &str) -> Option<&ProfileFlags> {
+        self.profiles.get(name)
+    }
+}
+
+/// Load the shared NXP LPC8xx MCU configuration.
+///
+/// Stage 1 ships a single config for both LPC804 and LPC845. If Stage 2
+/// needs per-chip variation (e.g. PLU defines on LPC804), branch on `mcu`.
+pub fn get_nxplpc_config(_mcu: &str) -> Result<NxpLpcMcuConfig> {
+    serde_json::from_str(NXPLPC_JSON).map_err(|e| {
+        fbuild_core::FbuildError::ConfigError(format!(
+            "failed to parse NXP LPC8xx MCU config: {}",
+            e
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nxplpc_config_parses() {
+        let config = get_nxplpc_config("lpc804").unwrap();
+        assert_eq!(config.architecture, "arm-cortex-m0plus");
+    }
+
+    #[test]
+    fn compiler_flags_target_cortex_m0plus() {
+        let config = get_nxplpc_config("lpc845").unwrap();
+        assert!(config
+            .compiler_flags
+            .common
+            .iter()
+            .any(|f| f == "-mcpu=cortex-m0plus"));
+        assert!(config.compiler_flags.common.iter().any(|f| f == "-mthumb"));
+        assert!(config
+            .compiler_flags
+            .common
+            .iter()
+            .any(|f| f == "-mfloat-abi=soft"));
+    }
+
+    #[test]
+    fn linker_flags_include_gc_sections() {
+        let config = get_nxplpc_config("lpc845").unwrap();
+        assert!(config.linker_flags.iter().any(|f| f == "-Wl,--gc-sections"));
+        assert!(config.linker_flags.iter().any(|f| f == "-nostartfiles"));
+    }
+
+    #[test]
+    fn profiles_define_release_and_quick() {
+        let config = get_nxplpc_config("lpc845").unwrap();
+        assert!(config.get_profile("release").is_some());
+        assert!(config.get_profile("quick").is_some());
+    }
+
+    #[test]
+    fn defines_map_contains_nxplpc_token() {
+        let config = get_nxplpc_config("lpc804").unwrap();
+        let defines = config.defines_map();
+        assert!(defines.contains_key("__NXPLPC__"));
+    }
+}

--- a/crates/fbuild-build/src/nxplpc/mod.rs
+++ b/crates/fbuild-build/src/nxplpc/mod.rs
@@ -1,0 +1,111 @@
+//! NXP LPC8xx (Cortex-M0+) bare-metal CMSIS build support.
+//!
+//! Stage 1 of FastLED/FastLED#2836: scaffolds board/toolchain wiring for
+//! LPC804 and LPC845. Stage 2 (FastLED C++ driver port) will land separately
+//! and unblock the per-platform CI workflows.
+
+pub mod mcu_config;
+
+use std::path::Path;
+
+use fbuild_core::Result;
+
+/// Linker script for LPC804 (32 KB Flash, 4 KB RAM).
+///
+/// Origins / sizes are taken from the LPC804 datasheet, table 5
+/// ("Memory mapping"). Standard Cortex-M0+ section layout.
+pub const LPC804_LD: &str = include_str!("assets/lpc804.ld");
+
+/// Linker script for LPC845 (64 KB Flash, 16 KB RAM).
+///
+/// Origins / sizes are taken from the LPC84x datasheet, section 7.6
+/// ("Memory map"). Standard Cortex-M0+ section layout.
+pub const LPC845_LD: &str = include_str!("assets/lpc845.ld");
+
+/// Minimal Reset_Handler + vector table for LPC804.
+pub const LPC804_STARTUP: &str = include_str!("assets/startup_lpc804.S");
+
+/// Minimal Reset_Handler + vector table for LPC845.
+pub const LPC845_STARTUP: &str = include_str!("assets/startup_lpc845.S");
+
+/// NXP LPC8xx platform support.
+///
+/// Stage 1 ships board/toolchain wiring only. `create_orchestrator()` returns
+/// a stub orchestrator that fails fast with a Stage-2-required message; the
+/// upstream `_ =>` arm in `crate::get_platform_support` already covers the
+/// "not yet implemented" path, but registering NxpLpc here keeps the dispatch
+/// table consistent with other platforms and lets Stage 2 plug in without
+/// touching `lib.rs` again.
+pub struct NxpLpcPlatformSupport;
+
+impl crate::PlatformSupport for NxpLpcPlatformSupport {
+    fn create_orchestrator(&self) -> Box<dyn crate::BuildOrchestrator> {
+        Box::new(NxpLpcStubOrchestrator)
+    }
+
+    fn install_deps(&self, project_dir: &Path) -> Result<()> {
+        // ARM GCC is the right toolchain for Cortex-M0+ bare metal.
+        // Pre-install it so Stage 2's orchestrator can `ensure_installed` cheaply.
+        use fbuild_packages::Package;
+        let tc = fbuild_packages::toolchain::ArmToolchain::new(project_dir);
+        Package::ensure_installed(&tc)?;
+        tracing::info!("ARM GCC toolchain installed for NXP LPC8xx");
+        Ok(())
+    }
+
+    fn default_board_id(&self) -> &str {
+        "lpc845"
+    }
+}
+
+/// Stage-1 placeholder orchestrator. Returns a clear "Stage 2 required" error
+/// so users running `fbuild build` against an LPC8xx board hit a useful
+/// message instead of a generic "not yet implemented".
+struct NxpLpcStubOrchestrator;
+
+impl crate::BuildOrchestrator for NxpLpcStubOrchestrator {
+    fn platform(&self) -> fbuild_core::Platform {
+        fbuild_core::Platform::NxpLpc
+    }
+
+    fn build(&self, _params: &crate::BuildParams) -> Result<crate::BuildResult> {
+        Err(fbuild_core::FbuildError::BuildFailed(
+            "NXP LPC8xx build orchestrator is Stage 2 of FastLED/FastLED#2836 \
+             and has not landed yet. Stage 1 (this PR) wires only the board \
+             definitions, Platform enum entry, linker scripts, and startup \
+             stubs. Track FastLED/fbuild for the Stage-2 follow-up."
+                .to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linker_scripts_have_expected_memory_regions() {
+        assert!(LPC804_LD.contains("FLASH"));
+        assert!(LPC804_LD.contains("0x00000000"));
+        assert!(LPC804_LD.contains("LENGTH = 32K"));
+        assert!(LPC804_LD.contains("0x10000000"));
+        assert!(LPC804_LD.contains("LENGTH = 4K"));
+
+        assert!(LPC845_LD.contains("FLASH"));
+        assert!(LPC845_LD.contains("LENGTH = 64K"));
+        assert!(LPC845_LD.contains("LENGTH = 16K"));
+    }
+
+    #[test]
+    fn startup_files_define_reset_handler() {
+        assert!(LPC804_STARTUP.contains("Reset_Handler"));
+        assert!(LPC845_STARTUP.contains("Reset_Handler"));
+    }
+
+    #[test]
+    fn stub_orchestrator_reports_nxplpc_platform() {
+        use crate::BuildOrchestrator;
+        let orch = NxpLpcStubOrchestrator;
+        assert_eq!(orch.platform(), fbuild_core::Platform::NxpLpc);
+    }
+}

--- a/crates/fbuild-cli/src/lib_select.rs
+++ b/crates/fbuild-cli/src/lib_select.rs
@@ -229,6 +229,14 @@ fn resolve_framework(
                     .to_string(),
             );
         }
+        Platform::NxpLpc => {
+            // NXP LPC8xx is bare-metal CMSIS — no Arduino-style libraries/ tree.
+            // lib-select has nothing to discover; FastLED is consumed as source.
+            return Err(
+                "NXP LPC8xx (bare-metal CMSIS) does not use a libraries/ tree; lib-select is not applicable"
+                    .to_string(),
+            );
+        }
     };
 
     if !libraries_dir.is_dir() {

--- a/crates/fbuild-config/assets/boards/json/lpc804.json
+++ b/crates/fbuild-config/assets/boards/json/lpc804.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "cmsis",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DLPC804 -DCPU_LPC804M101JDH24",
+    "f_cpu": "15000000L",
+    "mcu": "lpc804",
+    "variant": "lpc804"
+  },
+  "debug": {
+    "tools": {
+      "cmsis-dap": {},
+      "jlink": {},
+      "pyocd": {}
+    }
+  },
+  "fcpu": 15000000,
+  "frameworks": [
+    "cmsis"
+  ],
+  "id": "lpc804",
+  "mcu": "LPC804",
+  "name": "NXP LPC804",
+  "platform": "nxplpc",
+  "ram": 4096,
+  "rom": 32768,
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "lpc21isp",
+    "protocols": ["lpc21isp", "cmsis-dap", "jlink", "pyocd"],
+    "speed": 115200
+  },
+  "url": "https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/lpc800-arm-cortex-m0-plus-/low-cost-microcontrollers-mcus-based-on-arm-cortex-m0-plus-cores:LPC80X",
+  "vendor": "NXP"
+}

--- a/crates/fbuild-config/assets/boards/json/lpc845.json
+++ b/crates/fbuild-config/assets/boards/json/lpc845.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "core": "cmsis",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DLPC845 -DCPU_LPC845M301JBD48",
+    "f_cpu": "30000000L",
+    "mcu": "lpc845",
+    "variant": "lpc845"
+  },
+  "debug": {
+    "tools": {
+      "cmsis-dap": {
+        "onboard": true
+      },
+      "jlink": {},
+      "pyocd": {}
+    }
+  },
+  "fcpu": 30000000,
+  "frameworks": [
+    "cmsis"
+  ],
+  "id": "lpc845",
+  "mcu": "LPC845",
+  "name": "NXP LPC845",
+  "platform": "nxplpc",
+  "ram": 16384,
+  "rom": 65536,
+  "upload": {
+    "maximum_ram_size": 16384,
+    "maximum_size": 65536,
+    "protocol": "lpc21isp",
+    "protocols": ["lpc21isp", "cmsis-dap", "jlink", "pyocd"],
+    "speed": 115200
+  },
+  "url": "https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/lpc800-arm-cortex-m0-plus-/low-cost-microcontrollers-lpc84x-mcus-based-on-arm-cortex-m0-plus-cores:LPC84X",
+  "vendor": "NXP"
+}

--- a/crates/fbuild-config/assets/boards/manifest.json
+++ b/crates/fbuild-config/assets/boards/manifest.json
@@ -1052,6 +1052,8 @@
   "lpc1768",
   "lpc54114",
   "lpc546xx",
+  "lpc804",
+  "lpc845",
   "lpcxpresso55s16",
   "lplm4f120h5qr",
   "lpmsp430f5529",

--- a/crates/fbuild-config/src/board/methods.rs
+++ b/crates/fbuild-config/src/board/methods.rs
@@ -245,6 +245,7 @@ impl BoardConfig {
             Some(fbuild_core::Platform::Espressif32) => "ESP32".to_string(),
             Some(fbuild_core::Platform::Espressif8266) => "ESP8266".to_string(),
             Some(fbuild_core::Platform::NordicNrf52) => "NRF52".to_string(),
+            Some(fbuild_core::Platform::NxpLpc) => "NXPLPC".to_string(),
             Some(fbuild_core::Platform::RaspberryPi) => "RP2040".to_string(),
             Some(fbuild_core::Platform::RenesasRa) => "RENESAS".to_string(),
             Some(fbuild_core::Platform::SiliconLabs) => "SILABS".to_string(),

--- a/crates/fbuild-core/src/lib.rs
+++ b/crates/fbuild-core/src/lib.rs
@@ -82,6 +82,7 @@ pub enum Platform {
     Espressif32,
     Espressif8266,
     NordicNrf52,
+    NxpLpc,
     RaspberryPi,
     RenesasRa,
     SiliconLabs,
@@ -116,6 +117,8 @@ impl Platform {
             Some(Self::Ch32v)
         } else if s.contains("nordicnrf52") {
             Some(Self::NordicNrf52)
+        } else if s.contains("nxplpc") {
+            Some(Self::NxpLpc)
         } else if s.contains("renesas") {
             Some(Self::RenesasRa)
         } else if s.contains("siliconlabs") {
@@ -560,6 +563,22 @@ mod tests {
             Some(Platform::Ch32v)
         );
         assert_eq!(Platform::from_platform_str("CH32V"), Some(Platform::Ch32v));
+    }
+
+    #[test]
+    fn platform_from_str_nxplpc() {
+        assert_eq!(
+            Platform::from_platform_str("nxplpc"),
+            Some(Platform::NxpLpc)
+        );
+        assert_eq!(
+            Platform::from_platform_str("platformio/nxplpc"),
+            Some(Platform::NxpLpc)
+        );
+        assert_eq!(
+            Platform::from_platform_str("NXPLPC"),
+            Some(Platform::NxpLpc)
+        );
     }
 
     #[test]

--- a/docs/BOARD_STATUS.md
+++ b/docs/BOARD_STATUS.md
@@ -85,6 +85,10 @@ Live per-platform CI status and supported-board reference for fbuild.
 [![Build Apollo3 RedBoard](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml)
 [![Build Apollo3 expLoRaBLE](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml)
 
+### NXP LPC (Cortex-M0+)
+[![Build LPC804](https://github.com/fastled/fbuild/actions/workflows/build-lpc804.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc804.yml)
+[![Build LPC845](https://github.com/fastled/fbuild/actions/workflows/build-lpc845.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc845.yml)
+
 ### Silicon Labs
 [![Build MGM240](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml)
 

--- a/tests/platform/lpc804/README.md
+++ b/tests/platform/lpc804/README.md
@@ -1,0 +1,7 @@
+# LPC804 build fixture
+
+Bare-metal CMSIS test project for the NXP LPC804 (Cortex-M0+, 32 KB Flash, 4 KB RAM).
+
+Stage 1 of FastLED/FastLED#2836. The CI workflow that drives this fixture
+(`.github/workflows/build-lpc804.yml`) will FAIL until the Stage 2 FastLED-side
+port lands and the LPC8xx orchestrator can compile a real binary.

--- a/tests/platform/lpc804/lpc804.ino
+++ b/tests/platform/lpc804/lpc804.ino
@@ -1,0 +1,4 @@
+// Minimal LPC804 sketch. Stage-2 FastLED port (FastLED/FastLED#2836) will
+// replace this with a real LED-blink fixture once the orchestrator can compile.
+void setup() {}
+void loop() {}

--- a/tests/platform/lpc804/platformio.ini
+++ b/tests/platform/lpc804/platformio.ini
@@ -1,0 +1,4 @@
+[env:lpc804]
+platform = nxplpc
+board = lpc804
+framework = cmsis

--- a/tests/platform/lpc845/README.md
+++ b/tests/platform/lpc845/README.md
@@ -1,0 +1,7 @@
+# LPC845 build fixture
+
+Bare-metal CMSIS test project for the NXP LPC845 (Cortex-M0+, 64 KB Flash, 16 KB RAM, DMA).
+
+Stage 1 of FastLED/FastLED#2836. The CI workflow that drives this fixture
+(`.github/workflows/build-lpc845.yml`) will FAIL until the Stage 2 FastLED-side
+port lands and the LPC8xx orchestrator can compile a real binary.

--- a/tests/platform/lpc845/lpc845.ino
+++ b/tests/platform/lpc845/lpc845.ino
@@ -1,0 +1,4 @@
+// Minimal LPC845 sketch. Stage-2 FastLED port (FastLED/FastLED#2836) will
+// replace this with a real LED-blink fixture once the orchestrator can compile.
+void setup() {}
+void loop() {}

--- a/tests/platform/lpc845/platformio.ini
+++ b/tests/platform/lpc845/platformio.ini
@@ -1,0 +1,4 @@
+[env:lpc845]
+platform = nxplpc
+board = lpc845
+framework = cmsis


### PR DESCRIPTION
## Summary

Stage 1 of FastLED/FastLED#2836 — build/toolchain scaffolding for NXP LPC804 and LPC845 (Cortex-M0+) as bare-metal CMSIS targets. Stage 2 (the FastLED-side C++ driver port) lands separately.

| Part   | Core         | Flash | RAM   | Notes                              |
| ------ | ------------ | ----- | ----- | ---------------------------------- |
| LPC804 | Cortex-M0+   | 32 KB | 4 KB  | 15 MHz default, PLU, no DMA        |
| LPC845 | Cortex-M0+   | 64 KB | 16 KB | 30 MHz, has DMA                    |

## Files added/modified

**New:**
- `crates/fbuild-config/assets/boards/json/lpc804.json`
- `crates/fbuild-config/assets/boards/json/lpc845.json`
- `crates/fbuild-build/src/nxplpc/{mod.rs, mcu_config.rs, README.md}`
- `crates/fbuild-build/src/nxplpc/configs/{nxplpc.json, README.md}`
- `crates/fbuild-build/src/nxplpc/assets/{lpc804.ld, lpc845.ld, startup_lpc804.S, startup_lpc845.S, README.md}`
- `.github/workflows/build-lpc804.yml`, `build-lpc845.yml`
- `tests/platform/lpc804/{platformio.ini, lpc804.ino, README.md}`
- `tests/platform/lpc845/{platformio.ini, lpc845.ino, README.md}`

**Modified:**
- `crates/fbuild-core/src/lib.rs` — new `Platform::NxpLpc` enum variant, `nxplpc` substring match in `from_platform_str`, test coverage
- `crates/fbuild-build/src/lib.rs` — register `nxplpc` module + `NxpLpcPlatformSupport` in `get_platform_support`
- `crates/fbuild-cli/src/lib_select.rs` — exhaustive match arm (returns "not applicable" for bare-metal CMSIS, same shape as the WASM arm)
- `crates/fbuild-config/src/board/methods.rs` — `arch_define` returns `"NXPLPC"`
- `crates/fbuild-config/assets/boards/manifest.json` — sorted insertion of two new IDs
- `README.md`, `docs/BOARD_STATUS.md` — new "NXP LPC (Cortex-M0+)" badge group

## Stage 1 vs Stage 2

This PR ships the **build/toolchain wiring only**:

- The `NxpLpcPlatformSupport::install_deps` pre-fetches the ARM GCC toolchain (`ArmToolchain`), so Stage 2 won't pay that cost again.
- The orchestrator returns `BuildFailed("NXP LPC8xx build orchestrator is Stage 2 of FastLED/FastLED#2836 and has not landed yet…")` — clear message instead of a generic "not yet implemented".
- The two CI workflows therefore **fail at the `fbuild build` step** until Stage 2 lands. They're marked `continue-on-error: true` at the job level so they don't block `main`; remove that line in the Stage 2 PR.

Stage 2 will:
1. Replace `NxpLpcStubOrchestrator` with a real `BuildOrchestrator` impl that compiles sources against the embedded linker scripts + startup assembly,
2. Add a `lpc21isp`-backed deployer entry (for ISP-via-UART), and
3. Expand the IRQ vector tables to cover peripheral interrupts as drivers need them.

## Documented TODOs left in code

- `nxplpc/assets/startup_lpc845.S` — `SystemInit` is a no-op; LPC845 boots at 12 MHz IRC by default but the board JSON advertises `f_cpu = 30 MHz`. Stage 2 needs FRO + PLL + flash-wait-state setup (UM11029 §4). Documented inline with datasheet pointer.
- `nxplpc/assets/startup_lpc{804,845}.S` — vector tables are the ARMv6-M system-vector minimum (16 entries). Datasheet references included; Stage 2 expands per-peripheral as drivers require.
- `nxplpc/mcu_config.rs::get_nxplpc_config` — single shared MCU config for both chips. If Stage 2 needs per-chip flag divergence (e.g. PLU defines on LPC804), branch on `mcu`.
- Memory regions in the linker scripts are taken directly from the datasheets cited in each file header. Reviewers with hardware should sanity-check before flashing.

## How verified

- `soldr cargo check --workspace --all-targets` — green
- `soldr cargo clippy --workspace --all-targets -- -D warnings` — green
- `soldr cargo fmt --check` — green
- `soldr cargo test -p fbuild-core` — 86 pass (including new `platform_from_str_nxplpc`)
- `soldr cargo test -p fbuild-build --lib nxplpc` — 8 pass (linker-script content, startup-handler presence, MCU-config parse, stub orchestrator platform)
- `soldr cargo test -p fbuild-config --lib` — 142 pass
- `uv run python ci/validate_boards.py` — pre-existing drift unchanged; the new LPC8xx boards are skipped (no PlatformIO platform installed locally, as expected for a bare-metal target)

## Test plan

- [ ] CI: `Build LPC804` and `Build LPC845` workflows complete (will fail until Stage 2 — `continue-on-error: true`).
- [ ] Workspace CI stays green.
- [ ] Stage 2 PR rebases on this branch, lands the real orchestrator + lpc21isp deployer, and removes `continue-on-error: true` from both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)