### PR TITLE
feat(symbols): ingest toolchain paths from build_info.json

### DIFF
--- a/crates/fbuild-build/src/build_info.rs
+++ b/crates/fbuild-build/src/build_info.rs
@@ -14,6 +14,7 @@
 //!
 //! See FastLED/fbuild#297.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use fbuild_core::Result;
@@ -40,6 +41,23 @@ pub struct BuildInfo {
     pub objcopy_path: String,
     /// Absolute path to `size`.
     pub size_path: String,
+    /// Absolute path to `nm` (GCC convention: derived from `size_path` by
+    /// replacing the `size` suffix with `nm`). Consumed by `fbuild symbols`
+    /// (see #428) so users don't have to pass `--nm` on every invocation.
+    #[serde(default)]
+    pub nm_path: String,
+    /// Absolute path to `c++filt` (GCC convention). Used by the symbol
+    /// analyzer to demangle the names `nm` emits.
+    #[serde(default)]
+    pub cppfilt_path: String,
+    /// Absolute path to `readelf`. Useful for downstream section/segment
+    /// inspection.
+    #[serde(default)]
+    pub readelf_path: String,
+    /// Absolute path to `objdump`. Useful for downstream disassembly /
+    /// section dumps.
+    #[serde(default)]
+    pub objdump_path: String,
     /// Effective C compile flags as seen by the compiler driver.
     pub cc_flags: Vec<String>,
     /// Effective C++ compile flags as seen by the compiler driver.
@@ -58,6 +76,14 @@ pub struct BuildInfo {
     pub board: String,
     /// PlatformIO env name (e.g. `uno`, `teensy41-debug`).
     pub env: String,
+    /// PIO-shape mirror of the toolchain paths. PlatformIO emits an
+    /// `aliases` block keyed by short tool names (`nm`, `c++filt`,
+    /// `readelf`, `objdump`, `gcc`, etc.); FastLED's
+    /// `ci/util/symbol_analysis.py` and `ci/inspect_binary.py` read from
+    /// it. Mirroring keeps existing PIO consumers working drop-in
+    /// against fbuild-built artifacts. See #428.
+    #[serde(default)]
+    pub aliases: BTreeMap<String, String>,
 }
 
 impl BuildInfo {
@@ -65,6 +91,12 @@ impl BuildInfo {
     /// `-D` defines and `-I` includes out of `cxx_flags` (matching
     /// PlatformIO's metadata-emitter convention) without removing them
     /// from `cxx_flags` itself.
+    ///
+    /// The four diagnostic toolchain paths (`nm`, `c++filt`, `readelf`,
+    /// `objdump`) are derived from `size_path` using the GCC cross-tool
+    /// naming convention (`<prefix>-size` → `<prefix>-nm`, etc.). The
+    /// `aliases` block mirrors these onto short keys for PIO consumer
+    /// compatibility. See #428.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         prog_path: &Path,
@@ -83,6 +115,21 @@ impl BuildInfo {
     ) -> Self {
         let defines = extract_prefixed(&cxx_flags, "-D");
         let includes = extract_prefixed(&cxx_flags, "-I");
+        let nm_path = derive_gcc_tool_path(size_path, "nm");
+        let cppfilt_path = derive_gcc_tool_path(size_path, "c++filt");
+        let readelf_path = derive_gcc_tool_path(size_path, "readelf");
+        let objdump_path = derive_gcc_tool_path(size_path, "objdump");
+        let aliases = build_aliases(
+            cc_path,
+            cxx_path,
+            ar_path,
+            objcopy_path,
+            size_path,
+            &nm_path,
+            &cppfilt_path,
+            &readelf_path,
+            &objdump_path,
+        );
         Self {
             prog_path: path_to_string(Some(prog_path)),
             cc_path: path_to_string(cc_path),
@@ -90,6 +137,10 @@ impl BuildInfo {
             ar_path: path_to_string(ar_path),
             objcopy_path: path_to_string(objcopy_path),
             size_path: path_to_string(Some(size_path)),
+            nm_path: path_to_string(Some(nm_path.as_path())),
+            cppfilt_path: path_to_string(Some(cppfilt_path.as_path())),
+            readelf_path: path_to_string(Some(readelf_path.as_path())),
+            objdump_path: path_to_string(Some(objdump_path.as_path())),
             cc_flags,
             cxx_flags,
             link_flags,
@@ -99,8 +150,72 @@ impl BuildInfo {
             platform,
             board,
             env,
+            aliases,
         }
     }
+}
+
+/// Derive a sibling GCC cross-tool path from `size_path`.
+///
+/// For a `size_path` like `/toolchain/bin/xtensa-esp32-elf-size[.exe]`,
+/// returns `/toolchain/bin/xtensa-esp32-elf-<target>[.exe]`. When the
+/// stem doesn't end in `size` (rare — bare `size` on PATH), returns
+/// `<parent>/<target>` preserving any extension.
+pub fn derive_gcc_tool_path(size_path: &Path, target: &str) -> PathBuf {
+    let parent = size_path.parent().unwrap_or(Path::new("."));
+    let stem = size_path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let new_stem = if let Some(prefix) = stem.strip_suffix("size") {
+        format!("{prefix}{target}")
+    } else {
+        target.to_string()
+    };
+    match size_path.extension() {
+        Some(ext) if !ext.is_empty() => {
+            parent.join(format!("{new_stem}.{}", ext.to_string_lossy()))
+        }
+        _ => parent.join(new_stem),
+    }
+}
+
+/// Build the PIO-shape `aliases` block. Keys match PlatformIO's
+/// `pio project metadata` output so FastLED's existing Python
+/// consumers (`ci/util/symbol_analysis.py`, `ci/inspect_binary.py`)
+/// keep working unchanged. Empty paths are skipped so consumers can
+/// trust `aliases["nm"]` is non-empty whenever the key is present.
+#[allow(clippy::too_many_arguments)]
+fn build_aliases(
+    cc_path: Option<&Path>,
+    cxx_path: Option<&Path>,
+    ar_path: Option<&Path>,
+    objcopy_path: Option<&Path>,
+    size_path: &Path,
+    nm_path: &Path,
+    cppfilt_path: &Path,
+    readelf_path: &Path,
+    objdump_path: &Path,
+) -> BTreeMap<String, String> {
+    let mut aliases = BTreeMap::new();
+    let entries: &[(&str, Option<&Path>)] = &[
+        ("gcc", cc_path),
+        ("g++", cxx_path),
+        ("ar", ar_path),
+        ("objcopy", objcopy_path),
+        ("size", Some(size_path)),
+        ("nm", Some(nm_path)),
+        ("c++filt", Some(cppfilt_path)),
+        ("readelf", Some(readelf_path)),
+        ("objdump", Some(objdump_path)),
+    ];
+    for (key, path) in entries {
+        let s = path_to_string(*path);
+        if !s.is_empty() {
+            aliases.insert((*key).to_string(), s);
+        }
+    }
+    aliases
 }
 
 fn path_to_string(p: Option<&Path>) -> String {
@@ -171,6 +286,78 @@ pub fn pick_prog_path(
     bin.map(Path::to_path_buf)
         .or_else(|| hex.map(Path::to_path_buf))
         .or_else(|| elf.map(Path::to_path_buf))
+}
+
+/// Load a `build_info_<env>.json` (or `build_info.json`) file and return
+/// the inner [`BuildInfo`] for its single environment.
+///
+/// The PlatformIO + fbuild emitter convention is a one-key outer object
+/// (`{ "<env>": { ...BuildInfo } }`); this helper unwraps that
+/// transparently and errors out if the file doesn't match the shape.
+/// Consumed by `fbuild symbols` (#428) to resolve toolchain paths
+/// without the user passing `--nm`.
+pub fn load_build_info(path: &Path) -> Result<(String, BuildInfo)> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        fbuild_core::FbuildError::BuildFailed(format!("read {}: {e}", path.display()))
+    })?;
+    let outer: BTreeMap<String, BuildInfo> = serde_json::from_slice(&bytes).map_err(|e| {
+        fbuild_core::FbuildError::BuildFailed(format!(
+            "{}: not a valid build_info.json: {e}",
+            path.display()
+        ))
+    })?;
+    let mut it = outer.into_iter();
+    let (env, info) = it.next().ok_or_else(|| {
+        fbuild_core::FbuildError::BuildFailed(format!(
+            "{}: build_info.json is empty (expected exactly one env)",
+            path.display()
+        ))
+    })?;
+    if it.next().is_some() {
+        return Err(fbuild_core::FbuildError::BuildFailed(format!(
+            "{}: build_info.json carries more than one env (expected exactly one)",
+            path.display()
+        )));
+    }
+    Ok((env, info))
+}
+
+/// Walk upward from `start` looking for a `build_info.json` (or any
+/// `build_info_<env>.json`). PIO and fbuild both write these next to
+/// `platformio.ini`, but `start` is typically the directory containing
+/// `firmware.elf` (`.fbuild/build/<env>/` or `.pio/build/<env>/`). We
+/// search `start` itself first, then walk parent directories.
+///
+/// Returns `None` when no metadata file is found before reaching the
+/// filesystem root. `fbuild symbols` falls back to PATH-based `nm`
+/// lookup in that case so the command keeps working against bare ELFs.
+pub fn find_build_info_near(start: &Path) -> Option<PathBuf> {
+    let mut cursor: Option<&Path> = Some(start);
+    while let Some(dir) = cursor {
+        if let Some(found) = scan_dir_for_build_info(dir) {
+            return Some(found);
+        }
+        cursor = dir.parent();
+    }
+    None
+}
+
+fn scan_dir_for_build_info(dir: &Path) -> Option<PathBuf> {
+    let generic = dir.join("build_info.json");
+    if generic.is_file() {
+        return Some(generic);
+    }
+    let entries = std::fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with("build_info_") && name.ends_with(".json") && path.is_file() {
+            return Some(path);
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -384,6 +571,228 @@ mod tests {
         assert_eq!(
             extract_prefixed(&["-D".to_string(), "-DX".to_string()], "-D"),
             vec!["X".to_string()]
+        );
+    }
+
+    // ---- #428: toolchain path derivation + aliases mirror ----
+
+    /// Encode a derived path the same way [`BuildInfo::new`] does
+    /// (`Path::join` uses the platform separator, so test expectations
+    /// must too — `/bin/avr-nm` on Unix, `/bin\avr-nm` on Windows).
+    fn pj(parent: &str, name: &str) -> String {
+        PathBuf::from(parent)
+            .join(name)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn derive_gcc_tool_path_avr_prefix() {
+        let size = PathBuf::from("/bin/avr-size");
+        assert_eq!(
+            derive_gcc_tool_path(&size, "nm"),
+            PathBuf::from("/bin").join("avr-nm")
+        );
+        assert_eq!(
+            derive_gcc_tool_path(&size, "c++filt"),
+            PathBuf::from("/bin").join("avr-c++filt")
+        );
+        assert_eq!(
+            derive_gcc_tool_path(&size, "readelf"),
+            PathBuf::from("/bin").join("avr-readelf")
+        );
+        assert_eq!(
+            derive_gcc_tool_path(&size, "objdump"),
+            PathBuf::from("/bin").join("avr-objdump")
+        );
+    }
+
+    #[test]
+    fn derive_gcc_tool_path_xtensa_with_exe_suffix() {
+        let size = PathBuf::from("C:/toolchain/bin/xtensa-esp32s3-elf-size.exe");
+        assert_eq!(
+            derive_gcc_tool_path(&size, "nm"),
+            PathBuf::from("C:/toolchain/bin").join("xtensa-esp32s3-elf-nm.exe")
+        );
+        assert_eq!(
+            derive_gcc_tool_path(&size, "c++filt"),
+            PathBuf::from("C:/toolchain/bin").join("xtensa-esp32s3-elf-c++filt.exe")
+        );
+    }
+
+    #[test]
+    fn derive_gcc_tool_path_bare_size_falls_back_to_bare_target() {
+        // PATH-resolved `size` with no prefix.
+        let size = PathBuf::from("/usr/bin/size");
+        assert_eq!(
+            derive_gcc_tool_path(&size, "nm"),
+            PathBuf::from("/usr/bin").join("nm")
+        );
+    }
+
+    #[test]
+    fn build_info_populates_new_toolchain_fields() {
+        let info = sample_info();
+        // GCC convention: /bin/avr-size → /bin/avr-{nm,c++filt,readelf,objdump}
+        assert_eq!(info.nm_path, pj("/bin", "avr-nm"));
+        assert_eq!(info.cppfilt_path, pj("/bin", "avr-c++filt"));
+        assert_eq!(info.readelf_path, pj("/bin", "avr-readelf"));
+        assert_eq!(info.objdump_path, pj("/bin", "avr-objdump"));
+    }
+
+    #[test]
+    fn build_info_aliases_block_mirrors_paths() {
+        let info = sample_info();
+        // The aliases block carries short PIO-shape keys. Every present
+        // long-form path must also appear under its alias key.
+        // cc/cxx/ar/objcopy/size are passed in verbatim, so they keep the
+        // literal "/" separator we constructed them with. The four derived
+        // tools (nm/c++filt/readelf/objdump) go through Path::join so they
+        // use the platform separator — match that via pj().
+        assert_eq!(info.aliases.get("gcc"), Some(&"/bin/avr-gcc".to_string()));
+        assert_eq!(info.aliases.get("g++"), Some(&"/bin/avr-g++".to_string()));
+        assert_eq!(info.aliases.get("ar"), Some(&"/bin/avr-ar".to_string()));
+        assert_eq!(
+            info.aliases.get("objcopy"),
+            Some(&"/bin/avr-objcopy".to_string())
+        );
+        assert_eq!(info.aliases.get("size"), Some(&"/bin/avr-size".to_string()));
+        assert_eq!(info.aliases.get("nm"), Some(&pj("/bin", "avr-nm")));
+        assert_eq!(
+            info.aliases.get("c++filt"),
+            Some(&pj("/bin", "avr-c++filt"))
+        );
+        assert_eq!(
+            info.aliases.get("readelf"),
+            Some(&pj("/bin", "avr-readelf"))
+        );
+        assert_eq!(
+            info.aliases.get("objdump"),
+            Some(&pj("/bin", "avr-objdump"))
+        );
+    }
+
+    #[test]
+    fn build_info_aliases_omit_empty_optional_tools() {
+        // ESP8266-style: no ar, no objcopy. Their alias keys must be absent
+        // so consumers can rely on `key in aliases` meaning the path is real.
+        let info = BuildInfo::new(
+            Path::new("/build/firmware.elf"),
+            Some(Path::new("/bin/gcc")),
+            Some(Path::new("/bin/g++")),
+            None,
+            None,
+            Path::new("/bin/size"),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            "esp8266".to_string(),
+            "nodemcuv2".to_string(),
+            "nodemcuv2".to_string(),
+        );
+        assert!(!info.aliases.contains_key("ar"));
+        assert!(!info.aliases.contains_key("objcopy"));
+        // …but nm / c++filt / readelf / objdump are derived from size_path
+        // and always present.
+        assert!(info.aliases.contains_key("nm"));
+        assert!(info.aliases.contains_key("c++filt"));
+        assert!(info.aliases.contains_key("readelf"));
+        assert!(info.aliases.contains_key("objdump"));
+    }
+
+    /// #428: walking up from an ELF path should find the project's
+    /// `build_info.json`. Mirrors the FastLED `_find_build_info()` lookup.
+    #[test]
+    fn find_build_info_walks_up_from_elf_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path();
+        let build_dir = project.join(".fbuild").join("build").join("uno");
+        std::fs::create_dir_all(&build_dir).unwrap();
+        // Emit at the project root (where platformio.ini would live).
+        let info = sample_info();
+        emit_build_info(project, "uno", &info).unwrap();
+
+        // Search from the ELF directory walks up to the project root.
+        let found = find_build_info_near(&build_dir)
+            .expect("walk should reach the project root's build_info.json");
+        assert_eq!(found, project.join("build_info.json"));
+    }
+
+    #[test]
+    fn find_build_info_prefers_env_specific_in_same_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        // Only write build_info_uno.json, no generic build_info.json.
+        let info = sample_info();
+        let outer = BTreeMap::from([("uno".to_string(), info)]);
+        let json = serde_json::to_string_pretty(&outer).unwrap();
+        std::fs::write(dir.join("build_info_uno.json"), json).unwrap();
+
+        let found = find_build_info_near(dir).expect("should find env-specific file");
+        assert_eq!(found.file_name().unwrap(), "build_info_uno.json");
+    }
+
+    #[test]
+    fn find_build_info_returns_none_when_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let nested = tmp.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert!(find_build_info_near(&nested).is_none());
+    }
+
+    #[test]
+    fn load_build_info_unwraps_single_env() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let info = sample_info();
+        emit_build_info(tmp.path(), "uno", &info).unwrap();
+        let (env, loaded) = load_build_info(&tmp.path().join("build_info_uno.json")).unwrap();
+        assert_eq!(env, "uno");
+        assert_eq!(loaded, info);
+    }
+
+    /// #428: existing PIO consumers (FastLED `ci/util/symbol_analysis.py`)
+    /// read tool paths from `board_info["aliases"]["<short>"]`. Make sure
+    /// the emitted JSON carries that block.
+    #[test]
+    fn emit_writes_aliases_into_json() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let info = sample_info();
+        emit_build_info(tmp.path(), "uno", &info).unwrap();
+
+        let bytes = std::fs::read(tmp.path().join("build_info_uno.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let inner = parsed
+            .as_object()
+            .unwrap()
+            .get("uno")
+            .unwrap()
+            .as_object()
+            .unwrap();
+        let aliases = inner
+            .get("aliases")
+            .expect("aliases block must be emitted")
+            .as_object()
+            .expect("aliases must be an object");
+        let expected_nm = pj("/bin", "avr-nm");
+        let expected_cppfilt = pj("/bin", "avr-c++filt");
+        let expected_readelf = pj("/bin", "avr-readelf");
+        let expected_objdump = pj("/bin", "avr-objdump");
+        assert_eq!(
+            aliases.get("nm").and_then(|v| v.as_str()),
+            Some(expected_nm.as_str())
+        );
+        assert_eq!(
+            aliases.get("c++filt").and_then(|v| v.as_str()),
+            Some(expected_cppfilt.as_str())
+        );
+        assert_eq!(
+            aliases.get("readelf").and_then(|v| v.as_str()),
+            Some(expected_readelf.as_str())
+        );
+        assert_eq!(
+            aliases.get("objdump").and_then(|v| v.as_str()),
+            Some(expected_objdump.as_str())
         );
     }
 }

--- a/crates/fbuild-build/src/symbol_analyzer.rs
+++ b/crates/fbuild-build/src/symbol_analyzer.rs
@@ -408,6 +408,7 @@ pub fn format_markdown_report(map: &FineGrainedSymbolMap, top_n: usize) -> Strin
 ///   2. `<dir>/.fbuild/build/**/firmware.elf` (fbuild native output).
 ///   3. `<dir>/.pio/build/**/firmware.elf` (PlatformIO output).
 ///   4. Any `*.elf` directly inside `<dir>`.
+///
 /// Returns the most recently-modified candidate when multiple match.
 pub fn discover_elf_in_project(project_dir: &Path) -> Option<PathBuf> {
     // 1. build_info.json

--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -90,13 +90,22 @@ pub enum Commands {
         /// Path to the linker map (auto-detected if omitted).
         #[arg(long)]
         map: Option<String>,
-        /// Path to `nm` (auto-detected from PATH if omitted; pass the
-        /// cross-tool, e.g. `xtensa-esp32s3-elf-nm`).
+        /// Path to `nm` (highest precedence; pass the cross-tool, e.g.
+        /// `xtensa-esp32s3-elf-nm`). When omitted, fbuild reads
+        /// `nm_path` from `build_info.json` (auto-located near the ELF
+        /// or via `--build-info`), then falls back to PATH lookup.
         #[arg(long)]
         nm: Option<String>,
-        /// Path to `c++filt` (auto-derived from `nm` path if omitted).
+        /// Path to `c++filt` (highest precedence). When omitted, fbuild
+        /// reads `cppfilt_path` from `build_info.json`, then derives it
+        /// from the resolved nm path.
         #[arg(long = "cppfilt")]
         cppfilt: Option<String>,
+        /// Path to a `build_info.json` (or `build_info_<env>.json`) that
+        /// carries toolchain paths. When omitted, fbuild walks up from
+        /// the ELF directory looking for one. See #428.
+        #[arg(long = "build-info")]
+        build_info: Option<String>,
         /// Write structured report to PATH as JSON instead of the text
         /// table. Mutually compatible with `--output-dir`.
         #[arg(long)]

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -61,10 +61,11 @@ pub async fn async_main() {
             map,
             nm,
             cppfilt,
+            build_info,
             json,
             output_dir,
             top,
-        }) => run_symbols(input, map, nm, cppfilt, json, output_dir, top),
+        }) => run_symbols(input, map, nm, cppfilt, build_info, json, output_dir, top),
         Some(Commands::Build {
             project_dir,
             environment,

--- a/crates/fbuild-cli/src/cli/symbols_cmd.rs
+++ b/crates/fbuild-cli/src/cli/symbols_cmd.rs
@@ -4,20 +4,32 @@
 //! analysis the build orchestrator's `--symbol-analysis` flag emits,
 //! but on any ELF the user points at — including one built by
 //! PlatformIO or another out-of-band tool.
+//!
+//! Toolchain resolution (see #428):
+//!   1. `--nm` / `--cppfilt` CLI flags (user wins).
+//!   2. `--build-info <path>` if provided — `nm_path` / `cppfilt_path`
+//!      read from that file.
+//!   3. Auto-discovery: walk up from the ELF directory looking for
+//!      `build_info.json` or `build_info_<env>.json`.
+//!   4. PATH-based lookup of `nm`, with `c++filt` derived by stem.
+//!   5. Hard error.
 
 use std::path::{Path, PathBuf};
 
+use fbuild_build::build_info::{find_build_info_near, load_build_info};
 use fbuild_build::symbol_analyzer::{
     analyze_elf, default_map_path, derive_cppfilt_path, discover_elf_in_project,
     format_markdown_report, format_text_report, AnalyzeConfig,
 };
 use fbuild_core::{FbuildError, Result};
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_symbols(
     input: String,
     map: Option<String>,
     nm: Option<String>,
     cppfilt: Option<String>,
+    build_info: Option<String>,
     json_out: Option<String>,
     output_dir: Option<String>,
     top: usize,
@@ -32,25 +44,24 @@ pub fn run_symbols(
 
     let elf_path = resolve_elf(&input_path)?;
 
-    let nm_path = match nm {
-        Some(p) => PathBuf::from(p),
-        None => find_nm_on_path()?,
-    };
+    let tool_paths = ToolPaths::resolve(
+        &elf_path,
+        nm.as_deref(),
+        cppfilt.as_deref(),
+        build_info.as_deref(),
+    )?;
+    let nm_path = tool_paths.nm;
+    let cppfilt_path = tool_paths.cppfilt;
     if !nm_path.exists() {
         return Err(FbuildError::BuildFailed(format!(
-            "nm not found at {}",
+            "nm not found at {}\n\
+             Resolution searched: --nm flag → --build-info → \
+             build_info.json near ELF → PATH.\n\
+             Pass --nm explicitly to point at a cross-toolchain nm,\n\
+             or run `fbuild build` first so build_info.json carries nm_path.",
             nm_path.display()
         )));
     }
-
-    let cppfilt_path = cppfilt.map(PathBuf::from).or_else(|| {
-        let derived = derive_cppfilt_path(&nm_path);
-        if derived.exists() {
-            Some(derived)
-        } else {
-            None
-        }
-    });
 
     let map_path_owned = map
         .map(PathBuf::from)
@@ -164,4 +175,171 @@ fn find_nm_on_path() -> Result<PathBuf> {
     Err(FbuildError::BuildFailed(format!(
         "{exe_name} not found on PATH; pass --nm to point at a cross toolchain nm"
     )))
+}
+
+/// Resolved toolchain paths for the symbol analyzer.
+struct ToolPaths {
+    nm: PathBuf,
+    cppfilt: Option<PathBuf>,
+}
+
+impl ToolPaths {
+    /// Resolve `nm` / `c++filt` using the precedence documented in the
+    /// module header. `build_info_arg` is the explicit `--build-info`
+    /// path; when absent, walk up from `elf_path`.
+    fn resolve(
+        elf_path: &Path,
+        nm: Option<&str>,
+        cppfilt: Option<&str>,
+        build_info_arg: Option<&str>,
+    ) -> Result<Self> {
+        // Try the build_info source (explicit flag wins over auto-discovery).
+        let build_info_path = build_info_arg
+            .map(PathBuf::from)
+            .or_else(|| elf_path.parent().and_then(find_build_info_near));
+
+        let (bi_nm, bi_cppfilt) = match build_info_path {
+            Some(path) => match load_build_info(&path) {
+                Ok((_env, info)) => {
+                    tracing::info!("symbols: read toolchain paths from {}", path.display());
+                    (option_path(&info.nm_path), option_path(&info.cppfilt_path))
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "symbols: ignoring {}: {} (falling back to PATH)",
+                        path.display(),
+                        e
+                    );
+                    (None, None)
+                }
+            },
+            None => (None, None),
+        };
+
+        let nm = match nm {
+            Some(p) => PathBuf::from(p),
+            None => match bi_nm {
+                Some(p) => p,
+                None => find_nm_on_path()?,
+            },
+        };
+
+        let cppfilt = match cppfilt {
+            Some(p) => Some(PathBuf::from(p)),
+            None => bi_cppfilt.or_else(|| {
+                let derived = derive_cppfilt_path(&nm);
+                if derived.exists() {
+                    Some(derived)
+                } else {
+                    None
+                }
+            }),
+        };
+
+        Ok(Self { nm, cppfilt })
+    }
+}
+
+/// Treat an empty BuildInfo string field (the schema's "missing"
+/// sentinel) as `None`.
+fn option_path(s: &str) -> Option<PathBuf> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fbuild_build::build_info::{emit_build_info, BuildInfo};
+
+    fn dummy_build_info(nm: &str, cppfilt: &str) -> BuildInfo {
+        // size_path drives the four derived tool paths; pretend size has
+        // a name that won't match anything on disk so derivation alone
+        // doesn't fool the test — we explicitly override nm/cppfilt below.
+        let mut info = BuildInfo::new(
+            Path::new("/build/firmware.elf"),
+            Some(Path::new("/bin/gcc")),
+            Some(Path::new("/bin/g++")),
+            None,
+            None,
+            Path::new("/bin/size"),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            "test".to_string(),
+            "test".to_string(),
+            "test".to_string(),
+        );
+        info.nm_path = nm.to_string();
+        info.cppfilt_path = cppfilt.to_string();
+        info
+    }
+
+    /// #428: when `build_info.json` lives near the ELF and carries
+    /// `nm_path`, the symbols CLI must pick it up automatically.
+    #[test]
+    fn resolve_reads_nm_from_build_info_auto_discovery() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path();
+        let build_dir = project.join(".fbuild").join("build").join("uno");
+        std::fs::create_dir_all(&build_dir).unwrap();
+        let elf = build_dir.join("firmware.elf");
+        std::fs::write(&elf, b"\x7fELF").unwrap();
+
+        // We point nm_path at a file that actually exists on disk so the
+        // resolver doesn't later trip the existence check.
+        let nm_file = project.join("fake-nm");
+        std::fs::write(&nm_file, b"#!/bin/false\n").unwrap();
+        let info = dummy_build_info(&nm_file.to_string_lossy(), "");
+        emit_build_info(project, "uno", &info).unwrap();
+
+        let tools = ToolPaths::resolve(&elf, None, None, None).unwrap();
+        assert_eq!(tools.nm, nm_file);
+    }
+
+    /// Explicit `--nm` overrides whatever build_info.json says.
+    #[test]
+    fn resolve_explicit_nm_wins_over_build_info() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path();
+        let elf = project.join("firmware.elf");
+        std::fs::write(&elf, b"\x7fELF").unwrap();
+
+        // build_info points at one nm…
+        let bi_nm = project.join("from-buildinfo");
+        std::fs::write(&bi_nm, b"x").unwrap();
+        let info = dummy_build_info(&bi_nm.to_string_lossy(), "");
+        emit_build_info(project, "uno", &info).unwrap();
+
+        // …user overrides with --nm pointing at a different one.
+        let cli_nm = project.join("from-cli");
+        std::fs::write(&cli_nm, b"x").unwrap();
+
+        let tools = ToolPaths::resolve(&elf, Some(cli_nm.to_str().unwrap()), None, None).unwrap();
+        assert_eq!(tools.nm, cli_nm);
+    }
+
+    /// `--build-info <path>` is honoured even when the ELF isn't under
+    /// the project containing build_info.json.
+    #[test]
+    fn resolve_explicit_build_info_path_is_honoured() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let elf = tmp.path().join("firmware.elf");
+        std::fs::write(&elf, b"\x7fELF").unwrap();
+
+        let bi_dir = tmp.path().join("elsewhere");
+        std::fs::create_dir_all(&bi_dir).unwrap();
+        let nm_file = bi_dir.join("nm-from-explicit");
+        std::fs::write(&nm_file, b"x").unwrap();
+        let info = dummy_build_info(&nm_file.to_string_lossy(), "");
+        emit_build_info(&bi_dir, "uno", &info).unwrap();
+
+        let bi_path = bi_dir.join("build_info.json");
+        let tools = ToolPaths::resolve(&elf, None, None, Some(bi_path.to_str().unwrap())).unwrap();
+        assert_eq!(tools.nm, nm_file);
+    }
 }

