### PR TITLE
feat(bloat): rename `fbuild symbols` to `fbuild bloat`

### DIFF
--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -64,42 +64,48 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Fine-grained per-symbol bloat analysis of an ELF or project.
+    /// Fine-grained per-symbol bloat analysis of a project or ELF.
     ///
-    /// `<input>` may be either an ELF file or a project directory; when
-    /// a directory is given, `fbuild symbols` walks `build_info.json`
-    /// first then `.fbuild/build/**/firmware.elf`, `.pio/build/**/firmware.elf`
-    /// and finally any `*.elf` directly inside the directory.
+    /// Aligns with `cargo bloat` and Google's `bloaty` — the de-facto
+    /// names for per-symbol size analysis. The legacy spelling
+    /// `fbuild symbols` keeps working as a hidden alias through 2.3.x.
+    ///
+    /// `<input>` may be a project directory (preferred) or an ELF file
+    /// directly. When a directory is given, fbuild walks
+    /// `build_info.json` first then `.fbuild/build/**/firmware.elf`,
+    /// `.pio/build/**/firmware.elf`, and any `*.elf` directly inside.
     ///
     /// Runs `nm --print-size --size-sort -S` on the ELF, demangles via
-    /// `c++filt`, parses the alongside linker map (auto-detected as
-    /// `<elf-stem>.map` or `firmware.map`), and emits a table that
-    /// attributes each live symbol to its source archive + object +
+    /// `c++filt`, parses the alongside linker map, and emits a table
+    /// attributing each live symbol to its source archive + object +
     /// output section. Map-derived rows for anonymous rodata pools
     /// (`.rodata.<owner>.str1.<N>` etc.) are tagged
     /// `source: "map-derived"`.
+    ///
+    /// Toolchain paths come from the same `build_info.json` that
+    /// `fbuild build` emits — no `--nm` flag needed for the common
+    /// case (see #428).
     ///
     /// Outputs:
     ///   * default: text report to stdout
     ///   * `--json <path>`: structured JSON only
     ///   * `--output-dir <dir>`: BOTH `report.json` (machine) and
     ///     `report.md` (human, GitHub-friendly tables) side by side
