### PR TITLE
feat(deploy): wire Teensy dispatch arm so 'fbuild deploy -e teensyXX' actually runs (#430)

### DIFF
--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -18,6 +18,55 @@ use std::sync::Arc;
 #[cfg(feature = "espflash-native")]
 use super::common::{native_verify_enabled, native_write_enabled};
 
+/// Resolve a usable `teensy_loader_cli` binary for the Teensy deploy arm.
+///
+/// Search order:
+///   1. `$PATH` (`teensy_loader_cli` on Unix, `teensy_loader_cli.exe` on Win)
+///   2. `~/.platformio/packages/tool-teensy/teensy_loader_cli{.exe}` — the
+///      well-known path PlatformIO installs it at on every PIO-using machine.
+///
+/// Returns `None` if neither is found; the TeensyDeployer's default will then
+/// try a bare `teensy_loader_cli` invocation, which will surface
+/// `command not found` to the user — clearer than a silent abort here.
+fn find_teensy_loader_cli() -> Option<PathBuf> {
+    let exe_name = if cfg!(windows) {
+        "teensy_loader_cli.exe"
+    } else {
+        "teensy_loader_cli"
+    };
+
+    if let Ok(path_env) = std::env::var("PATH") {
+        let sep = if cfg!(windows) { ';' } else { ':' };
+        for dir in path_env.split(sep) {
+            let candidate = PathBuf::from(dir).join(exe_name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    // PlatformIO drops the binary here on every platform. Reusing it means a
+    // user who already has PIO working doesn't need to install anything else
+    // to deploy via fbuild.
+    let pio_root = if cfg!(windows) {
+        std::env::var("USERPROFILE").ok()
+    } else {
+        std::env::var("HOME").ok()
+    };
+    if let Some(home) = pio_root {
+        let pio_candidate = PathBuf::from(home)
+            .join(".platformio")
+            .join("packages")
+            .join("tool-teensy")
+            .join(exe_name);
+        if pio_candidate.is_file() {
+            return Some(pio_candidate);
+        }
+    }
+
+    None
+}
+
 /// POST /api/deploy
 pub async fn deploy(
     State(ctx): State<Arc<DaemonContext>>,
@@ -632,6 +681,33 @@ pub async fn deploy(
                 } else {
                     deployer
                 };
+                Box::new(deployer)
+            }
+            fbuild_core::Platform::Teensy => {
+                // The TeensyDeployer in fbuild-deploy/src/teensy.rs has been
+                // fully implemented (incl. unit tests for teensy40 / teensy41
+                // board configs) but wasn't dispatched here — issue #430.
+                // Without this arm `bash autoresearch teensyXX --simd` (and
+                // every other Teensy autoresearch flag) failed at the deploy
+                // step with "deployer for Teensy not yet implemented",
+                // blocking FastLED/FastLED#2628 hardware bring-up.
+                let board_config =
+                    fbuild_config::BoardConfig::from_board_id(&board_id, &deploy_board_overrides)
+                        .unwrap_or_else(|_| {
+                            fbuild_config::BoardConfig::from_board_id(
+                                "teensy41",
+                                &deploy_board_overrides,
+                            )
+                            .unwrap()
+                        });
+                let loader_params = fbuild_deploy::teensy::TeensyLoaderParams::default();
+                let loader_path = find_teensy_loader_cli();
+                let deployer = fbuild_deploy::teensy::TeensyDeployer::new(
+                    &board_config.board.to_uppercase(),
+                    &loader_params,
+                    loader_path,
+                    false,
+                );
                 Box::new(deployer)
             }
             _ => {


### PR DESCRIPTION
Closes #430. Unblocks FastLED/FastLED#2628 hardware bring-up.

## Summary

`crates/fbuild-deploy/src/teensy.rs` ships a complete `TeensyDeployer` (171 LOC + unit tests for teensy40 / teensy41 board configs) but it wasn't dispatched anywhere — the daemon's deploy match in `crates/fbuild-daemon/src/handlers/operations/deploy.rs:368` only had arms for `Espressif32`, `AtmelAvr`, `AtmelMegaAvr`. Every Teensy build hit the `_ =>` "deployer for Teensy not yet implemented" return.

Add the missing `Platform::Teensy =>` arm and a `find_teensy_loader_cli()` helper.

## Changes

- **`Platform::Teensy =>`** arm at the deploy match. Loads `BoardConfig::from_board_id` (falling back to `teensy41` if lookup fails — matches the AVR arm's `uno` fallback), constructs `TeensyDeployer::new(...)` with uppercased board id, default `TeensyLoaderParams`, and a discovered loader path.
- **`find_teensy_loader_cli()`** searches `$PATH` first (`teensy_loader_cli` / `.exe`), then falls back to `~/.platformio/packages/tool-teensy/teensy_loader_cli{.exe}` (canonical PlatformIO install path, present on every PIO-using machine). Returns `None` if neither is found; the `TeensyDeployer` default then surfaces a bare `command not found` to the user.

No new dependencies. Pure dispatch wire-up.

## Verification

Test device: Teensy 4.0 attached at COM22, with PlatformIO already installed (so `teensy_loader_cli.exe` at the known PIO path).

```
# Before this PR
$ bash autoresearch teensy40 --simd
...
deploy error: deploy failed: deployer for Teensy not yet implemented
❌ Deploy failed (fbuild) [122.3s]

# After this PR
$ bash autoresearch teensy40 --simd
...
Running: ...\fbuild.exe ... deploy -e teensy40 -p COM22
[teensy_loader_cli launches: --mcu=TEENSY40 -w -v firmware.hex]
Teensy Loader, Command Line, Version 2.2
Read "...firmware.hex": 72704 bytes, 3.6% usage
Found HalfKay Bootloader
Programming.error writing to Teensy   ← hardware-level state issue
```

The dispatch is verified end-to-end: fbuild → TeensyDeployer → teensy_loader_cli → HalfKay bootloader handshake. The test device's bootloader hit a "Programming.error" requiring physical reset (unplug/replug or 15-sec button hold for factory restore) — that's a known Windows USB issue independent of this fix and not in scope.

## Test plan

- [x] `cargo build --release -p fbuild-cli` — clean
- [x] `cargo build --release -p fbuild-daemon` — clean
- [x] `cargo test -p fbuild-deploy --lib teensy` — 3/3 passed (no regression)
- [x] `bash autoresearch teensy40 --simd` no longer fails at the "not yet implemented" guard

## Out of scope

- Bundling `teensy_loader_cli` into fbuild's tooling cache. Reusing the PIO-cached binary is zero-download for any PIO user; a separate fbuild-distribution story can layer in later.
- Resolving the HalfKay bootloader "Programming.error" hardware state — physical-reset required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)