### PR TITLE
feat(build): drive 'pip install .' through soldr cargo build (#423)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 **/*.rs.bk
 **/compile_commands.json
 
+# Staged binary copied into the wheel by setup.py's BuildWithCargo cmdclass
+# (#423). Source is target/release/fbuild[.exe]; never check the staged
+# copy in.
+/ci/bin/
+
 # IDE
 .idea/
 .vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.17"
+version = "2.2.18"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/ci/bin_launcher.py
+++ b/ci/bin_launcher.py
@@ -1,0 +1,39 @@
+"""Console-script entry point for the bundled `fbuild` binary.
+
+Wheels produced by `pip install .` (see `setup.py`) ship a native
+`fbuild[.exe]` binary inside `ci/bin/`. The wheel also declares this module
+as the `fbuild` console script via `[project.scripts]` in `pyproject.toml`,
+so `which fbuild` resolves to a tiny Python shim that lives next to this
+launcher. The launcher then `execv`s the real binary, replacing the Python
+process — so process semantics (PID, signal handling, stdio inheritance,
+exit code) match what bare-cargo `target/release/fbuild` would give.
+
+The release wheels published to PyPI by `ci/publish.py` follow the same
+layout: pre-built native binary at `ci/bin/fbuild[.exe]`, this launcher as
+the entry point.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# IMPORTANT: keep this filename matching `TARGET_BINARY_NAME` in setup.py.
+_BINARY_NAME = "fbuild.exe" if sys.platform == "win32" else "fbuild"
+
+
+def main() -> None:
+    binary = Path(__file__).resolve().parent / "bin" / _BINARY_NAME
+    if not binary.exists():
+        sys.stderr.write(
+            f"ERROR: bundled fbuild binary not found at {binary}.\n"
+            f"This wheel may be incomplete. Reinstall with `pip install --force-reinstall .` "
+            f"from the fbuild source tree, or install a release wheel from PyPI.\n"
+        )
+        sys.exit(1)
+
+    # execv replaces the Python process. argv[0] convention: pass the
+    # binary path so help text and error messages reference the real
+    # command, not the Python shim.
+    os.execv(str(binary), [str(binary)] + sys.argv[1:])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,12 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = ["zccache>=1.11.15"]
 
+# Console script: `fbuild` on PATH after `pip install .` execs the native
+# binary that setup.py stages into ci/bin/fbuild[.exe]. See setup.py +
+# ci/bin_launcher.py for the full wiring (#423).
+[project.scripts]
+fbuild = "ci.bin_launcher:main"
+
 [dependency-groups]
 dev = ["fbuild-dev-tools"]
 
@@ -18,3 +24,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["ci"]
+include-package-data = true
+
+# Ship the native binary that setup.py's BuildWithCargo cmdclass stages
+# into ci/bin/ during the build_py phase. Glob is broad enough to match
+# fbuild + fbuild.exe across platforms.
+[tool.setuptools.package-data]
+ci = ["bin/fbuild*"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,102 @@
+"""Local source-install build driver for fbuild.
+
+`pip install ~/dev/fbuild` (or any `pip install .` from the repo root) goes
+through this file because `pyproject.toml` declares the setuptools build
+backend. The plain backend would ship only `ci/` Python helpers — no working
+`fbuild` command — because the actual CLI is a Rust crate (`fbuild-cli`)
+that lives in the cargo workspace under `crates/`.
+
+This file wires the install path through `soldr cargo build --release -p
+fbuild-cli`, copies the resulting binary to `ci/bin/fbuild[.exe]`, and lets
+setuptools pack it into the wheel. The `ci.bin_launcher:main` entry point
+(declared in pyproject.toml) execs that binary, so `fbuild` on PATH after
+install Just Works.
+
+This is the LOCAL DEV install path. The RELEASE path is unchanged: it stays
+in `ci/build_dist.py` + `ci/publish.py` (build per-platform binaries on
+GitHub Actions, assemble platform-tagged wheels, upload to PyPI).
+
+Why soldr (and not bare cargo)?
+
+- soldr resolves the toolchain via `rustup which`, respecting
+  `rust-toolchain.toml` without requiring PATH to be pre-shaped.
+- soldr auto-sets `RUSTC_WRAPPER` to zccache, so rebuilds across `pip
+  install .` invocations are incremental + dep-cached.
+
+Why not `setuptools-rust` or `maturin`? Both are reasonable but heavier:
+they introduce another tool with its own toolchain assumptions, while
+soldr is already the canonical build driver across this repo's dev,
+trampoline, and CI paths (see `ci/trampoline.py`). Keeping the single
+soldr-cargo invocation means there's only one place to look when iteration
+is slow.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import setup
+from setuptools.command.build_py import build_py
+from setuptools.dist import Distribution
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+TARGET_BINARY_NAME = "fbuild.exe" if sys.platform == "win32" else "fbuild"
+TARGET_BINARY_PATH = REPO_ROOT / "target" / "release" / TARGET_BINARY_NAME
+STAGED_BIN_DIR = REPO_ROOT / "ci" / "bin"
+STAGED_BINARY_PATH = STAGED_BIN_DIR / TARGET_BINARY_NAME
+
+
+def _require_soldr() -> None:
+    if shutil.which("soldr") is None:
+        sys.stderr.write(
+            "\n"
+            "ERROR: `soldr` is required to build fbuild from source.\n"
+            "Install one of:\n"
+            "  uv tool install soldr\n"
+            "  curl -fsSL https://raw.githubusercontent.com/zackees/soldr/main/install.sh | bash\n"
+            "Then re-run `pip install .`.\n"
+            "\n"
+            "If you only want the Python helpers (no `fbuild` CLI), install\n"
+            "the `fbuild-dev-tools` subpackage instead: `uv sync` from this\n"
+            "repo root.\n"
+            "\n"
+        )
+        sys.exit(1)
+
+
+class BuildWithCargo(build_py):
+    """Run `soldr cargo build --release -p fbuild-cli` before packaging."""
+
+    def run(self) -> None:  # noqa: D401 — setuptools API name
+        _require_soldr()
+
+        cmd = ["soldr", "cargo", "build", "--release", "-p", "fbuild-cli"]
+        sys.stderr.write(f"  $ {' '.join(cmd)}\n")
+        subprocess.check_call(cmd, cwd=str(REPO_ROOT))
+
+        if not TARGET_BINARY_PATH.exists():
+            sys.stderr.write(f"ERROR: cargo build succeeded but binary not at {TARGET_BINARY_PATH}.\n")
+            sys.exit(1)
+
+        STAGED_BIN_DIR.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(TARGET_BINARY_PATH, STAGED_BINARY_PATH)
+        sys.stderr.write(f"  staged binary -> {STAGED_BINARY_PATH}\n")
+
+        super().run()
+
+
+class BinaryDistribution(Distribution):
+    """Force a platform-tagged wheel because we ship a native binary."""
+
+    def has_ext_modules(self) -> bool:  # noqa: D401 — setuptools API name
+        return True
+
+
+setup(
+    cmdclass={"build_py": BuildWithCargo},
+    distclass=BinaryDistribution,
+)


### PR DESCRIPTION
Closes #423.

## Summary

Wires `pip install ~/dev/fbuild` (and any `pip install .` from the repo root) through `soldr cargo build --release -p fbuild-cli` so the install produces a working `fbuild` command. Previously the setuptools backend only shipped the Python `ci/` helpers — `pip install .` left users without a CLI.

The release path on PyPI (`ci/build_dist.py` → GHA matrix → `ci/publish.py`) is unaffected; it still builds per-platform binaries on the GHA matrix and assembles platform-tagged wheels. The local install now produces a wheel with the same layout (binary in `ci/bin/`, `ci.bin_launcher:main` console script).

## Changes

- **`setup.py`** (new) — `cmdclass['build_py']` hook runs the cargo build, stages `target/release/fbuild[.exe]` into `ci/bin/`, then delegates to standard `build_py`. `BinaryDistribution.has_ext_modules` returns True so the wheel is platform-tagged.
- **`ci/bin_launcher.py`** (new) — `main()` execv's the bundled binary with the caller's argv. Process semantics (PID, signals, stdio, exit code) match bare-cargo `target/release/fbuild`.
- **`pyproject.toml`** — `[project.scripts] fbuild = "ci.bin_launcher:main"`, `include-package-data = true`, `[tool.setuptools.package-data] ci = ["bin/fbuild*"]`.
- **`.gitignore`** — exclude `ci/bin/` (build output).
- **`Cargo.lock`** — brought into sync with workspace `version = "2.2.18"` (was 2.2.17 across crates; rewritten by first cargo build).

## Validation

Smoke-tested locally on Windows:

```
$ python -m venv /tmp/fbuild-install-test
$ /tmp/fbuild-install-test/Scripts/pip install /c/Users/niteris/dev/fbuild
... (full cold build via soldr cargo)
Successfully built fbuild
Created wheel for fbuild: filename=fbuild-2.2.18-cp313-cp313-win_amd64.whl size=15246614

$ /tmp/fbuild-install-test/Scripts/fbuild --version
fbuild 2.2.18

# Incremental rebuild: touch crates/fbuild-cli/src/main.rs
$ time /tmp/fbuild-install-test/Scripts/pip install --force-reinstall --no-deps ...
~19s end-to-end (cargo incremental + zccache hit + wheel pack)
```

Platform tag (`cp313-cp313-win_amd64`) confirms `BinaryDistribution` is forcing a non-universal wheel — required because the wheel embeds a native binary.

## Test plan

- [x] Fresh-venv `pip install .` produces a working `fbuild` CLI
- [x] Incremental rebuild after `.rs` touch completes in ~19s
- [x] Build fails with clear message when `soldr` is missing from PATH (see `_require_soldr()` in `setup.py`)
- [x] `uv sync && run_fbuild` (existing trampoline path) still works for users who don't want a wheel build
- [ ] CI runs (Validate Boards + 75 platform builds + lint + cross-OS Checks)

## Out of scope

- Multi-binary wheels (shipping `fbuild-daemon` alongside `fbuild`). Follow-up.
- Replacing the GHA release pipeline. The local-install path complements PyPI wheels; it doesn't replace them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)