### PR TITLE
feat(build): default-on post-link bloat report

### DIFF
--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -207,6 +207,15 @@ pub enum Commands {
         /// Export build artifacts to a tooling-friendly directory
         #[arg(long)]
         output_dir: Option<String>,
+        /// Skip the default post-link bloat report
+        /// (`<project>/.fbuild/build/<env>/bloat-report/`).
+        ///
+        /// `fbuild build` runs the fine-grained bloat analyzer by
+        /// default and writes `report.json` + `report.md` alongside
+        /// the ELF — pass this flag in CI matrices where the extra
+        /// artefacts would blow up download size. See #441.
+        #[arg(long = "no-bloat-report")]
+        no_bloat_report: bool,
     },
     /// Deploy firmware to device
     Deploy {

--- a/crates/fbuild-cli/src/cli/build.rs
+++ b/crates/fbuild-cli/src/cli/build.rs
@@ -37,6 +37,7 @@ pub async fn run_build(
     symbol_analysis: Option<String>,
     no_timestamp: bool,
     output_dir: Option<String>,
+    no_bloat_report: bool,
 ) -> fbuild_core::Result<()> {
     // FBUILD_PERF_LOG=1 enables coarse CLI-side timing (daemon handshake +
     // round-trip). Zero-overhead when unset.
@@ -134,7 +135,40 @@ pub async fn run_build(
             println!("compile_commands.json written to {}", db_path.display());
         }
     }
+
+    // #441: auto-run the fine-grained bloat analyzer post-link unless
+    // opted out. compiledb-only runs don't produce an ELF, so skip
+    // there. An explicit `--bloat <path>` (i.e. `symbol_analysis`
+    // set to a non-empty path) is the legacy daemon-side spelling
+    // — leave it to the daemon and don't double up.
+    let explicit_bloat_path = req
+        .symbol_analysis_path
+        .as_deref()
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    if !no_bloat_report && !generate_compiledb && !explicit_bloat_path {
+        if let Err(e) = run_post_build_bloat(&project_dir) {
+            // Don't fail the build just because the report failed.
+            eprintln!("warning: post-build bloat report failed: {e}");
+        }
+    }
     Ok(())
+}
+
+/// Run the fine-grained bloat analyzer against the just-built
+/// project, writing the default `<project>/.fbuild/build/<env>/bloat-report/`
+/// pair. Errors are non-fatal — the build itself already succeeded.
+fn run_post_build_bloat(project_dir: &str) -> fbuild_core::Result<()> {
+    super::bloat_cmd::run_bloat(
+        project_dir.to_string(),
+        None, // map
+        None, // nm
+        None, // cppfilt
+        None, // build-info (auto-discover)
+        None, // json (use default output dir)
+        None, // output-dir (use default)
+        25,   // top
+    )
 }
 
 /// Convert MSYS/Git-Bash paths (/c/Users/...) to native Windows paths and canonicalize.

--- a/crates/fbuild-cli/src/cli/clang_tools.rs
+++ b/crates/fbuild-cli/src/cli/clang_tools.rs
@@ -48,6 +48,7 @@ pub async fn run_iwyu(
             None,
             true, // no_timestamp: compiledb generation doesn't need timestamps
             None,
+            true, // no_bloat_report: compiledb-only run produces no ELF
         )
         .await?;
         if !db_path.exists() {
@@ -472,6 +473,7 @@ pub async fn run_clang_tool(
         None,
         true, // no_timestamp: compiledb generation doesn't need timestamps
         None,
+        true, // no_bloat_report: compiledb-only run produces no ELF
     )
     .await?;
 

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -96,6 +96,7 @@ pub async fn async_main() {
             symbol_analysis,
             no_timestamp,
             output_dir,
+            no_bloat_report,
         }) => {
             let project_dir = resolve_project_dir(project_dir, &top_level_project_dir);
             if platformio {
@@ -114,6 +115,7 @@ pub async fn async_main() {
                     symbol_analysis,
                     no_timestamp,
                     output_dir,
+                    no_bloat_report,
                 )
                 .await
             }

--- a/crates/fbuild-cli/src/cli/tests.rs
+++ b/crates/fbuild-cli/src/cli/tests.rs
@@ -216,6 +216,34 @@ fn build_symbol_analysis_alias_still_accepted() {
     }
 }
 
+/// #441: `fbuild build` defaults `no_bloat_report` to false — the
+/// CLI auto-runs the bloat analyzer post-link.
+#[test]
+fn build_no_bloat_report_defaults_to_false() {
+    let argv = ["fbuild", "build", "."];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Build {
+            no_bloat_report, ..
+        }) => assert!(!no_bloat_report),
+        _ => panic!("expected Build subcommand"),
+    }
+}
+
+/// #441: `--no-bloat-report` opts out of the default post-link bloat
+/// report (for CI matrices where artifact size matters).
+#[test]
+fn build_no_bloat_report_flag_is_accepted() {
+    let argv = ["fbuild", "build", "--no-bloat-report", "."];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Build {
+            no_bloat_report, ..
+        }) => assert!(no_bloat_report),
+        _ => panic!("expected Build subcommand"),
+    }
+}
+
 /// #440: `fbuild bloat-diff <a> <b>` parses two positional inputs
 /// with the default region (`flash`) implicit.
 #[test]


### PR DESCRIPTION
## Summary

Closes #441 (Phase 5 of #434). **Stacked on top of #446 → #445 → #443 → #436.** Merge those first.

`fbuild build` now runs the fine-grained bloat analyzer automatically after a successful link and writes both `report.json` and `report.md` to `<project>/.fbuild/build/<env>/bloat-report/`. Pass `--no-bloat-report` to skip — useful in CI matrices where the extra artifacts would blow up download size.

### Behaviour

- Default `fbuild build .` → emits `bloat-report/{report.json,report.md}` + the bloat summary on stdout.
- `fbuild build --no-bloat-report .` → skips the post-link analyzer.
- `fbuild build --bloat <path> .` → respects the explicit path (legacy daemon-side spelling, #439); does not double-up.
- `fbuild build -t compiledb .` → no ELF produced, no bloat report.
- Bloat-analyzer failures are **non-fatal** — the build itself already succeeded; we don't want a missing nm to flip a green build red.

### Implementation

CLI-side hook in `run_build`: after the daemon returns success, call `bloat_cmd::run_bloat` against the project dir with all-defaults. Reuses the full toolchain auto-resolution from #428 + #438 + #439, so zero extra wiring per platform.

## Test plan

- [x] `soldr cargo check -p fbuild-cli --all-targets` ✅
- [x] `soldr cargo clippy -p fbuild-cli --all-targets -- -D warnings` ✅
- [x] `soldr cargo test -p fbuild-cli --bin fbuild` — 43 passed (was 41 + 2 new)

New tests:
- `build_no_bloat_report_defaults_to_false` — flag defaults match the documented behaviour
- `build_no_bloat_report_flag_is_accepted` — opt-out parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)