### PR TITLE
ci(lint-subprocess): use --no-project so uv run skips fbuild install

### DIFF
--- a/.github/workflows/lint-subprocess.yml
+++ b/.github/workflows/lint-subprocess.yml
@@ -24,5 +24,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
+      # `--no-project` is load-bearing: without it, `uv run` triggers an
+      # editable install of the `fbuild` package, whose build backend
+      # requires a globally-installed `soldr` (see `setup.py` /
+      # `build_backend.py`). This workflow does not install soldr — it
+      # is a stdlib-only Python lint, not a Rust build — so the install
+      # fails with `ERROR: 'soldr' is required to build fbuild from
+      # source`. The script itself carries a PEP 723 header declaring
+      # only `requires-python = ">=3.10"` and no third-party deps, so
+      # skipping project sync is safe.
       - name: Check no unannotated direct Command::new spawns
-        run: uv run python ci/find_direct_subprocess.py --fail
+        run: uv run --no-project python ci/find_direct_subprocess.py --fail


### PR DESCRIPTION
## Summary

The `Lint subprocess spawns` workflow has been failing on every PR with:

> ERROR: \`soldr\` is required to build fbuild from source.

Root cause: `uv run python ci/find_direct_subprocess.py --fail` triggers an editable install of the `fbuild` package, but the build backend requires a globally-installed `soldr` (see `setup.py` / `build_backend.py`). This workflow is a stdlib-only Python lint, not a Rust build — it never installs soldr.

The script itself carries a PEP 723 header declaring only `requires-python = ">=3.10"` and no third-party deps, so skipping the project sync is safe. Adding `--no-project` to the `uv run` invocation does exactly that.

Failure manifested in #450's CI (now merged, but the workflow was still broken on main):
- https://github.com/FastLED/fbuild/actions/runs/27073056391/job/79905582077?pr=450

## Test plan

- [x] Reproduced the failure mode locally: `uv run python ci/find_direct_subprocess.py --fail` → same `soldr` error against the post-merge main.
- [x] `uv run --no-project python ci/find_direct_subprocess.py --fail` → exits 0, prints the existing allowlisted hold-outs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)