### PR TITLE
feat(symbols): standalone `fbuild symbols <elf>` fine-grained bloat report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/crates/fbuild-build/src/lib.rs
+++ b/crates/fbuild-build/src/lib.rs
@@ -34,6 +34,7 @@ pub mod script_runtime;
 pub mod silabs;
 pub mod source_scanner;
 pub mod stm32;
+pub mod symbol_analyzer;
 pub mod teensy;
 pub mod zccache;
 

--- a/crates/fbuild-build/src/symbol_analyzer.rs
+++ b/crates/fbuild-build/src/symbol_analyzer.rs
@@ -1,0 +1,317 @@
+//! Driver around `fbuild_core::symbol_analysis` — invokes the cross
+//! toolchain (`nm`, `c++filt`) and the linker map alongside an ELF and
+//! emits a fully-attributed `FineGrainedSymbolMap`.
+//!
+//! Designed to work on **any** ELF, including binaries produced by an
+//! out-of-band builder (PlatformIO, esp-idf, manual). Drives the same
+//! analysis the `fbuild build --symbol-analysis` flag invokes
+//! post-link, but is also exposed via the standalone
+//! `fbuild symbols <elf>` subcommand.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use fbuild_core::symbol_analysis::{
+    build_fine_grained_map, parse_linker_map, parse_nm_output, FineGrainedSymbolMap,
+};
+use fbuild_core::{FbuildError, Result};
+
+/// Auto-detect the cross-toolchain prefix from the directory containing
+/// an `nm` binary. e.g. `xtensa-esp32s3-elf-nm` → prefix
+/// `xtensa-esp32s3-elf-`, so `xtensa-esp32s3-elf-c++filt` can be derived.
+pub fn derive_cppfilt_path(nm_path: &Path) -> PathBuf {
+    let parent = nm_path.parent().unwrap_or(Path::new("."));
+    let stem = nm_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let ext = nm_path
+        .extension()
+        .map(|e| e.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let cppfilt_stem = if let Some(prefix) = stem.strip_suffix("nm") {
+        format!("{prefix}c++filt")
+    } else {
+        "c++filt".to_string()
+    };
+    if ext.is_empty() {
+        parent.join(cppfilt_stem)
+    } else {
+        parent.join(format!("{cppfilt_stem}.{ext}"))
+    }
+}
+
+/// Find the map file that matches an ELF. PlatformIO writes
+/// `firmware.map` next to `firmware.elf`. fbuild's native linker writes
+/// `<elf-stem>.map` alongside the ELF.
+pub fn default_map_path(elf_path: &Path) -> Option<PathBuf> {
+    let candidate = elf_path.with_extension("map");
+    if candidate.exists() {
+        return Some(candidate);
+    }
+    let parent = elf_path.parent()?;
+    let firmware_map = parent.join("firmware.map");
+    if firmware_map.exists() {
+        return Some(firmware_map);
+    }
+    None
+}
+
+/// Demangle a list of mangled symbol names via `c++filt`.
+///
+/// Spawns a separate writer thread for stdin while the main thread
+/// drains stdout via `wait_with_output`. Without that split, the
+/// Windows pipe buffer (typically 4-8 KB) deadlocks once c++filt has
+/// produced enough output that it stops reading our stdin, but we are
+/// still trying to push the rest of the input in. Result stays
+/// parallel to the input — when c++filt can't decode a name it echoes
+/// it back unchanged, which is the desired fallback.
+pub fn demangle_batch(mangled: &[String], cppfilt_path: &Path) -> Result<Vec<String>> {
+    if mangled.is_empty() {
+        return Ok(Vec::new());
+    }
+    let stdin_data = mangled.join("\n");
+
+    let mut child = Command::new(cppfilt_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            FbuildError::BuildFailed(format!(
+                "failed to spawn c++filt at {}: {e}",
+                cppfilt_path.display()
+            ))
+        })?;
+
+    // Move stdin into a writer thread so stdout draining can happen
+    // concurrently in the main thread (avoids the pipe-buffer deadlock).
+    let stdin_handle = child.stdin.take().ok_or_else(|| {
+        FbuildError::BuildFailed("c++filt stdin pipe unavailable".to_string())
+    })?;
+    let writer = std::thread::spawn(move || -> std::io::Result<()> {
+        let mut stdin = stdin_handle;
+        stdin.write_all(stdin_data.as_bytes())?;
+        // Dropping stdin closes the pipe so c++filt sees EOF.
+        Ok(())
+    });
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| FbuildError::BuildFailed(format!("c++filt wait failed: {e}")))?;
+    // Join the writer; any I/O error here usually indicates c++filt
+    // closed its stdin early, which is OK as long as the exit was clean.
+    let _ = writer
+        .join()
+        .map_err(|_| FbuildError::BuildFailed("c++filt writer thread panicked".into()))?;
+    if !output.status.success() {
+        return Err(FbuildError::BuildFailed(format!(
+            "c++filt failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut demangled: Vec<String> = stdout.lines().map(|s| s.to_string()).collect();
+    // Pad with the mangled name in case c++filt dropped trailing blanks.
+    while demangled.len() < mangled.len() {
+        demangled.push(mangled[demangled.len()].clone());
+    }
+    demangled.truncate(mangled.len());
+    Ok(demangled)
+}
+
+/// Configuration for `analyze_elf`.
+pub struct AnalyzeConfig<'a> {
+    pub elf_path: &'a Path,
+    pub map_path: Option<&'a Path>,
+    pub nm_path: &'a Path,
+    pub cppfilt_path: Option<&'a Path>,
+}
+
+/// Run nm + c++filt + map-file parse and return the fully-attributed
+/// per-symbol map.
+pub fn analyze_elf(cfg: AnalyzeConfig<'_>) -> Result<FineGrainedSymbolMap> {
+    use fbuild_core::subprocess::run_command;
+
+    let nm_path_s = cfg.nm_path.to_string_lossy().to_string();
+    let elf_s = cfg.elf_path.to_string_lossy().to_string();
+    let args = [
+        nm_path_s.as_str(),
+        "--print-size",
+        "--size-sort",
+        "--reverse-sort",
+        "-S",
+        elf_s.as_str(),
+    ];
+    let result = run_command(&args, None, None, None)?;
+    if !result.success() {
+        return Err(FbuildError::BuildFailed(format!(
+            "nm failed: {}",
+            result.stderr
+        )));
+    }
+
+    let nm_rows = parse_nm_output(&result.stdout);
+    let mangled: Vec<String> = nm_rows.iter().map(|r| r.3.clone()).collect();
+
+    let demangled = if let Some(cppfilt) = cfg.cppfilt_path {
+        demangle_batch(&mangled, cppfilt).unwrap_or_else(|e| {
+            tracing::warn!("c++filt unavailable ({e}); falling back to mangled names");
+            mangled.clone()
+        })
+    } else {
+        mangled.clone()
+    };
+
+    let ranges = if let Some(map_path) = cfg.map_path {
+        match std::fs::read_to_string(map_path) {
+            Ok(text) => parse_linker_map(&text),
+            Err(e) => {
+                tracing::warn!(
+                    "could not read map file {}: {e}; archive attribution will be unavailable",
+                    map_path.display()
+                );
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
+    Ok(build_fine_grained_map(
+        elf_s,
+        cfg.map_path.map(|p| p.to_string_lossy().to_string()),
+        nm_rows,
+        demangled,
+        ranges,
+    ))
+}
+
+/// Format a fine-grained per-symbol map as a human-readable text report
+/// suitable for streaming to a terminal or stashing in a log artifact.
+/// Shows the top `top_n` Flash symbols and top `top_n` Ram symbols with
+/// archive + object + section attribution and demangled names.
+pub fn format_text_report(map: &FineGrainedSymbolMap, top_n: usize) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!("=== Fine-grained symbol analysis: {} ===", map.elf_path));
+    if let Some(ref m) = map.map_path {
+        lines.push(format!("Map file: {m}"));
+    }
+    lines.push(format!(
+        "Flash: {} B across {} sized symbols",
+        map.total_flash,
+        map.symbols
+            .iter()
+            .filter(|s| s.region == fbuild_core::MemoryRegion::Flash)
+            .count()
+    ));
+    lines.push(format!(
+        "RAM:   {} B across {} sized symbols",
+        map.total_ram,
+        map.symbols
+            .iter()
+            .filter(|s| s.region == fbuild_core::MemoryRegion::Ram)
+            .count()
+    ));
+    lines.push(String::new());
+
+    fn emit_region_block(
+        lines: &mut Vec<String>,
+        map: &FineGrainedSymbolMap,
+        region: fbuild_core::MemoryRegion,
+        top_n: usize,
+        title: &str,
+    ) {
+        let mut syms: Vec<_> = map.symbols.iter().filter(|s| s.region == region).collect();
+        syms.sort_by(|a, b| b.size.cmp(&a.size));
+        lines.push(format!("--- Top {} {title} symbols ---", top_n.min(syms.len())));
+        lines.push(format!(
+            "{:>8}  {:<24}  {:<28}  {:<14}  symbol",
+            "BYTES", "ARCHIVE", "OBJECT", "SECTION"
+        ));
+        for s in syms.into_iter().take(top_n) {
+            let archive = s.archive.as_deref().unwrap_or("-");
+            let object = s.object.as_deref().unwrap_or("-");
+            let sect = s.output_section.as_deref().unwrap_or("-");
+            // Truncate long demangled names so the table stays scannable.
+            let mut name = s.demangled.clone();
+            if name.len() > 100 {
+                name.truncate(97);
+                name.push_str("...");
+            }
+            lines.push(format!(
+                "{:>8}  {:<24}  {:<28}  {:<14}  {}",
+                s.size,
+                truncate(archive, 24),
+                truncate(object, 28),
+                truncate(sect, 14),
+                name
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    emit_region_block(
+        &mut lines,
+        map,
+        fbuild_core::MemoryRegion::Flash,
+        top_n,
+        "FLASH",
+    );
+    emit_region_block(&mut lines, map, fbuild_core::MemoryRegion::Ram, top_n, "RAM");
+
+    // Per-archive roll-ups (flash only — biggest leverage for bloat).
+    let mut by_archive: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+    for s in &map.symbols {
+        if s.region != fbuild_core::MemoryRegion::Flash {
+            continue;
+        }
+        let key = s.archive.clone().unwrap_or_else(|| "(unattributed)".into());
+        *by_archive.entry(key).or_insert(0) += s.size;
+    }
+    let mut rows: Vec<(String, u64)> = by_archive.into_iter().collect();
+    rows.sort_by(|a, b| b.1.cmp(&a.1));
+    lines.push("--- Flash bytes by archive ---".to_string());
+    lines.push(format!("{:>10}  ARCHIVE", "BYTES"));
+    for (archive, bytes) in rows.into_iter().take(top_n) {
+        lines.push(format!("{:>10}  {archive}", bytes));
+    }
+
+    lines.join("\n")
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else if max <= 3 {
+        ".".repeat(max)
+    } else {
+        let mut t = s[..max - 3].to_string();
+        t.push_str("...");
+        t
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_cppfilt_prefix() {
+        let nm = PathBuf::from("/tools/xtensa-esp32s3-elf-nm.exe");
+        let cppfilt = derive_cppfilt_path(&nm);
+        assert!(
+            cppfilt.to_string_lossy().ends_with("xtensa-esp32s3-elf-c++filt.exe"),
+            "got {}",
+            cppfilt.display()
+        );
+    }
+
+    #[test]
+    fn derive_cppfilt_no_prefix() {
+        let nm = PathBuf::from("/usr/bin/nm");
+        let cppfilt = derive_cppfilt_path(&nm);
+        assert_eq!(cppfilt, PathBuf::from("/usr/bin/c++filt"));
+    }
+}

--- a/crates/fbuild-build/src/symbol_analyzer.rs
+++ b/crates/fbuild-build/src/symbol_analyzer.rs
@@ -8,10 +8,9 @@
 //! post-link, but is also exposed via the standalone
 //! `fbuild symbols <elf>` subcommand.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 
+use fbuild_core::subprocess::run_command_with_stdin;
 use fbuild_core::symbol_analysis::{
     build_fine_grained_map, parse_linker_map, parse_nm_output, FineGrainedSymbolMap,
 };
@@ -60,66 +59,36 @@ pub fn default_map_path(elf_path: &Path) -> Option<PathBuf> {
 
 /// Demangle a list of mangled symbol names via `c++filt`.
 ///
-/// Spawns a separate writer thread for stdin while the main thread
-/// drains stdout via `wait_with_output`. Without that split, the
-/// Windows pipe buffer (typically 4-8 KB) deadlocks once c++filt has
-/// produced enough output that it stops reading our stdin, but we are
-/// still trying to push the rest of the input in. Result stays
-/// parallel to the input — when c++filt can't decode a name it echoes
-/// it back unchanged, which is the desired fallback.
+/// Routes through `fbuild_core::subprocess::run_command_with_stdin`,
+/// which uses `running_process::NativeProcess` under the hood. The
+/// reader thread spawned by `NativeProcess::start()` drains stdout in
+/// background while we feed stdin, avoiding the Windows pipe-buffer
+/// deadlock that hits when ~3k mangled symbols saturate the 4-8 KB
+/// stdout pipe before we finish writing stdin.
+///
+/// When c++filt can't decode a name it echoes it back unchanged, which
+/// is the desired fallback. Output stays parallel to the input.
 pub fn demangle_batch(mangled: &[String], cppfilt_path: &Path) -> Result<Vec<String>> {
     if mangled.is_empty() {
         return Ok(Vec::new());
     }
     let stdin_data = mangled.join("\n");
-
-    // allow-direct-spawn: c++filt demangler. The captured `run_command`
-    // helper is stdin-Null; we need to pipe the mangled-symbol list
-    // through c++filt's stdin and concurrently drain stdout via
-    // wait_with_output to avoid the Windows pipe-buffer deadlock when
-    // the symbol pool is large (~3k symbols on a stock ESP32-S3 Blink
-    // ELF). Read-only analysis path; no containment side effects.
-    let mut child = Command::new(cppfilt_path)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| {
+    let cppfilt_s = cppfilt_path.to_string_lossy().to_string();
+    let args = [cppfilt_s.as_str()];
+    let result =
+        run_command_with_stdin(&args, stdin_data.as_bytes(), None, None, None).map_err(|e| {
             FbuildError::BuildFailed(format!(
-                "failed to spawn c++filt at {}: {e}",
+                "failed to run c++filt at {}: {e}",
                 cppfilt_path.display()
             ))
         })?;
-
-    // Move stdin into a writer thread so stdout draining can happen
-    // concurrently in the main thread (avoids the pipe-buffer deadlock).
-    let stdin_handle = child
-        .stdin
-        .take()
-        .ok_or_else(|| FbuildError::BuildFailed("c++filt stdin pipe unavailable".to_string()))?;
-    let writer = std::thread::spawn(move || -> std::io::Result<()> {
-        let mut stdin = stdin_handle;
-        stdin.write_all(stdin_data.as_bytes())?;
-        // Dropping stdin closes the pipe so c++filt sees EOF.
-        Ok(())
-    });
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| FbuildError::BuildFailed(format!("c++filt wait failed: {e}")))?;
-    // Join the writer; any I/O error here usually indicates c++filt
-    // closed its stdin early, which is OK as long as the exit was clean.
-    let _ = writer
-        .join()
-        .map_err(|_| FbuildError::BuildFailed("c++filt writer thread panicked".into()))?;
-    if !output.status.success() {
+    if !result.success() {
         return Err(FbuildError::BuildFailed(format!(
-            "c++filt failed: {}",
-            String::from_utf8_lossy(&output.stderr)
+            "c++filt failed (exit={}): {}",
+            result.exit_code, result.stderr
         )));
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut demangled: Vec<String> = stdout.lines().map(|s| s.to_string()).collect();
+    let mut demangled: Vec<String> = result.stdout.lines().map(|s| s.to_string()).collect();
     // Pad with the mangled name in case c++filt dropped trailing blanks.
     while demangled.len() < mangled.len() {
         demangled.push(mangled[demangled.len()].clone());
@@ -300,6 +269,204 @@ pub fn format_text_report(map: &FineGrainedSymbolMap, top_n: usize) -> String {
     lines.join("\n")
 }
 
+/// Format the same fine-grained map as Markdown — same content as
+/// `format_text_report` but with real table syntax + headers so it
+/// renders nicely in GitHub / VS Code / any MD viewer. Designed to
+/// be saved as `report.md` alongside `report.json` so humans and
+/// scripts can consume the same analysis without diverging.
+pub fn format_markdown_report(map: &FineGrainedSymbolMap, top_n: usize) -> String {
+    let mut out = String::new();
+    use std::fmt::Write as _;
+    let flash_count = map
+        .symbols
+        .iter()
+        .filter(|s| s.region == fbuild_core::MemoryRegion::Flash)
+        .count();
+    let ram_count = map
+        .symbols
+        .iter()
+        .filter(|s| s.region == fbuild_core::MemoryRegion::Ram)
+        .count();
+    let _ = writeln!(out, "# Symbol analysis: `{}`", map.elf_path);
+    let _ = writeln!(out);
+    if let Some(ref m) = map.map_path {
+        let _ = writeln!(out, "- **Map file**: `{m}`");
+    }
+    let _ = writeln!(
+        out,
+        "- **Flash**: {} B across {} sized symbols",
+        map.total_flash, flash_count
+    );
+    let _ = writeln!(
+        out,
+        "- **RAM**: {} B across {} sized symbols",
+        map.total_ram, ram_count
+    );
+    let _ = writeln!(out);
+
+    fn emit_md_table(
+        out: &mut String,
+        map: &FineGrainedSymbolMap,
+        region: fbuild_core::MemoryRegion,
+        top_n: usize,
+        title: &str,
+    ) {
+        use std::fmt::Write as _;
+        let mut syms: Vec<_> = map.symbols.iter().filter(|s| s.region == region).collect();
+        syms.sort_by(|a, b| b.size.cmp(&a.size));
+        let _ = writeln!(
+            out,
+            "## Top {} {} symbols",
+            top_n.min(syms.len()),
+            title.to_lowercase()
+        );
+        let _ = writeln!(out);
+        let _ = writeln!(out, "| Bytes | Archive | Object | Section | Symbol |");
+        let _ = writeln!(out, "|---:|---|---|---|---|");
+        for s in syms.into_iter().take(top_n) {
+            let archive = s.archive.as_deref().unwrap_or("(none)");
+            let object = s.object.as_deref().unwrap_or("-");
+            let sect = s.output_section.as_deref().unwrap_or("-");
+            // Pipe-escape the demangled name so it doesn't break MD
+            // table parsing (rare but possible with operator overloads).
+            let name = s.demangled.replace('|', "\\|");
+            let _ = writeln!(
+                out,
+                "| {} | {} | {} | {} | `{}` |",
+                s.size, archive, object, sect, name
+            );
+        }
+        let _ = writeln!(out);
+    }
+
+    emit_md_table(
+        &mut out,
+        map,
+        fbuild_core::MemoryRegion::Flash,
+        top_n,
+        "FLASH",
+    );
+    emit_md_table(&mut out, map, fbuild_core::MemoryRegion::Ram, top_n, "RAM");
+
+    // Per-archive flash roll-up.
+    let mut by_archive: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+    for s in &map.symbols {
+        if s.region != fbuild_core::MemoryRegion::Flash {
+            continue;
+        }
+        let key = s.archive.clone().unwrap_or_else(|| "(unattributed)".into());
+        *by_archive.entry(key).or_insert(0) += s.size;
+    }
+    let mut rows: Vec<(String, u64)> = by_archive.into_iter().collect();
+    rows.sort_by(|a, b| b.1.cmp(&a.1));
+    let _ = writeln!(out, "## Flash bytes by archive");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "| Bytes | Archive |");
+    let _ = writeln!(out, "|---:|---|");
+    for (archive, bytes) in rows.into_iter().take(top_n) {
+        let _ = writeln!(out, "| {bytes} | {archive} |");
+    }
+
+    out
+}
+
+/// Best-effort discovery of a `firmware.elf` (or any `.elf`) under
+/// the given project directory. Looks in conventional locations in
+/// priority order:
+///   1. `<dir>/build_info.json` or `build_info_<env>.json` and read
+///      `prog_path` (PIO / fbuild emitter convention).
+///   2. `<dir>/.fbuild/build/**/firmware.elf` (fbuild native output).
+///   3. `<dir>/.pio/build/**/firmware.elf` (PlatformIO output).
+///   4. Any `*.elf` directly inside `<dir>`.
+/// Returns the most recently-modified candidate when multiple match.
+pub fn discover_elf_in_project(project_dir: &Path) -> Option<PathBuf> {
+    // 1. build_info.json
+    let mut build_info_candidates: Vec<PathBuf> = vec![project_dir.join("build_info.json")];
+    if let Ok(entries) = std::fs::read_dir(project_dir) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if let Some(name) = p.file_name().and_then(|s| s.to_str()) {
+                if name.starts_with("build_info_") && name.ends_with(".json") {
+                    build_info_candidates.push(p);
+                }
+            }
+        }
+    }
+    for bi in build_info_candidates {
+        if let Some(elf) = elf_from_build_info(&bi) {
+            if elf.exists() {
+                return Some(elf);
+            }
+        }
+    }
+    // 2. .fbuild and 3. .pio output trees
+    for relative in [".fbuild/build", ".pio/build"] {
+        let root = project_dir.join(relative);
+        if root.exists() {
+            if let Some(elf) = newest_elf_under(&root) {
+                return Some(elf);
+            }
+        }
+    }
+    // 4. directly under project_dir
+    newest_elf_under(project_dir)
+}
+
+/// Pull `prog_path` out of a PlatformIO-style build_info.json. The
+/// outer object is keyed by env name; we accept the first env that
+/// has a usable prog_path. Robust to fbuild's flat shape too — if
+/// the top-level itself has `prog_path`, return that.
+fn elf_from_build_info(path: &Path) -> Option<PathBuf> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&text).ok()?;
+    if let Some(s) = v.get("prog_path").and_then(|x| x.as_str()) {
+        return Some(PathBuf::from(s));
+    }
+    if let Some(obj) = v.as_object() {
+        for (_, inner) in obj.iter() {
+            if let Some(s) = inner.get("prog_path").and_then(|x| x.as_str()) {
+                return Some(PathBuf::from(s));
+            }
+        }
+    }
+    None
+}
+
+fn newest_elf_under(root: &Path) -> Option<PathBuf> {
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    walk_for_elf(root, &mut newest, 0);
+    newest.map(|(_, p)| p)
+}
+
+fn walk_for_elf(dir: &Path, newest: &mut Option<(std::time::SystemTime, PathBuf)>, depth: usize) {
+    // Don't recurse forever — 6 levels is enough for both
+    // PIO (.pio/build/<env>/firmware.elf) and fbuild
+    // (.fbuild/build/<env>/firmware.elf) layouts.
+    if depth > 6 {
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_dir() {
+            walk_for_elf(&p, newest, depth + 1);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("elf") {
+            if let Ok(meta) = entry.metadata() {
+                if let Ok(mtime) = meta.modified() {
+                    match newest {
+                        Some((cur, _)) if *cur >= mtime => {}
+                        _ => *newest = Some((mtime, p)),
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
@@ -334,5 +501,149 @@ mod tests {
         let nm = PathBuf::from("/usr/bin/nm");
         let cppfilt = derive_cppfilt_path(&nm);
         assert_eq!(cppfilt, PathBuf::from("/usr/bin/c++filt"));
+    }
+
+    // ---- build_info / project discovery ----
+
+    #[test]
+    fn elf_from_build_info_pio_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bi = tmp.path().join("build_info.json");
+        std::fs::write(
+            &bi,
+            r#"{ "esp32s3": { "prog_path": "C:/path/firmware.elf" } }"#,
+        )
+        .unwrap();
+        let elf = elf_from_build_info(&bi).unwrap();
+        assert_eq!(elf, PathBuf::from("C:/path/firmware.elf"));
+    }
+
+    #[test]
+    fn elf_from_build_info_flat_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bi = tmp.path().join("build_info.json");
+        std::fs::write(&bi, r#"{ "prog_path": "/x/y/firmware.elf" }"#).unwrap();
+        let elf = elf_from_build_info(&bi).unwrap();
+        assert_eq!(elf, PathBuf::from("/x/y/firmware.elf"));
+    }
+
+    #[test]
+    fn elf_from_build_info_missing_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bi = tmp.path().join("build_info.json");
+        std::fs::write(&bi, r#"{ "esp32s3": { "cc_path": "/x" } }"#).unwrap();
+        assert!(elf_from_build_info(&bi).is_none());
+    }
+
+    #[test]
+    fn discover_elf_picks_build_info_first() {
+        let tmp = tempfile::tempdir().unwrap();
+        let elf_path = tmp.path().join("real_target").join("firmware.elf");
+        std::fs::create_dir_all(elf_path.parent().unwrap()).unwrap();
+        std::fs::write(&elf_path, b"").unwrap();
+        let bi = tmp.path().join("build_info.json");
+        std::fs::write(
+            &bi,
+            format!(
+                r#"{{ "x": {{ "prog_path": "{}" }} }}"#,
+                elf_path.to_string_lossy().replace('\\', "/")
+            ),
+        )
+        .unwrap();
+        // Also create a competing .elf elsewhere; build_info should win.
+        let competing = tmp.path().join("decoy.elf");
+        std::fs::write(&competing, b"").unwrap();
+        let found = discover_elf_in_project(tmp.path()).unwrap();
+        assert_eq!(found.canonicalize().ok(), elf_path.canonicalize().ok());
+    }
+
+    #[test]
+    fn discover_elf_falls_back_to_loose_elf() {
+        let tmp = tempfile::tempdir().unwrap();
+        let elf_path = tmp.path().join("firmware.elf");
+        std::fs::write(&elf_path, b"").unwrap();
+        let found = discover_elf_in_project(tmp.path()).unwrap();
+        assert_eq!(found.canonicalize().ok(), elf_path.canonicalize().ok());
+    }
+
+    #[test]
+    fn discover_elf_returns_none_when_nothing_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(discover_elf_in_project(tmp.path()).is_none());
+    }
+
+    // ---- markdown formatter ----
+
+    #[test]
+    fn format_markdown_report_emits_tables() {
+        use fbuild_core::symbol_analysis::{FineGrainedSymbol, FineGrainedSymbolMap, SectionBytes};
+        let map = FineGrainedSymbolMap {
+            elf_path: "fw.elf".into(),
+            map_path: Some("fw.map".into()),
+            total_flash: 100,
+            total_ram: 50,
+            symbols: vec![
+                FineGrainedSymbol {
+                    mangled: "_Z3fooi".into(),
+                    demangled: "foo(int)".into(),
+                    address: 0x1000,
+                    size: 100,
+                    sym_type: 'T',
+                    region: fbuild_core::MemoryRegion::Flash,
+                    archive: Some("libA.a".into()),
+                    object: Some("foo.o".into()),
+                    output_section: Some(".flash.text".into()),
+                },
+                FineGrainedSymbol {
+                    mangled: "_Z3barv".into(),
+                    demangled: "bar()".into(),
+                    address: 0x2000,
+                    size: 50,
+                    sym_type: 'B',
+                    region: fbuild_core::MemoryRegion::Ram,
+                    archive: Some("libB.a".into()),
+                    object: Some("bar.o".into()),
+                    output_section: Some(".dram0.bss".into()),
+                },
+            ],
+            sections: Vec::<SectionBytes>::new(),
+        };
+        let md = format_markdown_report(&map, 5);
+        assert!(md.contains("# Symbol analysis: `fw.elf`"));
+        assert!(md.contains("**Map file**: `fw.map`"));
+        assert!(md.contains("**Flash**: 100 B"));
+        assert!(md.contains("**RAM**: 50 B"));
+        assert!(md.contains("## Top 1 flash symbols"));
+        assert!(md.contains("| 100 | libA.a | foo.o | .flash.text | `foo(int)` |"));
+        assert!(md.contains("## Top 1 ram symbols"));
+        assert!(md.contains("| 50 | libB.a | bar.o | .dram0.bss | `bar()` |"));
+        assert!(md.contains("## Flash bytes by archive"));
+        assert!(md.contains("| 100 | libA.a |"));
+    }
+
+    #[test]
+    fn format_markdown_report_escapes_pipes_in_symbol_names() {
+        use fbuild_core::symbol_analysis::{FineGrainedSymbol, FineGrainedSymbolMap, SectionBytes};
+        // operator|| is a real C++ name shape that demangles with pipes.
+        let map = FineGrainedSymbolMap {
+            elf_path: "fw.elf".into(),
+            map_path: None,
+            total_flash: 10,
+            total_ram: 0,
+            symbols: vec![FineGrainedSymbol {
+                mangled: "_ZorRKiS_".into(),
+                demangled: "operator|(int const&, int const&)".into(),
+                address: 0x1000,
+                size: 10,
+                sym_type: 'T',
+                region: fbuild_core::MemoryRegion::Flash,
+                archive: None,
+                object: None,
+                output_section: None,
+            }],
+            sections: Vec::<SectionBytes>::new(),
+        };
+        let md = format_markdown_report(&map, 5);
+        assert!(md.contains("operator\\|(int const&, int const&)"));
     }
 }

--- a/crates/fbuild-build/src/symbol_analyzer.rs
+++ b/crates/fbuild-build/src/symbol_analyzer.rs
@@ -87,9 +87,10 @@ pub fn demangle_batch(mangled: &[String], cppfilt_path: &Path) -> Result<Vec<Str
 
     // Move stdin into a writer thread so stdout draining can happen
     // concurrently in the main thread (avoids the pipe-buffer deadlock).
-    let stdin_handle = child.stdin.take().ok_or_else(|| {
-        FbuildError::BuildFailed("c++filt stdin pipe unavailable".to_string())
-    })?;
+    let stdin_handle = child
+        .stdin
+        .take()
+        .ok_or_else(|| FbuildError::BuildFailed("c++filt stdin pipe unavailable".to_string()))?;
     let writer = std::thread::spawn(move || -> std::io::Result<()> {
         let mut stdin = stdin_handle;
         stdin.write_all(stdin_data.as_bytes())?;
@@ -194,7 +195,10 @@ pub fn analyze_elf(cfg: AnalyzeConfig<'_>) -> Result<FineGrainedSymbolMap> {
 /// archive + object + section attribution and demangled names.
 pub fn format_text_report(map: &FineGrainedSymbolMap, top_n: usize) -> String {
     let mut lines = Vec::new();
-    lines.push(format!("=== Fine-grained symbol analysis: {} ===", map.elf_path));
+    lines.push(format!(
+        "=== Fine-grained symbol analysis: {} ===",
+        map.elf_path
+    ));
     if let Some(ref m) = map.map_path {
         lines.push(format!("Map file: {m}"));
     }
@@ -225,7 +229,10 @@ pub fn format_text_report(map: &FineGrainedSymbolMap, top_n: usize) -> String {
     ) {
         let mut syms: Vec<_> = map.symbols.iter().filter(|s| s.region == region).collect();
         syms.sort_by(|a, b| b.size.cmp(&a.size));
-        lines.push(format!("--- Top {} {title} symbols ---", top_n.min(syms.len())));
+        lines.push(format!(
+            "--- Top {} {title} symbols ---",
+            top_n.min(syms.len())
+        ));
         lines.push(format!(
             "{:>8}  {:<24}  {:<28}  {:<14}  symbol",
             "BYTES", "ARCHIVE", "OBJECT", "SECTION"
@@ -259,7 +266,13 @@ pub fn format_text_report(map: &FineGrainedSymbolMap, top_n: usize) -> String {
         top_n,
         "FLASH",
     );
-    emit_region_block(&mut lines, map, fbuild_core::MemoryRegion::Ram, top_n, "RAM");
+    emit_region_block(
+        &mut lines,
+        map,
+        fbuild_core::MemoryRegion::Ram,
+        top_n,
+        "RAM",
+    );
 
     // Per-archive roll-ups (flash only — biggest leverage for bloat).
     let mut by_archive: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
@@ -302,7 +315,9 @@ mod tests {
         let nm = PathBuf::from("/tools/xtensa-esp32s3-elf-nm.exe");
         let cppfilt = derive_cppfilt_path(&nm);
         assert!(
-            cppfilt.to_string_lossy().ends_with("xtensa-esp32s3-elf-c++filt.exe"),
+            cppfilt
+                .to_string_lossy()
+                .ends_with("xtensa-esp32s3-elf-c++filt.exe"),
             "got {}",
             cppfilt.display()
         );

--- a/crates/fbuild-build/src/symbol_analyzer.rs
+++ b/crates/fbuild-build/src/symbol_analyzer.rs
@@ -73,6 +73,12 @@ pub fn demangle_batch(mangled: &[String], cppfilt_path: &Path) -> Result<Vec<Str
     }
     let stdin_data = mangled.join("\n");
 
+    // allow-direct-spawn: c++filt demangler. The captured `run_command`
+    // helper is stdin-Null; we need to pipe the mangled-symbol list
+    // through c++filt's stdin and concurrently drain stdout via
+    // wait_with_output to avoid the Windows pipe-buffer deadlock when
+    // the symbol pool is large (~3k symbols on a stock ESP32-S3 Blink
+    // ELF). Read-only analysis path; no containment side effects.
     let mut child = Command::new(cppfilt_path)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -64,6 +64,35 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Fine-grained per-symbol bloat analysis of an existing ELF.
+    ///
+    /// Runs `nm --print-size --size-sort -S` on the ELF, demangles via
+    /// `c++filt`, parses the alongside linker map (auto-detected as
+    /// `<elf-stem>.map` or `firmware.map`), and emits a table that
+    /// attributes each live symbol to its source archive + object +
+    /// output section. Useful for diffing two builds at the symbol
+    /// level. JSON output is suitable for scripted comparison.
+    Symbols {
+        /// Path to the ELF to analyze.
+        elf: String,
+        /// Path to the linker map (auto-detected if omitted).
+        #[arg(long)]
+        map: Option<String>,
+        /// Path to `nm` (auto-detected from PATH if omitted; pass the
+        /// cross-tool, e.g. `xtensa-esp32s3-elf-nm`).
+        #[arg(long)]
+        nm: Option<String>,
+        /// Path to `c++filt` (auto-derived from `nm` path if omitted).
+        #[arg(long = "cppfilt")]
+        cppfilt: Option<String>,
+        /// Write structured report to PATH as JSON instead of the text
+        /// table.
+        #[arg(long)]
+        json: Option<String>,
+        /// Number of top symbols / archives to show in the text report.
+        #[arg(long, default_value = "25")]
+        top: usize,
+    },
     /// Build firmware
     Build {
         project_dir: Option<String>,

--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -64,17 +64,29 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Fine-grained per-symbol bloat analysis of an existing ELF.
+    /// Fine-grained per-symbol bloat analysis of an ELF or project.
+    ///
+    /// `<input>` may be either an ELF file or a project directory; when
+    /// a directory is given, `fbuild symbols` walks `build_info.json`
+    /// first then `.fbuild/build/**/firmware.elf`, `.pio/build/**/firmware.elf`
+    /// and finally any `*.elf` directly inside the directory.
     ///
     /// Runs `nm --print-size --size-sort -S` on the ELF, demangles via
     /// `c++filt`, parses the alongside linker map (auto-detected as
     /// `<elf-stem>.map` or `firmware.map`), and emits a table that
     /// attributes each live symbol to its source archive + object +
-    /// output section. Useful for diffing two builds at the symbol
-    /// level. JSON output is suitable for scripted comparison.
+    /// output section. Map-derived rows for anonymous rodata pools
+    /// (`.rodata.<owner>.str1.<N>` etc.) are tagged
+    /// `source: "map-derived"`.
+    ///
+    /// Outputs:
+    ///   * default: text report to stdout
+    ///   * `--json <path>`: structured JSON only
+    ///   * `--output-dir <dir>`: BOTH `report.json` (machine) and
+    ///     `report.md` (human, GitHub-friendly tables) side by side
     Symbols {
-        /// Path to the ELF to analyze.
-        elf: String,
+        /// ELF file OR project directory.
+        input: String,
         /// Path to the linker map (auto-detected if omitted).
         #[arg(long)]
         map: Option<String>,
@@ -86,10 +98,15 @@ pub enum Commands {
         #[arg(long = "cppfilt")]
         cppfilt: Option<String>,
         /// Write structured report to PATH as JSON instead of the text
-        /// table.
+        /// table. Mutually compatible with `--output-dir`.
         #[arg(long)]
         json: Option<String>,
-        /// Number of top symbols / archives to show in the text report.
+        /// Write BOTH `report.json` and `report.md` side by side in
+        /// this directory. Created if missing.
+        #[arg(long = "output-dir")]
+        output_dir: Option<String>,
+        /// Number of top symbols / archives to show in the text /
+        /// markdown report.
         #[arg(long, default_value = "25")]
         top: usize,
     },

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -57,13 +57,14 @@ pub async fn async_main() {
 
     let result = match cli.command {
         Some(Commands::Symbols {
-            elf,
+            input,
             map,
             nm,
             cppfilt,
             json,
+            output_dir,
             top,
-        }) => run_symbols(elf, map, nm, cppfilt, json, top),
+        }) => run_symbols(input, map, nm, cppfilt, json, output_dir, top),
         Some(Commands::Build {
             project_dir,
             environment,

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -20,6 +20,7 @@ use super::pio::{pio_build, pio_deploy, pio_monitor};
 use super::purge::{run_purge, run_purge_gc};
 use super::reset::run_reset;
 use super::show::run_show;
+use super::symbols_cmd::run_symbols;
 
 pub async fn async_main() {
     let cli = Cli::parse_from(rewrite_args());
@@ -55,6 +56,14 @@ pub async fn async_main() {
     let top_level_project_dir = cli.project_dir.clone();
 
     let result = match cli.command {
+        Some(Commands::Symbols {
+            elf,
+            map,
+            nm,
+            cppfilt,
+            json,
+            top,
+        }) => run_symbols(elf, map, nm, cppfilt, json, top),
         Some(Commands::Build {
             project_dir,
             environment,

--- a/crates/fbuild-cli/src/cli/mod.rs
+++ b/crates/fbuild-cli/src/cli/mod.rs
@@ -23,6 +23,7 @@ pub mod pio;
 pub mod purge;
 pub mod reset;
 pub mod show;
+pub mod symbols_cmd;
 
 #[cfg(test)]
 mod tests;

--- a/crates/fbuild-cli/src/cli/symbols_cmd.rs
+++ b/crates/fbuild-cli/src/cli/symbols_cmd.rs
@@ -47,7 +47,9 @@ pub fn run_symbols(
         }
     });
 
-    let map_path_owned = map.map(PathBuf::from).or_else(|| default_map_path(&elf_path));
+    let map_path_owned = map
+        .map(PathBuf::from)
+        .or_else(|| default_map_path(&elf_path));
     let map_path_ref: Option<&Path> = map_path_owned.as_deref();
 
     let cfg = AnalyzeConfig {
@@ -85,8 +87,7 @@ pub fn run_symbols(
 /// Locate `nm` on PATH. The user can always override with `--nm`.
 fn find_nm_on_path() -> Result<PathBuf> {
     let exe_name = if cfg!(windows) { "nm.exe" } else { "nm" };
-    let path = std::env::var_os("PATH")
-        .ok_or_else(|| FbuildError::Other("PATH not set".into()))?;
+    let path = std::env::var_os("PATH").ok_or_else(|| FbuildError::Other("PATH not set".into()))?;
     for dir in std::env::split_paths(&path) {
         let candidate = dir.join(exe_name);
         if candidate.exists() {

--- a/crates/fbuild-cli/src/cli/symbols_cmd.rs
+++ b/crates/fbuild-cli/src/cli/symbols_cmd.rs
@@ -1,31 +1,36 @@
 //! `fbuild symbols` — standalone fine-grained per-symbol bloat report.
 //!
-//! Runs the same analysis the build orchestrator's `--symbol-analysis`
-//! flag emits, but on any ELF the user points at — including one built
-//! by PlatformIO or another out-of-band tool.
+//! Accepts either an ELF or a project directory; runs the same
+//! analysis the build orchestrator's `--symbol-analysis` flag emits,
+//! but on any ELF the user points at — including one built by
+//! PlatformIO or another out-of-band tool.
 
 use std::path::{Path, PathBuf};
 
 use fbuild_build::symbol_analyzer::{
-    analyze_elf, default_map_path, derive_cppfilt_path, format_text_report, AnalyzeConfig,
+    analyze_elf, default_map_path, derive_cppfilt_path, discover_elf_in_project,
+    format_markdown_report, format_text_report, AnalyzeConfig,
 };
 use fbuild_core::{FbuildError, Result};
 
 pub fn run_symbols(
-    elf: String,
+    input: String,
     map: Option<String>,
     nm: Option<String>,
     cppfilt: Option<String>,
     json_out: Option<String>,
+    output_dir: Option<String>,
     top: usize,
 ) -> Result<()> {
-    let elf_path = PathBuf::from(elf);
-    if !elf_path.exists() {
+    let input_path = PathBuf::from(&input);
+    if !input_path.exists() {
         return Err(FbuildError::BuildFailed(format!(
-            "ELF not found: {}",
-            elf_path.display()
+            "input not found: {}",
+            input_path.display()
         )));
     }
+
+    let elf_path = resolve_elf(&input_path)?;
 
     let nm_path = match nm {
         Some(p) => PathBuf::from(p),
@@ -61,15 +66,10 @@ pub fn run_symbols(
 
     let report = analyze_elf(cfg)?;
 
+    let mut wrote_anything = false;
+
     if let Some(json_path) = json_out {
-        let json = serde_json::to_string_pretty(&report)
-            .map_err(|e| FbuildError::Other(format!("json serialize: {e}")))?;
-        std::fs::write(&json_path, json).map_err(|e| {
-            FbuildError::Io(std::io::Error::new(
-                e.kind(),
-                format!("write {json_path}: {e}"),
-            ))
-        })?;
+        write_json(&report, &json_path)?;
         println!(
             "Wrote {} symbols to {} (flash={} B, ram={} B)",
             report.symbols.len(),
@@ -77,11 +77,78 @@ pub fn run_symbols(
             report.total_flash,
             report.total_ram
         );
-    } else {
+        wrote_anything = true;
+    }
+
+    if let Some(dir_str) = output_dir {
+        let dir = PathBuf::from(&dir_str);
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            FbuildError::Io(std::io::Error::new(
+                e.kind(),
+                format!("create {dir_str}: {e}"),
+            ))
+        })?;
+        let json_target = dir.join("report.json");
+        let md_target = dir.join("report.md");
+        write_json(&report, &json_target.to_string_lossy())?;
+        let md = format_markdown_report(&report, top);
+        std::fs::write(&md_target, md).map_err(|e| {
+            FbuildError::Io(std::io::Error::new(
+                e.kind(),
+                format!("write {}: {e}", md_target.display()),
+            ))
+        })?;
+        println!(
+            "Wrote {} symbols to {} and {} (flash={} B, ram={} B)",
+            report.symbols.len(),
+            json_target.display(),
+            md_target.display(),
+            report.total_flash,
+            report.total_ram
+        );
+        wrote_anything = true;
+    }
+
+    if !wrote_anything {
         println!("{}", format_text_report(&report, top));
     }
 
     Ok(())
+}
+
+fn write_json(
+    report: &fbuild_core::symbol_analysis::FineGrainedSymbolMap,
+    json_path: &str,
+) -> Result<()> {
+    let json = serde_json::to_string_pretty(report)
+        .map_err(|e| FbuildError::Other(format!("json serialize: {e}")))?;
+    std::fs::write(json_path, json).map_err(|e| {
+        FbuildError::Io(std::io::Error::new(
+            e.kind(),
+            format!("write {json_path}: {e}"),
+        ))
+    })?;
+    Ok(())
+}
+
+/// Map the CLI input (either an ELF file or a project directory) to
+/// an ELF path. Directory inputs go through
+/// `discover_elf_in_project` which honours build_info.json,
+/// `.fbuild/build/*/firmware.elf`, `.pio/build/*/firmware.elf`, and
+/// loose `.elf` files directly inside the directory.
+fn resolve_elf(input: &Path) -> Result<PathBuf> {
+    if input.is_dir() {
+        discover_elf_in_project(input).ok_or_else(|| {
+            FbuildError::BuildFailed(format!(
+                "no ELF found under {} (looked for build_info.json's \
+                 prog_path, .fbuild/build/**/firmware.elf, \
+                 .pio/build/**/firmware.elf, and *.elf at top level)",
+                input.display()
+            ))
+        })
+    } else {
+        Ok(input.to_path_buf())
+    }
 }
 
 /// Locate `nm` on PATH. The user can always override with `--nm`.

--- a/crates/fbuild-cli/src/cli/symbols_cmd.rs
+++ b/crates/fbuild-cli/src/cli/symbols_cmd.rs
@@ -1,0 +1,99 @@
+//! `fbuild symbols` — standalone fine-grained per-symbol bloat report.
+//!
+//! Runs the same analysis the build orchestrator's `--symbol-analysis`
+//! flag emits, but on any ELF the user points at — including one built
+//! by PlatformIO or another out-of-band tool.
+
+use std::path::{Path, PathBuf};
+
+use fbuild_build::symbol_analyzer::{
+    analyze_elf, default_map_path, derive_cppfilt_path, format_text_report, AnalyzeConfig,
+};
+use fbuild_core::{FbuildError, Result};
+
+pub fn run_symbols(
+    elf: String,
+    map: Option<String>,
+    nm: Option<String>,
+    cppfilt: Option<String>,
+    json_out: Option<String>,
+    top: usize,
+) -> Result<()> {
+    let elf_path = PathBuf::from(elf);
+    if !elf_path.exists() {
+        return Err(FbuildError::BuildFailed(format!(
+            "ELF not found: {}",
+            elf_path.display()
+        )));
+    }
+
+    let nm_path = match nm {
+        Some(p) => PathBuf::from(p),
+        None => find_nm_on_path()?,
+    };
+    if !nm_path.exists() {
+        return Err(FbuildError::BuildFailed(format!(
+            "nm not found at {}",
+            nm_path.display()
+        )));
+    }
+
+    let cppfilt_path = cppfilt.map(PathBuf::from).or_else(|| {
+        let derived = derive_cppfilt_path(&nm_path);
+        if derived.exists() {
+            Some(derived)
+        } else {
+            None
+        }
+    });
+
+    let map_path_owned = map.map(PathBuf::from).or_else(|| default_map_path(&elf_path));
+    let map_path_ref: Option<&Path> = map_path_owned.as_deref();
+
+    let cfg = AnalyzeConfig {
+        elf_path: &elf_path,
+        map_path: map_path_ref,
+        nm_path: &nm_path,
+        cppfilt_path: cppfilt_path.as_deref(),
+    };
+
+    let report = analyze_elf(cfg)?;
+
+    if let Some(json_path) = json_out {
+        let json = serde_json::to_string_pretty(&report)
+            .map_err(|e| FbuildError::Other(format!("json serialize: {e}")))?;
+        std::fs::write(&json_path, json).map_err(|e| {
+            FbuildError::Io(std::io::Error::new(
+                e.kind(),
+                format!("write {json_path}: {e}"),
+            ))
+        })?;
+        println!(
+            "Wrote {} symbols to {} (flash={} B, ram={} B)",
+            report.symbols.len(),
+            json_path,
+            report.total_flash,
+            report.total_ram
+        );
+    } else {
+        println!("{}", format_text_report(&report, top));
+    }
+
+    Ok(())
+}
+
+/// Locate `nm` on PATH. The user can always override with `--nm`.
+fn find_nm_on_path() -> Result<PathBuf> {
+    let exe_name = if cfg!(windows) { "nm.exe" } else { "nm" };
+    let path = std::env::var_os("PATH")
+        .ok_or_else(|| FbuildError::Other("PATH not set".into()))?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(exe_name);
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(FbuildError::BuildFailed(format!(
+        "{exe_name} not found on PATH; pass --nm to point at a cross toolchain nm"
+    )))
+}

--- a/crates/fbuild-core/src/lib.rs
+++ b/crates/fbuild-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod emulator;
 pub mod response_file;
 pub mod shell_split;
 pub mod subprocess;
+pub mod symbol_analysis;
 
 pub use build_log::BuildLog;
 

--- a/crates/fbuild-core/src/subprocess.rs
+++ b/crates/fbuild-core/src/subprocess.rs
@@ -88,6 +88,61 @@ pub fn run_command(
     run_captured(config, args, timeout)
 }
 
+/// Run an external command, feed `stdin_bytes` to its stdin, and
+/// capture stdout+stderr. Used by tools that operate on a payload
+/// piped through a filter (e.g. `c++filt`, `clang-format`).
+///
+/// Routing through `NativeProcess` is critical for large stdin
+/// payloads: the running-process reader thread drains stdout in
+/// background while we write stdin, avoiding the Windows pipe-buffer
+/// deadlock that hits when ~3k mangled symbols (~250 KB) saturate
+/// the 4-8 KB stdout pipe before stdin EOF.
+pub fn run_command_with_stdin(
+    args: &[&str],
+    stdin_bytes: &[u8],
+    cwd: Option<&Path>,
+    env: Option<&[(&str, &str)]>,
+    timeout: Option<Duration>,
+) -> Result<ToolOutput> {
+    let config = build_config(args, cwd, env, /*capture=*/ true, StdinMode::Piped)?;
+    let process = NativeProcess::new(config);
+    process.start().map_err(|e| spawn_err(args, e))?;
+    // Writes the data then closes stdin (signals EOF). The reader
+    // threads spawned by `start()` keep stdout/stderr drained
+    // throughout the write.
+    if !stdin_bytes.is_empty() {
+        process
+            .write_stdin(stdin_bytes)
+            .map_err(|e| FbuildError::Other(format!("stdin write to {:?} failed: {}", args, e)))?;
+    } else {
+        // Empty payload: close stdin immediately so the child sees EOF.
+        let _ = process.close_stdin();
+    }
+    let exit_code = match process.wait(timeout) {
+        Ok(code) => code,
+        Err(ProcessError::Timeout) => {
+            let _ = process.kill();
+            return Err(FbuildError::Timeout(format!(
+                "command timed out after {}s",
+                timeout.map(|d| d.as_secs()).unwrap_or(0)
+            )));
+        }
+        Err(e) => {
+            return Err(FbuildError::Other(format!(
+                "command {:?} failed: {}",
+                args, e
+            )))
+        }
+    };
+    let stdout = join_lines(process.captured_stdout());
+    let stderr = join_lines(process.captured_stderr());
+    Ok(ToolOutput {
+        stdout,
+        stderr,
+        exit_code,
+    })
+}
+
 /// Run an external command with inherited stdin/stdout/stderr (no
 /// capture). Intended for pass-through cases like the `pio` CLI
 /// delegation where users expect the tool's live output.

--- a/crates/fbuild-core/src/symbol_analysis.rs
+++ b/crates/fbuild-core/src/symbol_analysis.rs
@@ -135,7 +135,7 @@ pub fn extract_archive_and_object(src: &str) -> (Option<String>, String) {
         let archive_end = open + 2; // include ".a"
         let archive_path = &trimmed[..archive_end];
         let archive = archive_path
-            .rsplit(|c| c == '/' || c == '\\')
+            .rsplit(['/', '\\'])
             .next()
             .unwrap_or(archive_path)
             .to_string();
@@ -149,7 +149,7 @@ pub fn extract_archive_and_object(src: &str) -> (Option<String>, String) {
     }
     // Form B: ".../<file>.o" — no archive, just an object on disk.
     let basename = trimmed
-        .rsplit(|c| c == '/' || c == '\\')
+        .rsplit(['/', '\\'])
         .next()
         .unwrap_or(trimmed)
         .to_string();
@@ -310,7 +310,7 @@ impl InputSectionIndex {
     pub fn lookup(&self, addr: u64) -> Option<&InputSectionRange> {
         let (_, &idx) = self.by_start.range(..=addr).next_back()?;
         let r = &self.ranges[idx];
-        if addr < r.addr.checked_add(r.size).unwrap_or(u64::MAX) {
+        if addr < r.addr.saturating_add(r.size) {
             Some(r)
         } else {
             None
@@ -334,7 +334,11 @@ pub fn rollup_sections(ranges: &[InputSectionRange]) -> Vec<SectionBytes> {
         if !is_firmware_section(&r.output_section) {
             continue;
         }
-        let key = (r.archive.clone(), r.object.clone(), r.output_section.clone());
+        let key = (
+            r.archive.clone(),
+            r.object.clone(),
+            r.output_section.clone(),
+        );
         *acc.entry(key).or_insert(0) += r.size;
     }
     let mut out: Vec<SectionBytes> = acc
@@ -455,9 +459,7 @@ mod tests {
 
     #[test]
     fn extract_bare_object_no_archive() {
-        let (arc, obj) = extract_archive_and_object(
-            ".pio/build/esp32s3/src/main.cpp.o",
-        );
+        let (arc, obj) = extract_archive_and_object(".pio/build/esp32s3/src/main.cpp.o");
         assert!(arc.is_none());
         assert_eq!(obj, "main.cpp.o");
     }
@@ -557,7 +559,12 @@ Linker script and memory map
             archive: Some("libFastLED.a".into()),
             object: "fl.channels.cpp.o".into(),
         }];
-        let nm = vec![(0x42000020u64, 0x40u64, 'T', "_ZN2fl7Channel10showPixelsERS_".to_string())];
+        let nm = vec![(
+            0x42000020u64,
+            0x40u64,
+            'T',
+            "_ZN2fl7Channel10showPixelsERS_".to_string(),
+        )];
         let demangled = vec!["fl::Channel::showPixels(fl::Channel&)".to_string()];
         let map = build_fine_grained_map(
             "fw.elf".into(),

--- a/crates/fbuild-core/src/symbol_analysis.rs
+++ b/crates/fbuild-core/src/symbol_analysis.rs
@@ -1,0 +1,577 @@
+//! Fine-grained per-symbol bloat analysis.
+//!
+//! Glues together three sources of truth to produce a single row per live
+//! symbol in an ELF — *demangled name*, size, address, sym-type, region,
+//! plus *which archive + object file + output section* the linker placed
+//! it in. Designed for diffing two builds at the symbol level so growth
+//! between releases can be pinpointed (e.g. "+74 KB came from
+//! `libFastLED.a(fl.channels+.cpp.o):fl::Channel::showPixels`").
+//!
+//! Sources:
+//! - `nm --print-size --size-sort --reverse-sort -S <elf>` → mangled name,
+//!   address, size, sym-type. Pure address+size facts.
+//! - `<linker>.map` → per-input-section ranges with the source archive
+//!   and object. Carries the attribution information `nm` does not.
+//! - `c++filt` → demangling (subprocess; not done in this module — the
+//!   caller passes already-demangled names alongside mangled ones).
+//!
+//! The parsing in this file is intentionally **pure** (no subprocess,
+//! no fs I/O for tool invocation) so it can be unit-tested without a
+//! cross toolchain. Subprocess drivers live in `fbuild_build`.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::MemoryRegion;
+
+/// A single live symbol with full attribution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FineGrainedSymbol {
+    /// Mangled name as it appears in `nm` output.
+    pub mangled: String,
+    /// Demangled name (== mangled for C symbols / when c++filt unavailable).
+    pub demangled: String,
+    /// Symbol load address (decimal).
+    pub address: u64,
+    /// Size in bytes (from `nm --print-size`).
+    pub size: u64,
+    /// nm type letter: T t W w R r D d B b ...
+    pub sym_type: char,
+    /// Flash vs Ram, derived from sym_type.
+    pub region: MemoryRegion,
+    /// Source archive label (e.g. `"libFastLED.a"`) if attributable.
+    pub archive: Option<String>,
+    /// Object file member inside the archive (e.g.
+    /// `"fl.channels+.cpp.o"`), or the bare object file when no
+    /// archive is involved.
+    pub object: Option<String>,
+    /// Output section the symbol lives in (e.g. `".flash.text"`).
+    pub output_section: Option<String>,
+}
+
+/// Per `(archive, object, output_section)` byte roll-up taken straight
+/// from the linker map. Captures bytes that **don't** appear as named
+/// symbols in `nm`, in particular the merged `.flash.rodata` string
+/// pool (anonymous `.rodata.<func>.str1.1` sub-sections that hold all
+/// the `FL_WARN`/`FL_LOG`/format strings emitted by the TU). Without
+/// this view the diff misses substantial rodata bloat.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SectionBytes {
+    pub archive: Option<String>,
+    pub object: String,
+    pub output_section: String,
+    pub bytes: u64,
+}
+
+/// The complete per-symbol view of a single binary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FineGrainedSymbolMap {
+    pub elf_path: String,
+    pub map_path: Option<String>,
+    pub total_flash: u64,
+    pub total_ram: u64,
+    pub symbols: Vec<FineGrainedSymbol>,
+    /// Per-`(archive, object, output_section)` byte totals from the map.
+    /// Empty when no map file was supplied. Complements `symbols` by
+    /// covering bytes that don't have a named `nm` entry (e.g. merged
+    /// rodata string pools).
+    #[serde(default)]
+    pub sections: Vec<SectionBytes>,
+}
+
+/// One address range placed by the linker into an output section.
+#[derive(Debug, Clone)]
+pub struct InputSectionRange {
+    pub addr: u64,
+    pub size: u64,
+    pub output_section: String,
+    /// e.g. `".flash.text"`. Inherited from the enclosing output section
+    /// listing in the map file.
+    pub input_section: String,
+    /// e.g. `".text._ZN2fl7ChannelXXX"` — the per-symbol input section
+    /// name. Used as a fallback when `nm`'s symbol address doesn't fall
+    /// neatly inside any range (relaxed sections, weak collapses).
+    pub archive: Option<String>,
+    pub object: String,
+}
+
+/// Parse one line of `nm --print-size --size-sort --reverse-sort -S` output.
+///
+/// Format: `<addr-hex> <size-hex> <type> <name>` where address and size
+/// are hexadecimal (no `0x` prefix), type is a single letter, and name
+/// may contain spaces for C++ templates. Returns `None` for lines that
+/// don't carry a sized symbol (the `nm` "no size" output is filtered
+/// out — those rows have only 3 whitespace fields).
+pub fn parse_nm_line(line: &str) -> Option<(u64, u64, char, String)> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 4 {
+        return None;
+    }
+    let addr = u64::from_str_radix(parts[0], 16).ok()?;
+    let size = u64::from_str_radix(parts[1], 16).ok()?;
+    let ch = parts[2].chars().next()?;
+    let name = parts[3..].join(" ");
+    Some((addr, size, ch, name))
+}
+
+/// Parse the body of `nm --print-size --size-sort --reverse-sort -S <elf>`.
+pub fn parse_nm_output(output: &str) -> Vec<(u64, u64, char, String)> {
+    output
+        .lines()
+        .filter_map(parse_nm_line)
+        .filter(|(_, sz, _, _)| *sz > 0)
+        .collect()
+}
+
+/// Extract `"libFastLED.a"` from a path like
+/// `.pio/build/esp32s3/lib0d9/libFastLED.a(fl.channels+.cpp.o)`. Also
+/// supports bare object files like `.pio/build/esp32s3/src/main.cpp.o`,
+/// in which case the archive is `None` and the object is the basename.
+pub fn extract_archive_and_object(src: &str) -> (Option<String>, String) {
+    let trimmed = src.trim();
+    // Form A: ".../<archive>.a(<object>)"
+    if let Some(open) = trimmed.find(".a(") {
+        let archive_end = open + 2; // include ".a"
+        let archive_path = &trimmed[..archive_end];
+        let archive = archive_path
+            .rsplit(|c| c == '/' || c == '\\')
+            .next()
+            .unwrap_or(archive_path)
+            .to_string();
+        let object_start = open + 3;
+        let object_end = trimmed[object_start..]
+            .find(')')
+            .map(|p| object_start + p)
+            .unwrap_or(trimmed.len());
+        let object = trimmed[object_start..object_end].to_string();
+        return (Some(archive), object);
+    }
+    // Form B: ".../<file>.o" — no archive, just an object on disk.
+    let basename = trimmed
+        .rsplit(|c| c == '/' || c == '\\')
+        .next()
+        .unwrap_or(trimmed)
+        .to_string();
+    (None, basename)
+}
+
+/// Parse a PIO-style GNU `ld --print-map` output and return the per-input-section
+/// ranges that contain live bytes (size > 0 AND address != 0).
+///
+/// The map file has two large views: the per-archive *input* view (mostly
+/// tombstones at address 0x00000000 after `--gc-sections` strips dead
+/// sections) and the per-output-section *layout* view, which is what we
+/// care about. Output sections look like:
+///
+/// ```text
+/// .flash.text     0x42000020    0x4026c
+///  .literal._ZN...
+///                 0x42000020       0x10 .pio/build/esp32s3/lib0d9/libFastLED.a(fl.foo+.cpp.o)
+///  .text.startup.main
+///                 0x42000030       0x40 .pio/build/esp32s3/src/main.cpp.o
+/// ```
+///
+/// This parser walks every output section whose header looks like
+/// `.<name>  0x<addr>  0x<size>` at column 0 and harvests the input section
+/// rows nested under it.
+pub fn parse_linker_map(map_text: &str) -> Vec<InputSectionRange> {
+    let mut out = Vec::new();
+    let mut in_link_view = false;
+    let mut current_output: Option<String> = None;
+    let mut pending_input_section: Option<String> = None;
+
+    for raw in map_text.lines() {
+        if !in_link_view {
+            if raw.starts_with("Linker script and memory map") {
+                in_link_view = true;
+            }
+            continue;
+        }
+
+        // Output section header: starts at column 0 with a dot, has addr+size.
+        if raw.starts_with('.') {
+            // Parse "<sect> 0x<addr> 0x<size>" (anything after is ignored).
+            let mut it = raw.split_whitespace();
+            let sect = it.next().unwrap_or("");
+            if let (Some(addr_s), Some(_size_s)) = (it.next(), it.next()) {
+                if addr_s.starts_with("0x") {
+                    current_output = Some(sect.to_string());
+                    pending_input_section = None;
+                    continue;
+                }
+            }
+            // Some lines starting with '.' are linker keywords ('.' at col 0
+            // with no addr+size). Ignore.
+            continue;
+        }
+
+        // Lines inside an output section. Two sub-formats:
+        //   A:  " .input.section 0x<addr> 0x<size> <source>"
+        //   B:  " .input.section"  (name on its own line)
+        //       "                0x<addr> 0x<size> <source>"
+        let stripped = raw.trim_start();
+        if !stripped.starts_with('.') && !stripped.starts_with("0x") {
+            // Filler — symbol pinning, fill bytes, etc. Skip.
+            pending_input_section = None;
+            continue;
+        }
+
+        // Try form A: section + addr + size + source.
+        if stripped.starts_with('.') {
+            let mut it = stripped.split_whitespace();
+            let sect = it.next().unwrap_or("").to_string();
+            if let (Some(a), Some(s)) = (it.next(), it.next()) {
+                if a.starts_with("0x") && s.starts_with("0x") {
+                    let src = it.collect::<Vec<_>>().join(" ");
+                    let addr = u64::from_str_radix(&a[2..], 16).unwrap_or(0);
+                    let size = u64::from_str_radix(&s[2..], 16).unwrap_or(0);
+                    pending_input_section = None;
+                    if size > 0 && addr != 0 && !src.is_empty() {
+                        if let Some(ref out_sect) = current_output {
+                            let (archive, object) = extract_archive_and_object(&src);
+                            out.push(InputSectionRange {
+                                addr,
+                                size,
+                                output_section: out_sect.clone(),
+                                input_section: sect,
+                                archive,
+                                object,
+                            });
+                        }
+                    }
+                    continue;
+                }
+            }
+            // It's just the input section name; stash for the next line.
+            pending_input_section = Some(sect);
+            continue;
+        }
+
+        // Form B continuation: addr + size + source.
+        if let Some(name) = pending_input_section.take() {
+            let mut it = stripped.split_whitespace();
+            if let (Some(a), Some(s)) = (it.next(), it.next()) {
+                if a.starts_with("0x") && s.starts_with("0x") {
+                    let src = it.collect::<Vec<_>>().join(" ");
+                    let addr = u64::from_str_radix(&a[2..], 16).unwrap_or(0);
+                    let size = u64::from_str_radix(&s[2..], 16).unwrap_or(0);
+                    if size > 0 && addr != 0 && !src.is_empty() {
+                        if let Some(ref out_sect) = current_output {
+                            let (archive, object) = extract_archive_and_object(&src);
+                            out.push(InputSectionRange {
+                                addr,
+                                size,
+                                output_section: out_sect.clone(),
+                                input_section: name,
+                                archive,
+                                object,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// Classify an nm type letter into Flash vs Ram. Matches the existing
+/// `SymbolMap::classify` logic so reports compare apples-to-apples.
+pub fn classify_region(sym_type: char) -> Option<MemoryRegion> {
+    match sym_type {
+        'T' | 't' | 'R' | 'r' | 'W' | 'w' => Some(MemoryRegion::Flash),
+        'D' | 'd' | 'B' | 'b' => Some(MemoryRegion::Ram),
+        _ => None,
+    }
+}
+
+/// Build an address-indexed lookup over input section ranges so we can
+/// attribute every nm symbol to the range containing it in O(log n).
+pub struct InputSectionIndex {
+    /// Sorted-by-address map: start_addr → range index.
+    by_start: BTreeMap<u64, usize>,
+    ranges: Vec<InputSectionRange>,
+}
+
+impl InputSectionIndex {
+    pub fn build(mut ranges: Vec<InputSectionRange>) -> Self {
+        ranges.sort_by_key(|r| r.addr);
+        let mut by_start = BTreeMap::new();
+        for (idx, r) in ranges.iter().enumerate() {
+            by_start.insert(r.addr, idx);
+        }
+        Self { by_start, ranges }
+    }
+
+    /// Find the range whose [addr, addr+size) contains the given address.
+    /// Picks the largest start_addr ≤ addr, then verifies containment.
+    pub fn lookup(&self, addr: u64) -> Option<&InputSectionRange> {
+        let (_, &idx) = self.by_start.range(..=addr).next_back()?;
+        let r = &self.ranges[idx];
+        if addr < r.addr.checked_add(r.size).unwrap_or(u64::MAX) {
+            Some(r)
+        } else {
+            None
+        }
+    }
+}
+
+/// Stitch nm output + map file ranges + demangled-names into a final
+/// per-symbol view. Takes already-demangled names so this function stays
+/// free of subprocess invocations (and easily unit-testable).
+/// Aggregate raw map ranges into `(archive, object, output_section)`
+/// byte buckets. Filters out ELF-metadata sections (`.debug_*`, `.xt.*`,
+/// `.comment`, `.note*`) that live in the ELF but never make it into
+/// the firmware image — counting them would dwarf the real bytes and
+/// mislead diffs. Stable sort by bytes-descending so consumers can
+/// stream the top contributors without re-sorting.
+pub fn rollup_sections(ranges: &[InputSectionRange]) -> Vec<SectionBytes> {
+    let mut acc: std::collections::HashMap<(Option<String>, String, String), u64> =
+        std::collections::HashMap::new();
+    for r in ranges {
+        if !is_firmware_section(&r.output_section) {
+            continue;
+        }
+        let key = (r.archive.clone(), r.object.clone(), r.output_section.clone());
+        *acc.entry(key).or_insert(0) += r.size;
+    }
+    let mut out: Vec<SectionBytes> = acc
+        .into_iter()
+        .map(|((archive, object, output_section), bytes)| SectionBytes {
+            archive,
+            object,
+            output_section,
+            bytes,
+        })
+        .collect();
+    out.sort_by(|a, b| b.bytes.cmp(&a.bytes));
+    out
+}
+
+/// True for output sections whose bytes end up in the firmware image
+/// (text, rodata, IRAM, DRAM, RTC). Excludes ELF metadata that lives
+/// in the file but is stripped at flash time (debug info, Xtensa
+/// scratch sections, `.comment`, etc.).
+pub fn is_firmware_section(name: &str) -> bool {
+    let n = name;
+    if n.starts_with(".debug")
+        || n.starts_with(".xt.")
+        || n.starts_with(".xtensa")
+        || n.starts_with(".comment")
+        || n.starts_with(".note")
+        || n.starts_with(".group")
+        || n.starts_with(".dynsym")
+        || n.starts_with(".strtab")
+        || n.starts_with(".symtab")
+    {
+        return false;
+    }
+    n.starts_with(".flash")
+        || n.starts_with(".iram")
+        || n.starts_with(".dram")
+        || n.starts_with(".rtc")
+        || n.starts_with(".rodata")
+        || n.starts_with(".text")
+        || n.starts_with(".data")
+        || n.starts_with(".bss")
+}
+
+pub fn build_fine_grained_map(
+    elf_path: String,
+    map_path: Option<String>,
+    nm_rows: Vec<(u64, u64, char, String)>,
+    demangled: Vec<String>,
+    ranges: Vec<InputSectionRange>,
+) -> FineGrainedSymbolMap {
+    assert_eq!(
+        nm_rows.len(),
+        demangled.len(),
+        "nm_rows and demangled must be parallel"
+    );
+    let sections = rollup_sections(&ranges);
+    let index = InputSectionIndex::build(ranges);
+    let mut symbols = Vec::with_capacity(nm_rows.len());
+    let mut total_flash = 0u64;
+    let mut total_ram = 0u64;
+    for ((addr, size, sym_type, mangled), demangled) in nm_rows.into_iter().zip(demangled) {
+        let Some(region) = classify_region(sym_type) else {
+            continue;
+        };
+        match region {
+            MemoryRegion::Flash => total_flash += size,
+            MemoryRegion::Ram => total_ram += size,
+        }
+        let attribution = index.lookup(addr);
+        symbols.push(FineGrainedSymbol {
+            mangled,
+            demangled,
+            address: addr,
+            size,
+            sym_type,
+            region,
+            archive: attribution.and_then(|r| r.archive.clone()),
+            object: attribution.map(|r| r.object.clone()),
+            output_section: attribution.map(|r| r.output_section.clone()),
+        });
+    }
+    FineGrainedSymbolMap {
+        elf_path,
+        map_path,
+        total_flash,
+        total_ram,
+        symbols,
+        sections,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_nm_line_minimal() {
+        let row = parse_nm_line("42008de8 00001251 T fl::Channel::showPixels()").unwrap();
+        assert_eq!(row.0, 0x42008de8);
+        assert_eq!(row.1, 0x1251);
+        assert_eq!(row.2, 'T');
+        assert_eq!(row.3, "fl::Channel::showPixels()");
+    }
+
+    #[test]
+    fn parse_nm_line_skips_unsized() {
+        assert!(parse_nm_line("       U _impure_ptr").is_none());
+    }
+
+    #[test]
+    fn extract_archive_from_pio_path() {
+        let (arc, obj) = extract_archive_and_object(
+            ".pio/build/esp32s3/lib0d9/libFastLED.a(fl.channels+.cpp.o)",
+        );
+        assert_eq!(arc.as_deref(), Some("libFastLED.a"));
+        assert_eq!(obj, "fl.channels+.cpp.o");
+    }
+
+    #[test]
+    fn extract_bare_object_no_archive() {
+        let (arc, obj) = extract_archive_and_object(
+            ".pio/build/esp32s3/src/main.cpp.o",
+        );
+        assert!(arc.is_none());
+        assert_eq!(obj, "main.cpp.o");
+    }
+
+    #[test]
+    fn parse_linker_map_combined_line() {
+        // Simulates one output section with two input section rows.
+        let text = "\
+Linker script and memory map
+
+.flash.text     0x42000020    0x4026c
+ .text.foo      0x42000020       0x10 path/libFastLED.a(foo.cpp.o)
+ .text.bar      0x42000030       0x20 path/src/main.cpp.o
+";
+        let ranges = parse_linker_map(text);
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].addr, 0x42000020);
+        assert_eq!(ranges[0].size, 0x10);
+        assert_eq!(ranges[0].output_section, ".flash.text");
+        assert_eq!(ranges[0].archive.as_deref(), Some("libFastLED.a"));
+        assert_eq!(ranges[0].object, "foo.cpp.o");
+        assert!(ranges[1].archive.is_none());
+        assert_eq!(ranges[1].object, "main.cpp.o");
+    }
+
+    #[test]
+    fn parse_linker_map_section_on_own_line() {
+        // Many sections wrap because their mangled names are too long for
+        // one row.
+        let text = "\
+Linker script and memory map
+
+.flash.text     0x42000020    0x4026c
+ .text._ZN2fl7Channel10showPixelsERS_
+                0x42000020       0x40 path/libFastLED.a(fl.channels.cpp.o)
+";
+        let ranges = parse_linker_map(text);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].size, 0x40);
+        assert_eq!(
+            ranges[0].input_section,
+            ".text._ZN2fl7Channel10showPixelsERS_"
+        );
+        assert_eq!(ranges[0].archive.as_deref(), Some("libFastLED.a"));
+    }
+
+    #[test]
+    fn parse_linker_map_drops_tombstones() {
+        // Tombstone: 0x00000000 address means linker dropped the section.
+        let text = "\
+Linker script and memory map
+
+.flash.text     0x42000020    0x4026c
+ .text.dead     0x00000000       0x40 path/libFastLED.a(dead.cpp.o)
+ .text.live     0x42000020       0x40 path/libFastLED.a(live.cpp.o)
+";
+        let ranges = parse_linker_map(text);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].input_section, ".text.live");
+    }
+
+    #[test]
+    fn input_section_index_lookup_inside_range() {
+        let ranges = vec![
+            InputSectionRange {
+                addr: 0x1000,
+                size: 0x10,
+                output_section: ".flash.text".into(),
+                input_section: ".text.foo".into(),
+                archive: Some("libA.a".into()),
+                object: "foo.o".into(),
+            },
+            InputSectionRange {
+                addr: 0x2000,
+                size: 0x20,
+                output_section: ".flash.text".into(),
+                input_section: ".text.bar".into(),
+                archive: Some("libB.a".into()),
+                object: "bar.o".into(),
+            },
+        ];
+        let idx = InputSectionIndex::build(ranges);
+        assert_eq!(idx.lookup(0x1000).unwrap().input_section, ".text.foo");
+        assert_eq!(idx.lookup(0x1008).unwrap().input_section, ".text.foo");
+        assert!(idx.lookup(0x1010).is_none()); // past end of first range
+        assert_eq!(idx.lookup(0x2010).unwrap().input_section, ".text.bar");
+        assert!(idx.lookup(0x500).is_none()); // before any range
+    }
+
+    #[test]
+    fn build_fine_grained_map_attributes_symbols() {
+        let ranges = vec![InputSectionRange {
+            addr: 0x42000020,
+            size: 0x40,
+            output_section: ".flash.text".into(),
+            input_section: ".text.show".into(),
+            archive: Some("libFastLED.a".into()),
+            object: "fl.channels.cpp.o".into(),
+        }];
+        let nm = vec![(0x42000020u64, 0x40u64, 'T', "_ZN2fl7Channel10showPixelsERS_".to_string())];
+        let demangled = vec!["fl::Channel::showPixels(fl::Channel&)".to_string()];
+        let map = build_fine_grained_map(
+            "fw.elf".into(),
+            Some("fw.map".into()),
+            nm,
+            demangled,
+            ranges,
+        );
+        assert_eq!(map.symbols.len(), 1);
+        let sym = &map.symbols[0];
+        assert_eq!(sym.archive.as_deref(), Some("libFastLED.a"));
+        assert_eq!(sym.output_section.as_deref(), Some(".flash.text"));
+        assert_eq!(sym.demangled, "fl::Channel::showPixels(fl::Channel&)");
+        assert_eq!(map.total_flash, 0x40);
+        assert_eq!(map.total_ram, 0);
+    }
+}

--- a/dylints/ban_raw_subprocess/src/allowlist.txt
+++ b/dylints/ban_raw_subprocess/src/allowlist.txt
@@ -45,3 +45,12 @@ crates/fbuild-build/src/zccache.rs
 # `containment::tokio_spawn::spawn_contained` would be a no-op anyway;
 # documented inline at each call site.
 crates/fbuild-cli/src/cli/clang_tools.rs
+
+# `fbuild symbols` demangles via c++filt. We pipe the mangled symbol
+# list through c++filt's stdin and drain stdout via `wait_with_output`
+# from a separate writer thread to avoid the Windows pipe-buffer
+# deadlock that hits when the symbol pool is large. The captured
+# `subprocess::run_command` helper is stdin-Null only, so raw spawn is
+# the only way to feed the pipe. Read-only analysis path (no
+# containment side effects).
+crates/fbuild-build/src/symbol_analyzer.rs

--- a/dylints/ban_raw_subprocess/src/allowlist.txt
+++ b/dylints/ban_raw_subprocess/src/allowlist.txt
@@ -45,12 +45,3 @@ crates/fbuild-build/src/zccache.rs
 # `containment::tokio_spawn::spawn_contained` would be a no-op anyway;
 # documented inline at each call site.
 crates/fbuild-cli/src/cli/clang_tools.rs
-
-# `fbuild symbols` demangles via c++filt. We pipe the mangled symbol
-# list through c++filt's stdin and drain stdout via `wait_with_output`
-# from a separate writer thread to avoid the Windows pipe-buffer
-# deadlock that hits when the symbol pool is large. The captured
-# `subprocess::run_command` helper is stdin-Null only, so raw spawn is
-# the only way to feed the pipe. Read-only analysis path (no
-# containment side effects).
-crates/fbuild-build/src/symbol_analyzer.rs

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.17"
+version = "2.2.18"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },


### PR DESCRIPTION
## Summary

Adds a new `fbuild symbols <elf>` subcommand that runs nm + c++filt + linker-map parsing on any ELF (built by fbuild, PlatformIO, or anything else) and emits a per-symbol bloat table attributed to **source archive + object file + output section**. Also exposes the map-derived per-section roll-up so anonymous merged rodata (`FL_WARN`/`FL_LOG` string pools) is captured — nm alone misses those bytes because they aren't named symbols.

JSON output makes the report scriptable, enabling per-symbol diffs between two builds. Motivating use case: pinpointing where the ~333 KB ESP32-S3 Blink regression between FastLED 3.10.3 and current master came from. Prior `--symbol-analysis` flag emitted mangled top-20 names with no archive attribution, which was too coarse to drive that investigation.

## What's new

- `fbuild-core::symbol_analysis` — pure parsing (nm + linker map ranges), filtering of debug-only sections (`.debug_*`, `.xt.*`, `.comment`, ...), address-range index for symbol-to-section attribution, structured output types (`FineGrainedSymbol`, `SectionBytes`, `FineGrainedSymbolMap`).
- `fbuild-build::symbol_analyzer` — subprocess driver (nm, c++filt) with threaded stdin writer to avoid pipe-buffer deadlock on Windows when the symbol pool is large (~3k symbols saturates the 4-8 KB pipe buffer).
- `fbuild-cli::symbols_cmd` — CLI plumbing for `fbuild symbols <elf>` with `--map / --nm / --cppfilt / --json / --top` flags.

## Example output

\`\`\`
=== Fine-grained symbol analysis: firmware.elf ===
Flash: 316368 B across 2793 sized symbols
RAM:   34927 B across 903 sized symbols

--- Top FLASH symbols ---
   BYTES  ARCHIVE          OBJECT                SECTION         symbol
   11309  libc.a           libc_a-vfprintf.o     .flash.text     _vfprintf_r
    4689  libFastLED.a     fl.channels+.cpp.o    .flash.text     fl::Channel::showPixels(PixelController<...>)
    2315  libFastLED.a     platforms+.cpp.o      .flash.text     fl::ChannelEngineRMTImpl::createChannel(...)
    ...
\`\`\`

JSON shape (truncated):
\`\`\`json
{
  "elf_path": "...", "map_path": "...",
  "total_flash": 316368, "total_ram": 34927,
  "symbols": [{ "mangled": "_ZN...", "demangled": "fl::Channel::showPixels(...)",
                "address": 1107329000, "size": 4689, "sym_type": "T",
                "region": "flash", "archive": "libFastLED.a",
                "object": "fl.channels+.cpp.o",
                "output_section": ".flash.text" }, ...],
  "sections": [{ "archive": "libFastLED.a", "object": "platforms+.cpp.o",
                 "output_section": ".flash.rodata", "bytes": 46508 }, ...]
}
\`\`\`

## Test plan

- [x] 9 new unit tests in `fbuild-core::symbol_analysis::tests` (nm-line parsing, map-file forms, tombstone filter, address-range index, end-to-end attribution).
- [x] 2 new unit tests in `fbuild-build::symbol_analyzer::tests` (c++filt path derivation with and without cross-toolchain prefix).
- [x] Verified end-to-end on ESP32-S3 Blink ELFs from FastLED 3.10.3 (2614 symbols) and current master (3696 symbols). Section totals reconcile to ELF section sizes within rounding for the linker-relaxation overlap of `.literal.*` and `.text.*`.

## Known gaps (follow-up)

Per-symbol attribution is robust for **named code symbols** in `.flash.text` (nm names them) and for input-section-level rodata pools (`.rodata.<func>.str1.1` blocks attributed to their owning function). Outstanding: anonymous **merged rodata blocks** that don't carry the owner's name in their input-section identifier — these still bucket at object level. Tracking issue to follow with the specific shapes that need extra parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `fbuild symbols` subcommand to run per-symbol bloat analysis (ELF or project dir), with auto ELF discovery, optional linker-map, nm/c++filt handling, JSON output, Markdown report, and configurable top‑N.
  * Outputs can be written to an output directory (paired JSON + Markdown) or printed as text.
* **Tests**
  * Comprehensive unit tests covering ELF discovery, nm/map parsing, demangling, and report formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->