### PR TITLE
fix(ci): drop unsupported `continue-on-error` from LPC8xx workflows

### DIFF
--- a/.github/workflows/build-lpc804.yml
+++ b/.github/workflows/build-lpc804.yml
@@ -3,9 +3,15 @@ name: Build LPC804
 # Stage 1 of FastLED/FastLED#2836: build/toolchain wiring lands now, the
 # actual Stage-2 LPC8xx orchestrator lands in a follow-up FastLED-side PR.
 # Until Stage 2 lands, this workflow's `fbuild build` step fails fast with
-# a "Stage 2 required" error. `continue-on-error: true` keeps the overall
-# check status non-blocking on `main` while still surfacing red runs on the
-# Actions tab. Remove `continue-on-error` once Stage 2 lands.
+# a "Stage 2 required" error.
+#
+# This workflow stays out of branch protection's required-checks list, so
+# a red run here doesn't block merges on `main`. The previous attempt used
+# `continue-on-error: true` on the calling job, but that keyword is NOT in
+# the allow-list for jobs that call a reusable workflow — every push to
+# main went red with "workflow file issue" before any job actually ran.
+# See:
+# https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow
 
 on:
   workflow_dispatch: {}
@@ -16,7 +22,6 @@ on:
 
 jobs:
   build:
-    continue-on-error: true
     uses: ./.github/workflows/template_build.yml
     with:
       workflow-name: "NXP LPC804"

--- a/.github/workflows/build-lpc845.yml
+++ b/.github/workflows/build-lpc845.yml
@@ -3,9 +3,15 @@ name: Build LPC845
 # Stage 1 of FastLED/FastLED#2836: build/toolchain wiring lands now, the
 # actual Stage-2 LPC8xx orchestrator lands in a follow-up FastLED-side PR.
 # Until Stage 2 lands, this workflow's `fbuild build` step fails fast with
-# a "Stage 2 required" error. `continue-on-error: true` keeps the overall
-# check status non-blocking on `main` while still surfacing red runs on the
-# Actions tab. Remove `continue-on-error` once Stage 2 lands.
+# a "Stage 2 required" error.
+#
+# This workflow stays out of branch protection's required-checks list, so
+# a red run here doesn't block merges on `main`. The previous attempt used
+# `continue-on-error: true` on the calling job, but that keyword is NOT in
+# the allow-list for jobs that call a reusable workflow — every push to
+# main went red with "workflow file issue" before any job actually ran.
+# See:
+# https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow
 
 on:
   workflow_dispatch: {}
@@ -16,7 +22,6 @@ on:
 
 jobs:
   build:
-    continue-on-error: true
     uses: ./.github/workflows/template_build.yml
     with:
       workflow-name: "NXP LPC845"


### PR DESCRIPTION
## Summary

Fixes the [push run](https://github.com/FastLED/fbuild/actions/runs/27073787763) and the 30/30 prior failures on `build-lpc804.yml` + `build-lpc845.yml`. Both workflows set `continue-on-error: true` on a job that calls a reusable workflow (`uses: ./.github/workflows/template_build.yml`).

That keyword is **not in the allow-list** for jobs that call a reusable workflow — see [supported keywords for reusable-workflow caller jobs](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow). Every push to main went red with \"workflow file issue\" before any job actually ran.

### What changed

Drop the unsupported `continue-on-error: true` line from both workflows. The remaining YAML is structurally identical to the working `build-esp32c6.yml` sibling.

The original intent — \"non-blocking on `main`\" — is preserved by **not** adding these workflows to branch protection's required-checks list. The inline comment is updated to call that out so the next visitor doesn't reach for `continue-on-error` again.

## Test plan

- [x] Diff is +18/−8: dropped `continue-on-error: true` from both files; expanded the inline comment to point at the allow-list.
- [x] No other build-*.yml file uses `continue-on-error` (`grep -lE \"continue-on-error\" .github/workflows/build-*.yml` returns just these two before this PR).
- [ ] CI on this PR will trigger both `build-lpc804.yml` and `build-lpc845.yml`; the workflow-parse failure should be gone (jobs may still red later when they hit the Stage 2 \"required\" error — that's expected pre-Stage-2 behaviour and is not blocked from merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflows with improved documentation explaining build stage handling and failure behaviors.
  * Modified build job configuration to properly propagate build failures instead of suppressing them, ensuring more reliable build result reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->