-    Symbols {
-        /// ELF file OR project directory.
+    #[command(alias = "symbols")]
+    Bloat {
+        /// Project directory (preferred) or ELF file.
         input: String,
         /// Path to the linker map (auto-detected if omitted).
-        #[arg(long)]
+        #[arg(long, hide = true)]
         map: Option<String>,
-        /// Path to `nm` (highest precedence; pass the cross-tool, e.g.
-        /// `xtensa-esp32s3-elf-nm`). When omitted, fbuild reads
-        /// `nm_path` from `build_info.json` (auto-located near the ELF
-        /// or via `--build-info`), then falls back to PATH lookup.
-        #[arg(long)]
+        /// Override for `nm` (highest precedence). Normally read from
+        /// `build_info.json`; pass this only when working against an
+        /// out-of-band ELF whose project has no build_info.
+        #[arg(long, hide = true)]
         nm: Option<String>,
-        /// Path to `c++filt` (highest precedence). When omitted, fbuild
-        /// reads `cppfilt_path` from `build_info.json`, then derives it
-        /// from the resolved nm path.
-        #[arg(long = "cppfilt")]
+        /// Override for `c++filt` (highest precedence). Normally read
+        /// from `build_info.json` or derived from `nm`.
+        #[arg(long = "cppfilt", hide = true)]
         cppfilt: Option<String>,
         /// Path to a `build_info.json` (or `build_info_<env>.json`) that
         /// carries toolchain paths. When omitted, fbuild walks up from

--- a/crates/fbuild-cli/src/cli/bloat_cmd.rs
+++ b/crates/fbuild-cli/src/cli/bloat_cmd.rs
@@ -1,8 +1,12 @@
-//! `fbuild symbols` — standalone fine-grained per-symbol bloat report.
+//! `fbuild bloat` — standalone fine-grained per-symbol bloat report.
 //!
-//! Accepts either an ELF or a project directory; runs the same
-//! analysis the build orchestrator's `--symbol-analysis` flag emits,
-//! but on any ELF the user points at — including one built by
+//! Aligns with `cargo bloat` / Google's `bloaty` for vocabulary. The
+//! legacy CLI spelling `fbuild symbols` is still accepted via clap
+//! alias for back-compat through 2.3.x.
+//!
+//! Accepts either a project directory (preferred) or an ELF; runs the
+//! same analysis the build orchestrator's `--symbol-analysis` flag
+//! emits, but on any ELF the user points at — including one built by
 //! PlatformIO or another out-of-band tool.
 //!
 //! Toolchain resolution (see #428):
@@ -24,7 +28,7 @@ use fbuild_build::symbol_analyzer::{
 use fbuild_core::{FbuildError, Result};
 
 #[allow(clippy::too_many_arguments)]
-pub fn run_symbols(
+pub fn run_bloat(
     input: String,
     map: Option<String>,
     nm: Option<String>,

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use crate::{daemon_client, lib_select, mcp};
 
 use super::args::{resolve_project_dir, rewrite_args, Cli, Commands};
+use super::bloat_cmd::run_bloat;
 use super::build::run_build;
 use super::clang_tools::{run_clang_tool, run_iwyu};
 use super::compile_many::{
@@ -20,7 +21,6 @@ use super::pio::{pio_build, pio_deploy, pio_monitor};
 use super::purge::{run_purge, run_purge_gc};
 use super::reset::run_reset;
 use super::show::run_show;
-use super::symbols_cmd::run_symbols;
 
 pub async fn async_main() {
     let cli = Cli::parse_from(rewrite_args());
@@ -56,7 +56,7 @@ pub async fn async_main() {
     let top_level_project_dir = cli.project_dir.clone();
 
     let result = match cli.command {
-        Some(Commands::Symbols {
+        Some(Commands::Bloat {
             input,
             map,
             nm,
@@ -65,7 +65,7 @@ pub async fn async_main() {
             json,
             output_dir,
             top,
-        }) => run_symbols(input, map, nm, cppfilt, build_info, json, output_dir, top),
+        }) => run_bloat(input, map, nm, cppfilt, build_info, json, output_dir, top),
         Some(Commands::Build {
             project_dir,
             environment,

--- a/crates/fbuild-cli/src/cli/mod.rs
+++ b/crates/fbuild-cli/src/cli/mod.rs
@@ -23,7 +23,7 @@ pub mod pio;
 pub mod purge;
 pub mod reset;
 pub mod show;
-pub mod symbols_cmd;
+pub mod bloat_cmd;
 
 #[cfg(test)]
 mod tests;

--- a/crates/fbuild-cli/src/cli/tests.rs
+++ b/crates/fbuild-cli/src/cli/tests.rs
@@ -157,3 +157,26 @@ fn compile_many_diag_stage2_flag_is_accepted() {
         _ => panic!("expected CompileMany subcommand"),
     }
 }
+
+/// #438: `fbuild bloat .` parses as the new canonical name.
+#[test]
+fn bloat_command_parses() {
+    let argv = ["fbuild", "bloat", "."];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Bloat { input, .. }) => assert_eq!(input, "."),
+        _ => panic!("expected Bloat subcommand"),
+    }
+}
+
+/// #438: `fbuild symbols .` still works through the clap alias for
+/// back-compat. Deprecation lands in 2.4.0.
+#[test]
+fn symbols_alias_still_parses_as_bloat() {
+    let argv = ["fbuild", "symbols", "."];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Bloat { input, .. }) => assert_eq!(input, "."),
+        _ => panic!("expected Bloat subcommand (via `symbols` alias)"),
+    }
+}

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -28,7 +28,7 @@ For a full FAQ-style index of every doc in this repo (human + LLM entry point), 
 - **[BOARD_STATUS.md](BOARD_STATUS.md)** - Per-platform CI badges and supported boards
 - **[DEVELOPMENT.md](DEVELOPMENT.md)** - Testing, troubleshooting, local setup
 - **[CI_CACHE.md](CI_CACHE.md)** - Consumer-facing cross-run CI cache strategy
-- **[symbols.md](symbols.md)** - `fbuild symbols` per-symbol bloat analysis (toolchain auto-resolve from build_info.json, #428)
+- **[bloat.md](bloat.md)** - `fbuild bloat` per-symbol bloat analysis (renamed from `symbols` in #438, toolchain auto-resolve from build_info.json #428)
 - **[DESIGN_DECISIONS.md](DESIGN_DECISIONS.md)** - ADR-style decisions with rationale
 - **[ROADMAP.md](ROADMAP.md)** - Implementation phases
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - Index of all architecture documents

--- a/docs/bloat.md
+++ b/docs/bloat.md
@@ -1,25 +1,29 @@
-# `fbuild symbols` — per-symbol bloat analysis
+# `fbuild bloat` — per-symbol bloat analysis
 
-`fbuild symbols` produces a fine-grained, attributed report of every
+`fbuild bloat` produces a fine-grained, attributed report of every
 live symbol in an ELF: name, size, region (`flash` / `ram`), source
 archive, object file, and output section. It's the same analysis the
 build orchestrator emits when you pass `--symbol-analysis` to
 `fbuild build`, but as a standalone subcommand that works against any
 ELF — fbuild-built, PlatformIO-built, or hand-compiled.
 
+> **Note:** the legacy spelling `fbuild symbols` is still accepted as
+> a hidden alias for back-compat through 2.3.x. Deprecation warning
+> lands in 2.4.0; alias removal in 3.0.
+
 ## TL;DR
 
 Point it at a project directory:
 
 ```bash
-fbuild symbols .
+fbuild bloat .
 ```
 
 Or at an ELF directly:
 
 ```bash
-fbuild symbols .fbuild/build/uno/firmware.elf
-fbuild symbols .pio/build/esp32s3/firmware.elf
+fbuild bloat .fbuild/build/uno/firmware.elf
+fbuild bloat .pio/build/esp32s3/firmware.elf
 ```
 
 No `--nm`. No `--cppfilt`. No manual ELF / map paths. Toolchain paths
@@ -53,7 +57,7 @@ $ fbuild build .
 # … link succeeds, writes .fbuild/build/esp32s3/firmware.elf +
 # build_info.json with toolchain paths …
 
-$ fbuild symbols .
+$ fbuild bloat .
 # resolves ELF via discover_elf_in_project()
 # resolves nm/c++filt via build_info.json
 # emits text report to stdout
@@ -65,7 +69,7 @@ into the directory side-by-side. Pass `--json <path>` for JSON only.
 ## Example: PlatformIO-built ESP32-S3
 
 PlatformIO emits its own `build_info_<env>.json` (with an `aliases`
-block) next to `platformio.ini`. `fbuild symbols .pio/build/esp32s3/firmware.elf`
+block) next to `platformio.ini`. `fbuild bloat .pio/build/esp32s3/firmware.elf`
 walks up from `.pio/build/esp32s3/` to the project root, finds it, and
 reads the toolchain paths from there. No `--nm` needed.
 


### PR DESCRIPTION
## Summary

Closes #438 (Phase 2 of #434). **Stacked on top of #436** — please merge that first.

- Renames `Commands::Symbols` → `Commands::Bloat`. Adds clap `alias = "symbols"` so the legacy spelling still parses to the same handler.
- Renames `symbols_cmd.rs` → `bloat_cmd.rs`, `run_symbols` → `run_bloat`.
- Marks `--nm`, `--cppfilt`, `--map` with `#[arg(hide = true)]`. They keep working as overrides for advanced use, but the public surface is now just `<input>`, `--build-info`, `--json`, `--output-dir`, `--top`.
- Renames `docs/symbols.md` → `docs/bloat.md`; updates `docs/CLAUDE.md` index entry.
- Adds two parser tests: `bloat_command_parses` (canonical spelling) and `symbols_alias_still_parses_as_bloat` (back-compat).

The `symbol_analysis` flag on `fbuild build` is **not** renamed in this PR — that's Phase 5 (#441) which turns it into `--bloat`.

## Test plan

- [x] `soldr cargo check -p fbuild-cli --all-targets` ✅
- [x] `soldr cargo clippy -p fbuild-cli --all-targets -- -D warnings` ✅
- [x] `soldr cargo test -p fbuild-cli --bin fbuild` — 27 passed (was 25 + 2 new alias tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)