--- a/crates/fbuild-core/src/symbol_analysis/mod.rs
+++ b/crates/fbuild-core/src/symbol_analysis/mod.rs
@@ -690,6 +690,5 @@ fn sym_type_for_synth(output_section: &str) -> char {
     }
 }
 
-
 #[cfg(test)]
 mod tests;

--- a/crates/fbuild-core/src/symbol_analysis/tests.rs
+++ b/crates/fbuild-core/src/symbol_analysis/tests.rs
@@ -19,9 +19,8 @@ fn parse_nm_line_skips_unsized() {
 
 #[test]
 fn extract_archive_from_pio_path() {
-    let (arc, obj) = extract_archive_and_object(
-        ".pio/build/esp32s3/lib0d9/libFastLED.a(fl.channels+.cpp.o)",
-    );
+    let (arc, obj) =
+        extract_archive_and_object(".pio/build/esp32s3/lib0d9/libFastLED.a(fl.channels+.cpp.o)");
     assert_eq!(arc.as_deref(), Some("libFastLED.a"));
     assert_eq!(obj, "fl.channels+.cpp.o");
 }

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -28,6 +28,7 @@ For a full FAQ-style index of every doc in this repo (human + LLM entry point), 
 - **[BOARD_STATUS.md](BOARD_STATUS.md)** - Per-platform CI badges and supported boards
 - **[DEVELOPMENT.md](DEVELOPMENT.md)** - Testing, troubleshooting, local setup
 - **[CI_CACHE.md](CI_CACHE.md)** - Consumer-facing cross-run CI cache strategy
+- **[symbols.md](symbols.md)** - `fbuild symbols` per-symbol bloat analysis (toolchain auto-resolve from build_info.json, #428)
 - **[DESIGN_DECISIONS.md](DESIGN_DECISIONS.md)** - ADR-style decisions with rationale
 - **[ROADMAP.md](ROADMAP.md)** - Implementation phases
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - Index of all architecture documents

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -1,0 +1,126 @@
+# `fbuild symbols` — per-symbol bloat analysis
+
+`fbuild symbols` produces a fine-grained, attributed report of every
+live symbol in an ELF: name, size, region (`flash` / `ram`), source
+archive, object file, and output section. It's the same analysis the
+build orchestrator emits when you pass `--symbol-analysis` to
+`fbuild build`, but as a standalone subcommand that works against any
+ELF — fbuild-built, PlatformIO-built, or hand-compiled.
+
+## TL;DR
+
+Point it at a project directory:
+
+```bash
+fbuild symbols .
+```
+
+Or at an ELF directly:
+
+```bash
+fbuild symbols .fbuild/build/uno/firmware.elf
+fbuild symbols .pio/build/esp32s3/firmware.elf
+```
+
+No `--nm`. No `--cppfilt`. No manual ELF / map paths. Toolchain paths
+come from the `build_info.json` fbuild (or PlatformIO) wrote next to
+the ELF.
+
+## Where toolchain paths come from
+
+The analyzer needs four binaries: `nm` (lists symbol sizes), `c++filt`
+(demangles C++ names), and optionally `readelf` / `objdump` for
+downstream tools. These are looked up in this order:
+
+1. **`--nm <path>` / `--cppfilt <path>` flags** (highest precedence;
+   the user's explicit override always wins).
+2. **`--build-info <path>`** — load `nm_path` / `cppfilt_path` from
+   that file.
+3. **Auto-discovery** — walk up from the ELF's directory looking for
+   `build_info.json` or `build_info_<env>.json`. Both fbuild and
+   PlatformIO write one next to `platformio.ini`.
+4. **PATH lookup** of bare `nm` (and derive `c++filt` from its stem).
+5. Hard error with a message pointing at all four sources.
+
+`fbuild build` populates the `nm_path`, `cppfilt_path`, `readelf_path`,
+and `objdump_path` fields (and a PIO-shape `aliases` block mirroring
+them) in `build_info_<env>.json` so step 3 just works.
+
+## Example: fbuild-built ESP32-S3
+
+```bash
+$ fbuild build .
+# … link succeeds, writes .fbuild/build/esp32s3/firmware.elf +
+# build_info.json with toolchain paths …
+
+$ fbuild symbols .
+# resolves ELF via discover_elf_in_project()
+# resolves nm/c++filt via build_info.json
+# emits text report to stdout
+```
+
+Pass `--output-dir <dir>` to drop both `report.json` and `report.md`
+into the directory side-by-side. Pass `--json <path>` for JSON only.
+
+## Example: PlatformIO-built ESP32-S3
+
+PlatformIO emits its own `build_info_<env>.json` (with an `aliases`
+block) next to `platformio.ini`. `fbuild symbols .pio/build/esp32s3/firmware.elf`
+walks up from `.pio/build/esp32s3/` to the project root, finds it, and
+reads the toolchain paths from there. No `--nm` needed.
+
+## When auto-discovery falls back to PATH
+
+- The ELF isn't under a project that contains a `build_info.json`
+  (e.g. you copied just the ELF into `/tmp`).
+- The `build_info.json` is older than the schema this fbuild expects
+  (`nm_path` field missing).
+
+In both cases the analyzer falls back to bare `nm` on `PATH`, which
+works only for host ELFs. For cross-toolchain ELFs, pass `--nm` or
+`--build-info` explicitly.
+
+## Schema: the `aliases` block
+
+`build_info.json` carries a top-level `aliases` block keyed by short
+PIO tool names so PlatformIO consumers (FastLED
+`ci/util/symbol_analysis.py`, `ci/inspect_binary.py`, etc.) can read
+both PIO- and fbuild-built artifacts uniformly:
+
+```json
+{
+  "esp32s3": {
+    "prog_path": "...",
+    "cc_path":   "/.../xtensa-esp32s3-elf-gcc",
+    "cxx_path":  "/.../xtensa-esp32s3-elf-g++",
+    "size_path": "/.../xtensa-esp32s3-elf-size",
+    "nm_path":   "/.../xtensa-esp32s3-elf-nm",
+    "cppfilt_path": "/.../xtensa-esp32s3-elf-c++filt",
+    "readelf_path": "/.../xtensa-esp32s3-elf-readelf",
+    "objdump_path": "/.../xtensa-esp32s3-elf-objdump",
+    "aliases": {
+      "gcc":      "/.../xtensa-esp32s3-elf-gcc",
+      "g++":      "/.../xtensa-esp32s3-elf-g++",
+      "size":     "/.../xtensa-esp32s3-elf-size",
+      "nm":       "/.../xtensa-esp32s3-elf-nm",
+      "c++filt":  "/.../xtensa-esp32s3-elf-c++filt",
+      "readelf":  "/.../xtensa-esp32s3-elf-readelf",
+      "objdump":  "/.../xtensa-esp32s3-elf-objdump",
+      "ar":       "/.../xtensa-esp32s3-elf-ar",
+      "objcopy":  "/.../xtensa-esp32s3-elf-objcopy"
+    }
+  }
+}
+```
+
+Alias keys are only present when the corresponding path is non-empty;
+consumers can rely on `"nm" in aliases` meaning the path is real.
+
+## Related
+
+- Issue [#428](https://github.com/FastLED/fbuild/issues/428) —
+  toolchain-path schema and CLI auto-discovery (this doc).
+- Issue [#434](https://github.com/FastLED/fbuild/issues/434) — the
+  `fbuild bloat` meta that subsumes `symbols`.
+- PR [#424] / PR [#427] — the fine-grained analyzer and map-derived
+  rodata attribution this CLI drives.


### PR DESCRIPTION
## Summary

Closes #428 (Phase 1 of #434).

- Extends `BuildInfo` with `nm_path` / `cppfilt_path` / `readelf_path` / `objdump_path` plus a PIO-shape `aliases` block that mirrors them onto short keys (`nm`, `c++filt`, etc.). PlatformIO consumers (FastLED `ci/util/symbol_analysis.py`, `ci/inspect_binary.py`) keep working drop-in against fbuild-built artifacts.
- Derives the four paths centrally in `BuildInfo::new` from `size_path` using the GCC cross-tool naming convention (`<prefix>-size` → `<prefix>-{nm,c++filt,readelf,objdump}`). All of fbuild's existing orchestrators (AVR, ESP32, RP2040, STM32, Teensy, ESP8266, NRF52, SAM, Renesas, Apollo3, LPC, Silabs, CH32V) ship GCC cross-toolchains, so no orchestrator surgery is needed.
- Teaches `fbuild symbols` to auto-locate `build_info.json` by walking up from the ELF directory; adds a `--build-info <path>` explicit override. New resolution order:
  1. `--nm` / `--cppfilt` CLI flags (user wins).
  2. `--build-info <path>` if provided.
  3. Auto-discovery: walk up from ELF dir for `build_info.json` or `build_info_<env>.json`.
  4. PATH lookup of bare `nm`, with `c++filt` derived by stem.
  5. Hard error with a message pointing at all four sources.
- Common case becomes flag-less:
  ```
  fbuild symbols .fbuild/build/uno/firmware.elf
  fbuild symbols .pio/build/esp32s3/firmware.elf
  ```
- Adds `docs/symbols.md` walking through the resolution order, the `aliases` schema, and PIO/fbuild interop.

## Test plan

- [x] `soldr cargo check --workspace --all-targets` ✅
- [x] `soldr cargo clippy -p fbuild-build -p fbuild-cli --all-targets -- -D warnings` ✅
- [x] `soldr cargo test -p fbuild-build --lib` — 627 passed, 0 failed
- [x] `soldr cargo test -p fbuild-cli --bin fbuild` — 25 passed, 0 failed
- New tests:
  - `derive_gcc_tool_path_avr_prefix` / `xtensa_with_exe_suffix` / `bare_size_falls_back` — derivation rules
  - `build_info_populates_new_toolchain_fields` — the four new fields land
  - `build_info_aliases_block_mirrors_paths` — PIO-shape mirror
  - `build_info_aliases_omit_empty_optional_tools` — ESP8266 (no ar/objcopy) keeps consumers safe with `key in aliases`
  - `emit_writes_aliases_into_json` — round-trip via JSON
  - `find_build_info_walks_up_from_elf_dir` / `prefers_env_specific` / `returns_none_when_absent` — discovery walker
  - `load_build_info_unwraps_single_env` — single-env outer object contract
  - `resolve_reads_nm_from_build_info_auto_discovery` — CLI resolver: build_info auto-pickup
  - `resolve_explicit_nm_wins_over_build_info` — CLI resolver: explicit override precedence
  - `resolve_explicit_build_info_path_is_honoured` — CLI resolver: `--build-info` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)