### PR TITLE
feat(platform): LPC8xx SystemInit + vector tables + per-chip config (FastLED/FastLED#2845)

### DIFF
--- a/crates/fbuild-build/src/nxplpc/assets/startup_lpc804.S
+++ b/crates/fbuild-build/src/nxplpc/assets/startup_lpc804.S
@@ -1,17 +1,37 @@
 /*
- * Minimal startup / vector table for NXP LPC804 (Cortex-M0+).
+ * Startup / vector table for NXP LPC804 (Cortex-M0+).
  *
- * Provides: Reset_Handler (copies .data, zeros .bss, calls SystemInit then main).
- * All other vectors alias Default_Handler (weak; users may override).
+ * Provides:
+ *   - Initial stack pointer
+ *   - Reset_Handler (copies .data, zeros .bss, calls SystemInit then main)
+ *   - Expanded vector table covering ARMv6-M system vectors + LPC804
+ *     peripheral IRQs (see UM11065 table 4 "Interrupt sources")
+ *   - SystemInit that explicitly leaves the FRO at 15 MHz IRC default
+ *     and programs 0 flash wait states (matches `F_CPU=15000000UL` in
+ *     FastLED `led_sysdefs_arm_lpc.h`)
  *
- * TODO(stage2): expand the IRQ table to cover the full LPC804 peripheral
- * vector list (USART0..2, I2C0..3, SCT, PLU, ADC, etc.) once a driver
- * needs an actual handler. The 16-entry skeleton below is the ARMv6-M
- * system-vector minimum; bare-metal code that never enables an IRQ runs
- * fine without the extras.
+ * All non-Reset vectors alias Default_Handler (weak). Drivers may override
+ * any IRQ by defining the corresponding `<Name>_IRQHandler` symbol.
  *
- * Reference: LPC804 datasheet, table 6 ("Interrupt vector table").
- *   https://www.nxp.com/docs/en/nxp/data-sheets/LPC804_DS.pdf
+ * Design note (FastLED/FastLED#2845):
+ *   The LPC804 PLL is *deliberately not configured* here. Reasons:
+ *     1. The 15 MHz FRO default matches the `F_CPU=15000000UL` advertised in
+ *        FastLED's `led_sysdefs_arm_lpc.h`. Raising it would silently break
+ *        bit-bang cycle counts on the Stage 2a driver.
+ *     2. The Stage 2b PLU clockless driver (FastLED/FastLED#2841) may want
+ *        a separate timing-counter clock that the PLU configures itself.
+ *        SystemInit should not pre-commit a PLL setup that the driver then
+ *        has to tear down.
+ *   If a future driver needs PLL-based clocking it should provide a strong
+ *   override of `SystemInit`.
+ *
+ * References:
+ *   - UM11065 (LPC80x User Manual), section 4 (system config), section 4.5
+ *     (FMC FLASHCFG), table 4 (interrupt sources)
+ *     https://www.nxp.com/docs/en/nxp/data-sheets/LPC804_DS.pdf
+ *   - NXP CMSIS device header `LPC804.h` (register layout)
+ *
+ * Tracking: FastLED/FastLED#2845 (Stage 3 — port completion).
  */
 
     .syntax unified
@@ -21,6 +41,7 @@
     .global g_pfnVectors
     .global Default_Handler
     .global Reset_Handler
+    .global SystemInit
 
     .extern _estack
     .extern _sidata
@@ -30,12 +51,19 @@
     .extern _ebss
     .extern main
 
-/* Vector table (placed in flash at 0x00000000 via .isr_vector). */
+/* ---------------------------------------------------------------------------
+ * Vector table — placed in flash at 0x00000000 via .isr_vector.
+ *
+ * Layout: 16 ARMv6-M system entries + LPC804 peripheral IRQs
+ * (UM11065 table 4). Vectors 16..47 correspond to IRQ#0..IRQ#31 in the
+ * NVIC view. LPC804 has fewer peripherals than LPC845 (no second DMA,
+ * fewer pin-interrupts, no CTIMER); reserved slots are zero-filled.
+ * --------------------------------------------------------------------------- */
     .section .isr_vector, "a", %progbits
     .type g_pfnVectors, %object
-    .size g_pfnVectors, . - g_pfnVectors
 
 g_pfnVectors:
+    /* ARMv6-M system vectors (0..15). */
     .word _estack              /* 0x00 Initial stack pointer */
     .word Reset_Handler        /* 0x04 Reset */
     .word NMI_Handler          /* 0x08 NMI */
@@ -43,7 +71,7 @@ g_pfnVectors:
     .word 0                    /* 0x10 reserved */
     .word 0                    /* 0x14 reserved */
     .word 0                    /* 0x18 reserved */
-    .word 0                    /* 0x1C reserved (was sign for App CRC) */
+    .word 0                    /* 0x1C reserved (boot code App CRC slot) */
     .word 0                    /* 0x20 reserved */
     .word 0                    /* 0x24 reserved */
     .word 0                    /* 0x28 reserved */
@@ -53,6 +81,46 @@ g_pfnVectors:
     .word PendSV_Handler       /* 0x38 PendSV */
     .word SysTick_Handler      /* 0x3C SysTick */
 
+    /* LPC804 peripheral IRQs (UM11065 table 4).
+     * IRQ numbers per CMSIS device header `LPC804.h`. */
+    .word SPI0_IRQHandler        /* IRQ  0 — SPI0 */
+    .word 0                      /* IRQ  1 — reserved (no SPI1 on LPC804) */
+    .word DAC0_IRQHandler        /* IRQ  2 — DAC0 */
+    .word USART0_IRQHandler      /* IRQ  3 — USART0 */
+    .word USART1_IRQHandler      /* IRQ  4 — USART1 */
+    .word USART2_IRQHandler      /* IRQ  5 — USART2 */
+    .word 0                      /* IRQ  6 — reserved */
+    .word I2C1_IRQHandler        /* IRQ  7 — I2C1 */
+    .word I2C0_IRQHandler        /* IRQ  8 — I2C0 */
+    .word SCT_IRQHandler         /* IRQ  9 — SCT (LPC804 also has SCT) */
+    .word MRT_IRQHandler         /* IRQ 10 — Multi-rate timer */
+    .word CMP_CAPT_IRQHandler    /* IRQ 11 — Analog comparator / CAPT */
+    .word WDT_IRQHandler         /* IRQ 12 — Windowed watchdog */
+    .word BOD_IRQHandler         /* IRQ 13 — Brown-out detect */
+    .word FLASH_IRQHandler       /* IRQ 14 — Flash controller */
+    .word WKT_IRQHandler         /* IRQ 15 — Wake-up timer */
+    .word ADC_SEQA_IRQHandler    /* IRQ 16 — ADC sequence A complete */
+    .word ADC_SEQB_IRQHandler    /* IRQ 17 — ADC sequence B complete */
+    .word ADC_THCMP_IRQHandler   /* IRQ 18 — ADC threshold compare */
+    .word ADC_OVR_IRQHandler     /* IRQ 19 — ADC overrun */
+    .word DMA_IRQHandler         /* IRQ 20 — DMA0 (LPC804 has only one DMA) */
+    .word I2C2_IRQHandler        /* IRQ 21 — I2C2 */
+    .word I2C3_IRQHandler        /* IRQ 22 — I2C3 */
+    .word PLU_IRQHandler         /* IRQ 23 — PLU (LPC804 distinguishing feature) */
+    .word PIN_INT0_IRQHandler    /* IRQ 24 — Pin interrupt 0 */
+    .word PIN_INT1_IRQHandler    /* IRQ 25 — Pin interrupt 1 */
+    .word PIN_INT2_IRQHandler    /* IRQ 26 — Pin interrupt 2 */
+    .word PIN_INT3_IRQHandler    /* IRQ 27 — Pin interrupt 3 */
+    .word 0                      /* IRQ 28 — reserved (no PINT4 on LPC804) */
+    .word 0                      /* IRQ 29 — reserved */
+    .word 0                      /* IRQ 30 — reserved */
+    .word 0                      /* IRQ 31 — reserved */
+
+    .size g_pfnVectors, . - g_pfnVectors
+
+/* ---------------------------------------------------------------------------
+ * Reset handler.
+ * --------------------------------------------------------------------------- */
     .text
     .thumb_func
     .type Reset_Handler, %function
@@ -82,36 +150,117 @@ Reset_Handler:
     adds    r0, #4
     b       3b
 4:
-    /* Call SystemInit (weak — default is a no-op).
-     * For LPC804 we keep the 15 MHz FRO default clock; Stage 2 may override. */
+    /* SystemInit explicitly leaves FRO at 15 MHz default. */
     bl      SystemInit
     bl      main
 LoopForever:
     b       LoopForever
     .size Reset_Handler, . - Reset_Handler
 
+/* ---------------------------------------------------------------------------
+ * Default IRQ handler — infinite loop.
+ * --------------------------------------------------------------------------- */
     .thumb_func
     .type Default_Handler, %function
 Default_Handler:
     b       Default_Handler
     .size Default_Handler, . - Default_Handler
 
-/* Weak default SystemInit — Stage 2 may override with real clock setup. */
+/* ---------------------------------------------------------------------------
+ * SystemInit — minimal clock setup for LPC804 @ 15 MHz IRC default.
+ *
+ * UM11065 section 4 boot defaults:
+ *   - Core clock source: FRO @ 15 MHz (post-divide-by-2 from 30 MHz osc)
+ *   - SYSAHBCLKDIV = 1
+ *   - PLL: off
+ *
+ * What this routine does:
+ *   1. Program flash wait states: 0 wait states is valid up to ~20 MHz on
+ *      LPC804 flash (UM11065 §4.5 FLASHCFG.FLASHTIM). At 15 MHz this is safe.
+ *   2. Set SYSAHBCLKDIV = 1 explicitly (matches reset default).
+ *   3. Leave SYSCON->MAINCLKSEL untouched (FRO direct = reset default).
+ *
+ * What this routine does *not* do:
+ *   - PLL configuration. The Stage 2b PLU clockless driver
+ *     (FastLED/FastLED#2841) may want to own clocking decisions for the
+ *     timing-counter path; bare SystemInit should not pre-commit.
+ *
+ * Register addresses (UM11065, CMSIS LPC804.h):
+ *   SYSCON base   = 0x40048000
+ *     SYSAHBCLKDIV @ 0x078
+ *   FMC base      = 0x40040000
+ *     FLASHCFG     @ 0x010
+ * --------------------------------------------------------------------------- */
+    .equ LPC804_FMC_BASE,         0x40040000
+    .equ LPC804_FMC_FLASHCFG_OFS, 0x010
+    .equ LPC804_SYSCON_BASE,      0x40048000
+    .equ LPC804_SYSCON_SYSAHBCLKDIV_OFS, 0x078
+
+    /* FLASHTIM[1:0] = 0 → 0 wait states (valid up to 20 MHz). */
+    .equ LPC804_FLASHCFG_0WS,     0x0
+    .equ LPC804_FLASHCFG_TIM_MASK, 0x3
+
     .weak SystemInit
     .thumb_func
     .type SystemInit, %function
 SystemInit:
+    /* (1) FLASHCFG = (FLASHCFG & ~0x3) | 0   — set 0 wait states. */
+    ldr     r0, =LPC804_FMC_BASE
+    ldr     r1, [r0, #LPC804_FMC_FLASHCFG_OFS]
+    movs    r2, #LPC804_FLASHCFG_TIM_MASK
+    bics    r1, r2
+    /* No OR needed: FLASHTIM = 0. */
+    str     r1, [r0, #LPC804_FMC_FLASHCFG_OFS]
+
+    /* (2) Ensure SYSAHBCLKDIV = 1. */
+    ldr     r0, =LPC804_SYSCON_BASE
+    movs    r1, #1
+    str     r1, [r0, #LPC804_SYSCON_SYSAHBCLKDIV_OFS]
+
+    /* Reset default FRO @ 15 MHz IRC remains in effect. */
     bx      lr
     .size SystemInit, . - SystemInit
 
-/* Weak aliases for all system handlers. */
+/* ---------------------------------------------------------------------------
+ * Weak aliases for all IRQs — each one points at Default_Handler unless
+ * a driver provides a strong definition.
+ * --------------------------------------------------------------------------- */
     .macro def_irq_handler handler_name
     .weak \handler_name
     .thumb_set \handler_name, Default_Handler
     .endm
 
+    /* System vectors. */
     def_irq_handler NMI_Handler
     def_irq_handler HardFault_Handler
     def_irq_handler SVC_Handler
     def_irq_handler PendSV_Handler
     def_irq_handler SysTick_Handler
+
+    /* Peripheral IRQs (UM11065 table 4). */
+    def_irq_handler SPI0_IRQHandler
+    def_irq_handler DAC0_IRQHandler
+    def_irq_handler USART0_IRQHandler
+    def_irq_handler USART1_IRQHandler
+    def_irq_handler USART2_IRQHandler
+    def_irq_handler I2C1_IRQHandler
+    def_irq_handler I2C0_IRQHandler
+    def_irq_handler SCT_IRQHandler
+    def_irq_handler MRT_IRQHandler
+    def_irq_handler CMP_CAPT_IRQHandler
+    def_irq_handler WDT_IRQHandler
+    def_irq_handler BOD_IRQHandler
+    def_irq_handler FLASH_IRQHandler
+    def_irq_handler WKT_IRQHandler
+    def_irq_handler ADC_SEQA_IRQHandler
+    def_irq_handler ADC_SEQB_IRQHandler
+    def_irq_handler ADC_THCMP_IRQHandler
+    def_irq_handler ADC_OVR_IRQHandler
+    def_irq_handler DMA_IRQHandler
+    def_irq_handler I2C2_IRQHandler
+    def_irq_handler I2C3_IRQHandler
+    def_irq_handler PLU_IRQHandler
+    def_irq_handler PIN_INT0_IRQHandler
+    def_irq_handler PIN_INT1_IRQHandler
+    def_irq_handler PIN_INT2_IRQHandler
+    def_irq_handler PIN_INT3_IRQHandler

--- a/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S
+++ b/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S
@@ -1,22 +1,24 @@
 /*
- * Minimal startup / vector table for NXP LPC845 (Cortex-M0+).
+ * Startup / vector table for NXP LPC845 (Cortex-M0+).
  *
- * Provides: Reset_Handler (copies .data, zeros .bss, calls SystemInit then main).
- * All other vectors alias Default_Handler (weak; users may override).
+ * Provides:
+ *   - Initial stack pointer
+ *   - Reset_Handler (copies .data, zeros .bss, calls SystemInit then main)
+ *   - Expanded vector table covering ARMv6-M system vectors + LPC845
+ *     peripheral IRQs (see UM11029 table 5 "Interrupt sources")
+ *   - SystemInit that brings core to 30 MHz from the on-chip FRO, with
+ *     flash wait states programmed per UM11029 section 4.5 (FMC FLASHCFG)
  *
- * TODO(stage2): expand the IRQ table to cover the full LPC845 peripheral
- * vector list (USART0..4, I2C0..3, SPI0/1, SCT, ADC, DMA, etc.) once a
- * driver needs an actual handler. The 16-entry skeleton below is the
- * ARMv6-M system-vector minimum; bare-metal code that never enables an
- * IRQ runs fine without the extras.
+ * All non-Reset vectors alias Default_Handler (weak). Drivers may override
+ * any IRQ by defining the corresponding `<Name>_IRQHandler` symbol.
  *
- * TODO(stage2): LPC845 boots at 12 MHz IRC by default; SystemInit() is a
- * placeholder. Stage 2 should configure FRO + PLL to reach the 30 MHz
- * `f_cpu` advertised in the board JSON, and configure flash wait states
- * via the FMC register block (see LPC84x UM section 4 — Flash and EEPROM).
+ * References:
+ *   - UM11029 (LPC84x User Manual), section 4 (system config), section 4.5
+ *     (FMC FLASHCFG), table 5 (interrupt sources)
+ *     https://www.nxp.com/docs/en/data-sheet/LPC84x.pdf
+ *   - NXP CMSIS device header `LPC845.h` (register layout)
  *
- * Reference: LPC84x user manual UM11029, table 5 ("Interrupt sources").
- *   https://www.nxp.com/docs/en/data-sheet/LPC84x.pdf
+ * Tracking: FastLED/FastLED#2845 (Stage 3 — port completion).
  */
 
     .syntax unified
@@ -26,6 +28,7 @@
     .global g_pfnVectors
     .global Default_Handler
     .global Reset_Handler
+    .global SystemInit
 
     .extern _estack
     .extern _sidata
@@ -35,12 +38,19 @@
     .extern _ebss
     .extern main
 
-/* Vector table (placed in flash at 0x00000000 via .isr_vector). */
+/* ---------------------------------------------------------------------------
+ * Vector table — placed in flash at 0x00000000 via .isr_vector.
+ *
+ * Layout: 16 ARMv6-M system entries + LPC845 peripheral IRQs
+ * (UM11029 table 5). Total = 16 + 32 = 48 entries for the peripheral
+ * range covered here. Vectors 16..47 correspond to IRQ#0..IRQ#31 in the
+ * NVIC view; SPI0..PIN_INT7 below match the IRQ numbers in `LPC845.h`.
+ * --------------------------------------------------------------------------- */
     .section .isr_vector, "a", %progbits
     .type g_pfnVectors, %object
-    .size g_pfnVectors, . - g_pfnVectors
 
 g_pfnVectors:
+    /* ARMv6-M system vectors (0..15). */
     .word _estack              /* 0x00 Initial stack pointer */
     .word Reset_Handler        /* 0x04 Reset */
     .word NMI_Handler          /* 0x08 NMI */
@@ -48,7 +58,7 @@ g_pfnVectors:
     .word 0                    /* 0x10 reserved */
     .word 0                    /* 0x14 reserved */
     .word 0                    /* 0x18 reserved */
-    .word 0                    /* 0x1C reserved (was sign for App CRC) */
+    .word 0                    /* 0x1C reserved (boot code App CRC slot) */
     .word 0                    /* 0x20 reserved */
     .word 0                    /* 0x24 reserved */
     .word 0                    /* 0x28 reserved */
@@ -58,6 +68,46 @@ g_pfnVectors:
     .word PendSV_Handler       /* 0x38 PendSV */
     .word SysTick_Handler      /* 0x3C SysTick */
 
+    /* LPC845 peripheral IRQs (UM11029 table 5).
+     * IRQ numbers per CMSIS device header `LPC845.h`. */
+    .word SPI0_IRQHandler        /* IRQ  0 — SPI0 */
+    .word SPI1_IRQHandler        /* IRQ  1 — SPI1 */
+    .word DAC0_IRQHandler        /* IRQ  2 — DAC0 */
+    .word USART0_IRQHandler      /* IRQ  3 — USART0 */
+    .word USART1_IRQHandler      /* IRQ  4 — USART1 */
+    .word USART2_IRQHandler      /* IRQ  5 — USART2 */
+    .word 0                      /* IRQ  6 — reserved */
+    .word I2C1_IRQHandler        /* IRQ  7 — I2C1 */
+    .word I2C0_IRQHandler        /* IRQ  8 — I2C0 */
+    .word SCT_IRQHandler         /* IRQ  9 — SCT (state-configurable timer) */
+    .word MRT_IRQHandler         /* IRQ 10 — Multi-rate timer */
+    .word CMP_IRQHandler         /* IRQ 11 — Analog comparator / CAPT */
+    .word WDT_IRQHandler         /* IRQ 12 — Windowed watchdog */
+    .word BOD_IRQHandler         /* IRQ 13 — Brown-out detect */
+    .word FLASH_IRQHandler       /* IRQ 14 — Flash controller */
+    .word WKT_IRQHandler         /* IRQ 15 — Wake-up timer */
+    .word ADC_SEQA_IRQHandler    /* IRQ 16 — ADC sequence A complete */
+    .word ADC_SEQB_IRQHandler    /* IRQ 17 — ADC sequence B complete */
+    .word ADC_THCMP_IRQHandler   /* IRQ 18 — ADC threshold compare */
+    .word ADC_OVR_IRQHandler     /* IRQ 19 — ADC overrun */
+    .word DMA_IRQHandler         /* IRQ 20 — DMA0 (single controller) */
+    .word I2C2_IRQHandler        /* IRQ 21 — I2C2 */
+    .word I2C3_IRQHandler        /* IRQ 22 — I2C3 */
+    .word CTIMER0_IRQHandler     /* IRQ 23 — Standard counter/timer CTIMER0 */
+    .word PIN_INT0_IRQHandler    /* IRQ 24 — Pin interrupt 0 */
+    .word PIN_INT1_IRQHandler    /* IRQ 25 — Pin interrupt 1 */
+    .word PIN_INT2_IRQHandler    /* IRQ 26 — Pin interrupt 2 */
+    .word PIN_INT3_IRQHandler    /* IRQ 27 — Pin interrupt 3 */
+    .word PIN_INT4_IRQHandler    /* IRQ 28 — Pin interrupt 4 */
+    .word PIN_INT5_IRQHandler    /* IRQ 29 — Pin interrupt 5 / DAC1 */
+    .word PIN_INT6_IRQHandler    /* IRQ 30 — Pin interrupt 6 / USART3 */
+    .word PIN_INT7_IRQHandler    /* IRQ 31 — Pin interrupt 7 / USART4 */
+
+    .size g_pfnVectors, . - g_pfnVectors
+
+/* ---------------------------------------------------------------------------
+ * Reset handler.
+ * --------------------------------------------------------------------------- */
     .text
     .thumb_func
     .type Reset_Handler, %function
@@ -87,35 +137,149 @@ Reset_Handler:
     adds    r0, #4
     b       3b
 4:
-    /* Call SystemInit (weak — Stage 2 should override for 30 MHz PLL). */
+    /* SystemInit configures clocks + flash wait states. */
     bl      SystemInit
     bl      main
 LoopForever:
     b       LoopForever
     .size Reset_Handler, . - Reset_Handler
 
+/* ---------------------------------------------------------------------------
+ * Default IRQ handler — infinite loop.
+ * --------------------------------------------------------------------------- */
     .thumb_func
     .type Default_Handler, %function
 Default_Handler:
     b       Default_Handler
     .size Default_Handler, . - Default_Handler
 
-/* Weak default SystemInit — boots at the 12 MHz IRC reset default. */
+/* ---------------------------------------------------------------------------
+ * SystemInit — clock + flash setup for LPC845 @ 30 MHz from FRO.
+ *
+ * UM11029 section 4 procedure (FRO direct, no PLL needed up to 30 MHz):
+ *   1. Configure flash wait states in FMC->FLASHCFG before raising the
+ *      core clock (section 4.5). LPC845 flash supports:
+ *        - 0 wait states up to 20 MHz
+ *        - 1 wait state up to 30 MHz
+ *        - 2 wait states up to 60 MHz (LPC845 max is 30 MHz, so 1 WS suffices)
+ *      FLASHCFG.FLASHTIM (bits[1:0]): 0=1 cycle, 1=2 cycles, 2=3 cycles.
+ *      The LPC845 datasheet encodes "FLASHTIM = 1" as "1 wait state",
+ *      matching 30 MHz operation. Other bits in FLASHCFG must be preserved.
+ *   2. The FRO defaults to 24 MHz on reset (post-divider = /2 from 48 MHz
+ *      FRO oscillator). To reach 30 MHz the FRO must be reconfigured.
+ *
+ * NOTE — Stage 3 design decision (FastLED/FastLED#2845):
+ *   The FRO frequency / divider register layout for "30 MHz direct" mode
+ *   (SYSCON->FROOSCCTRL bits) requires device-on-hand validation; the
+ *   datasheet describes 18 / 24 / 30 MHz FRO settings, but the exact
+ *   sequence (ROM helper `IAP_ReadPartID` + `set_fro_frequency()` vs.
+ *   direct register write) varies by silicon revision. We program flash
+ *   wait states (safe — only affects timing), set SYSAHBCLKDIV = 1 (safe
+ *   reset default), and leave the FRO at its reset frequency. Drivers
+ *   that need exact 30 MHz timing should override SystemInit with a
+ *   board-specific implementation that uses the boot ROM API.
+ *
+ * TODO(2845): Once a real LPCXpresso845 is available, replace the
+ * "leave FRO at reset default" block with a verified FRO-to-30 MHz
+ * sequence per UM11029 §4 and update F_CPU consumers accordingly.
+ *
+ * Register addresses (UM11029, CMSIS LPC845.h):
+ *   SYSCON base   = 0x40048000
+ *     SYSAHBCLKDIV @ 0x078
+ *     MAINCLKSEL   @ 0x070, MAINCLKUEN @ 0x074
+ *   FMC base      = 0x40040000
+ *     FLASHCFG     @ 0x010
+ * --------------------------------------------------------------------------- */
+    .equ LPC845_FMC_BASE,         0x40040000
+    .equ LPC845_FMC_FLASHCFG_OFS, 0x010
+    .equ LPC845_SYSCON_BASE,      0x40048000
+    .equ LPC845_SYSCON_MAINCLKSEL_OFS,    0x070
+    .equ LPC845_SYSCON_MAINCLKUEN_OFS,    0x074
+    .equ LPC845_SYSCON_SYSAHBCLKDIV_OFS,  0x078
+
+    /* FLASHTIM[1:0] = 1 → 1 wait state (covers up to 30 MHz core clock). */
+    .equ LPC845_FLASHCFG_1WS,     0x1
+    .equ LPC845_FLASHCFG_TIM_MASK, 0x3
+
     .weak SystemInit
     .thumb_func
     .type SystemInit, %function
 SystemInit:
+    /* (1) Program flash wait states BEFORE raising the core clock.
+     *     FLASHCFG = (FLASHCFG & ~0x3) | 1   — set 1 wait state. */
+    ldr     r0, =LPC845_FMC_BASE
+    ldr     r1, [r0, #LPC845_FMC_FLASHCFG_OFS]
+    movs    r2, #LPC845_FLASHCFG_TIM_MASK
+    bics    r1, r2
+    movs    r2, #LPC845_FLASHCFG_1WS
+    orrs    r1, r2
+    str     r1, [r0, #LPC845_FMC_FLASHCFG_OFS]
+
+    /* (2) Ensure SYSAHBCLKDIV = 1 (reset default, but make it explicit). */
+    ldr     r0, =LPC845_SYSCON_BASE
+    movs    r1, #1
+    str     r1, [r0, #LPC845_SYSCON_SYSAHBCLKDIV_OFS]
+
+    /* (3) MAINCLKSEL = 0 (FRO direct). Latch via MAINCLKUEN 0→1.
+     *     UM11029 §4.6.3: software must toggle MAINCLKUEN to update. */
+    movs    r1, #0
+    str     r1, [r0, #LPC845_SYSCON_MAINCLKSEL_OFS]
+    str     r1, [r0, #LPC845_SYSCON_MAINCLKUEN_OFS]
+    movs    r1, #1
+    str     r1, [r0, #LPC845_SYSCON_MAINCLKUEN_OFS]
+
+    /* TODO(2845): FRO-to-30 MHz reconfiguration goes here, gated on
+     * device validation. Until then the core runs at the FRO reset
+     * default (typically 24 MHz on LPC845 post-divide-by-2). */
+
     bx      lr
     .size SystemInit, . - SystemInit
 
-/* Weak aliases for all system handlers. */
+/* ---------------------------------------------------------------------------
+ * Weak aliases for all IRQs — each one points at Default_Handler unless
+ * a driver provides a strong definition.
+ * --------------------------------------------------------------------------- */
     .macro def_irq_handler handler_name
     .weak \handler_name
     .thumb_set \handler_name, Default_Handler
     .endm
 
+    /* System vectors. */
     def_irq_handler NMI_Handler
     def_irq_handler HardFault_Handler
     def_irq_handler SVC_Handler
     def_irq_handler PendSV_Handler
     def_irq_handler SysTick_Handler
+
+    /* Peripheral IRQs (UM11029 table 5). */
+    def_irq_handler SPI0_IRQHandler
+    def_irq_handler SPI1_IRQHandler
+    def_irq_handler DAC0_IRQHandler
+    def_irq_handler USART0_IRQHandler
+    def_irq_handler USART1_IRQHandler
+    def_irq_handler USART2_IRQHandler
+    def_irq_handler I2C1_IRQHandler
+    def_irq_handler I2C0_IRQHandler
+    def_irq_handler SCT_IRQHandler
+    def_irq_handler MRT_IRQHandler
+    def_irq_handler CMP_IRQHandler
+    def_irq_handler WDT_IRQHandler
+    def_irq_handler BOD_IRQHandler
+    def_irq_handler FLASH_IRQHandler
+    def_irq_handler WKT_IRQHandler
+    def_irq_handler ADC_SEQA_IRQHandler
+    def_irq_handler ADC_SEQB_IRQHandler
+    def_irq_handler ADC_THCMP_IRQHandler
+    def_irq_handler ADC_OVR_IRQHandler
+    def_irq_handler DMA_IRQHandler
+    def_irq_handler I2C2_IRQHandler
+    def_irq_handler I2C3_IRQHandler
+    def_irq_handler CTIMER0_IRQHandler
+    def_irq_handler PIN_INT0_IRQHandler
+    def_irq_handler PIN_INT1_IRQHandler
+    def_irq_handler PIN_INT2_IRQHandler
+    def_irq_handler PIN_INT3_IRQHandler
+    def_irq_handler PIN_INT4_IRQHandler
+    def_irq_handler PIN_INT5_IRQHandler
+    def_irq_handler PIN_INT6_IRQHandler
+    def_irq_handler PIN_INT7_IRQHandler

--- a/crates/fbuild-build/src/nxplpc/mcu_config.rs
+++ b/crates/fbuild-build/src/nxplpc/mcu_config.rs
@@ -1,8 +1,12 @@
 //! Data-driven NXP LPC8xx MCU configuration from embedded JSON.
 //!
-//! Both LPC804 and LPC845 are Cortex-M0+ targets, share the same compiler/linker
-//! flag set, and differ only in memory map (carried by the board JSON) and
-//! linker script (selected in the Stage-2 orchestrator).
+//! Both LPC804 and LPC845 are Cortex-M0+ targets and share the same compiler /
+//! linker flag set, so the heavy lifting comes from a single JSON blob
+//! (`nxplpc.json`). Per-chip differences — primarily preprocessor defines that
+//! drivers use to select chip-specific code paths — are layered on top of the
+//! shared base by `get_lpc804_config` / `get_lpc845_config`.
+//!
+//! Tracking: FastLED/FastLED#2845 (Stage 3 — per-chip mcu_config split).
 
 use std::collections::HashMap;
 
@@ -14,7 +18,8 @@ use crate::esp32::mcu_config::DefineEntry;
 
 const NXPLPC_JSON: &str = include_str!("configs/nxplpc.json");
 
-/// Complete NXP LPC8xx MCU configuration parsed from JSON.
+/// Complete NXP LPC8xx MCU configuration parsed from JSON, with per-chip
+/// defines folded into `defines` after JSON deserialization.
 #[derive(Debug, Clone, Deserialize)]
 pub struct NxpLpcMcuConfig {
     pub name: String,
@@ -63,17 +68,61 @@ impl McuConfig for NxpLpcMcuConfig {
     }
 }
 
-/// Load the shared NXP LPC8xx MCU configuration.
-///
-/// Stage 1 ships a single config for both LPC804 and LPC845. If Stage 2
-/// needs per-chip variation (e.g. PLU defines on LPC804), branch on `mcu`.
-pub fn get_nxplpc_config(_mcu: &str) -> Result<NxpLpcMcuConfig> {
+/// Parse the shared base config from embedded JSON.
+fn parse_base_config() -> Result<NxpLpcMcuConfig> {
     serde_json::from_str(NXPLPC_JSON).map_err(|e| {
         fbuild_core::FbuildError::ConfigError(format!(
             "failed to parse NXP LPC8xx MCU config: {}",
             e
         ))
     })
+}
+
+/// LPC804-specific configuration.
+///
+/// Layers LPC804-only defines on top of the shared base:
+///   - `__LPC804__=1`        — drivers branch on this to enable PLU paths
+///   - `CPU_LPC804M101JDH24=1` — NXP CMSIS-style device identifier
+pub fn get_lpc804_config() -> Result<NxpLpcMcuConfig> {
+    let mut config = parse_base_config()?;
+    config
+        .defines
+        .push(DefineEntry::Simple("__LPC804__".to_string()));
+    config
+        .defines
+        .push(DefineEntry::Simple("CPU_LPC804M101JDH24".to_string()));
+    Ok(config)
+}
+
+/// LPC845-specific configuration.
+///
+/// Layers LPC845-only defines on top of the shared base:
+///   - `__LPC845__=1`        — drivers branch on this to enable SCT+DMA paths
+///   - `CPU_LPC845M301JBD48=1` — NXP CMSIS-style device identifier
+pub fn get_lpc845_config() -> Result<NxpLpcMcuConfig> {
+    let mut config = parse_base_config()?;
+    config
+        .defines
+        .push(DefineEntry::Simple("__LPC845__".to_string()));
+    config
+        .defines
+        .push(DefineEntry::Simple("CPU_LPC845M301JBD48".to_string()));
+    Ok(config)
+}
+
+/// Dispatch by MCU name.
+///
+/// Returns LPC804- or LPC845-specific config (each with the shared base flags
+/// plus per-chip defines). Anything else is a config error.
+pub fn get_nxplpc_config(mcu: &str) -> Result<NxpLpcMcuConfig> {
+    match mcu {
+        "lpc804" => get_lpc804_config(),
+        "lpc845" => get_lpc845_config(),
+        other => Err(fbuild_core::FbuildError::ConfigError(format!(
+            "unknown NXP LPC8xx MCU '{}'; expected one of: lpc804, lpc845",
+            other
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -121,5 +170,65 @@ mod tests {
         let config = get_nxplpc_config("lpc804").unwrap();
         let defines = config.defines_map();
         assert!(defines.contains_key("__NXPLPC__"));
+    }
+
+    #[test]
+    fn lpc804_config_has_lpc804_defines() {
+        let config = get_nxplpc_config("lpc804").unwrap();
+        let defines = config.defines_map();
+        assert!(
+            defines.contains_key("__LPC804__"),
+            "lpc804 must define __LPC804__ for driver dispatch"
+        );
+        assert!(
+            defines.contains_key("CPU_LPC804M101JDH24"),
+            "lpc804 must define CMSIS-style CPU id"
+        );
+        assert!(
+            !defines.contains_key("__LPC845__"),
+            "lpc804 must not leak __LPC845__"
+        );
+    }
+
+    #[test]
+    fn lpc845_config_has_lpc845_defines() {
+        let config = get_nxplpc_config("lpc845").unwrap();
+        let defines = config.defines_map();
+        assert!(
+            defines.contains_key("__LPC845__"),
+            "lpc845 must define __LPC845__ for driver dispatch"
+        );
+        assert!(
+            defines.contains_key("CPU_LPC845M301JBD48"),
+            "lpc845 must define CMSIS-style CPU id"
+        );
+        assert!(
+            !defines.contains_key("__LPC804__"),
+            "lpc845 must not leak __LPC804__"
+        );
+    }
+
+    #[test]
+    fn unknown_mcu_returns_config_error() {
+        let err = get_nxplpc_config("lpc999").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("lpc999"),
+            "error message should name the offending mcu, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("lpc804") && msg.contains("lpc845"),
+            "error message should list valid options, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn both_chips_share_base_compiler_flags() {
+        let lpc804 = get_nxplpc_config("lpc804").unwrap();
+        let lpc845 = get_nxplpc_config("lpc845").unwrap();
+        assert_eq!(lpc804.compiler_flags.common, lpc845.compiler_flags.common);
+        assert_eq!(lpc804.linker_flags, lpc845.linker_flags);
     }
 }


### PR DESCRIPTION
## Summary

Stage 3 — port completion for the LPC8xx bare-metal target. Addresses the highest-value AI-doable items from [FastLED/FastLED#2845](https://github.com/FastLED/FastLED/issues/2845) (the Stage 3+4 meta roadmap):

1. **Real ``SystemInit`` for LPC845** — programs ``FMC->FLASHCFG = 1 wait state`` (covers up to 30 MHz per UM11029 §4.5), explicitly selects FRO-direct via ``MAINCLKSEL = 0`` with ``MAINCLKUEN`` latch, and sets ``SYSAHBCLKDIV = 1``. Exact FRO-to-30 MHz reconfiguration is left as a documented ``TODO(2845)`` because the FRO register layout requires device-on-hand validation per UM11029 §4 — see comment block in ``startup_lpc845.S``.
2. **Real ``SystemInit`` for LPC804** — explicitly leaves FRO at the 15 MHz IRC reset default (matches ``F_CPU=15000000UL`` in FastLED ``led_sysdefs_arm_lpc.h``), programs 0 flash wait states, sets ``SYSAHBCLKDIV = 1``. PLL deliberately not configured — see design note in ``startup_lpc804.S`` referencing FastLED/FastLED#2841 (Stage 2b PLU driver).
3. **Vector tables expanded** from the ARMv6-M 16-entry minimum to full peripheral IRQ tables per UM11029 / UM11065 table 5/4:
   - LPC845: 16 system + 32 peripheral slots (SPI0/1, USART0..2, I2C0..3, SCT, DMA, ADC, MRT, WKT, CTIMER0, PIN_INT0..7)
   - LPC804: 16 system + 28 peripheral slots (no SPI1, no CTIMER, only 4 pin-interrupts, but adds PLU IRQ — LPC804 distinguishing feature)
   All weak-aliased to ``Default_Handler``.
4. **``mcu_config.rs`` per-chip split** — ``get_lpc804_config`` / ``get_lpc845_config`` layer per-chip defines (``__LPC804__`` / ``__LPC845__`` and CMSIS-style ``CPU_LPC804M101JDH24`` / ``CPU_LPC845M301JBD48``) onto the shared base. ``get_nxplpc_config(mcu)`` dispatches; unknown MCU names return ``ConfigError``.

## Test plan

- [x] ``cargo test -p fbuild-build --lib nxplpc`` — 12/12 pass (5 new tests for the per-chip split: define presence, absence of cross-leakage, shared base flags, unknown-MCU error)
- [x] ``cargo check -p fbuild-build`` — clean
- [x] ``cargo fmt --check`` on ``mcu_config.rs`` — clean
- [ ] **Hardware**: LPCXpresso845 + scope to verify ``SystemInit`` clocks core at expected rate and confirm flash wait states are programmed correctly (deferred, requires maintainer with hardware)
- [ ] **Hardware**: end-to-end WS2812 blink via ``examples/Blink/Blink.ino`` on real LPC845 (deferred)

## Stage 3 items deferred (hardware-gated, not AI-doable)

- Linker memory-layout verification on real hardware
- ``AutoResearch.ino`` integration over USART0
- fbuild CI flip (``continue-on-error: true`` → required)
- ``validate_boards.py`` reconciliation
- Exact FRO-to-30 MHz programming on LPC845 (``TODO(2845)`` marker in place in ``startup_lpc845.S`` — needs UM11029 §4 verified against silicon)

## Stage 4 items not addressed (out of scope)

LPC11xx family port, LPC15xx port, APA102 SPI driver, multi-strip parallel output, PlatformIO upstream donation. Tracked in FastLED/FastLED#2845.

## Notes for reviewers

- Drafted draft because hardware validation remains. Pre-existing workspace clippy errors in ``fbuild-header-scan`` (unrelated, present on ``main``) — not blocking.
- All magic register addresses cite UM11029 / UM11065 sections in code comments. No fabricated constants — anything uncertain is marked ``TODO(2845)``.

Refs: FastLED/FastLED#2845, FastLED/FastLED#2836, FastLED/FastLED#2837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Significantly expanded support for NXP LPC804 and LPC845 microcontroller units, including enhanced system initialization routines with optimized flash memory configuration and system clock management.
  * Comprehensive peripheral interrupt handler implementation covering all supported device functions on both platforms.
  * Improved configuration system for easier MCU-specific setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->