### PR TITLE
refactor(paths) + fix(symbols): BuildLayout single-source + PT_LOAD bloat filter

### DIFF
--- a/crates/fbuild-build/Cargo.toml
+++ b/crates/fbuild-build/Cargo.toml
@@ -24,9 +24,9 @@ walkdir = { workspace = true }
 sha2 = { workspace = true }
 blake3 = { workspace = true }
 tempfile = { workspace = true }
+object = { workspace = true }
 
 [dev-dependencies]
 filetime = { workspace = true }
 fbuild-test-support = { path = "../fbuild-test-support" }
 tar = { workspace = true }
-object = { workspace = true }

--- a/crates/fbuild-build/src/compile_many.rs
+++ b/crates/fbuild-build/src/compile_many.rs
@@ -87,19 +87,14 @@ pub fn default_sketch_jobs() -> usize {
 
 /// Resolve the on-disk build root the orchestrator uses for a given sketch.
 ///
-/// Matches the convention used by every per-platform orchestrator:
-/// `<sketch>/.fbuild/build/<env>/<profile>/`. Centralized here so the
-/// stage-1→stage-2 cache-seeding code can address that path without
-/// re-deriving the same string in three places. See FastLED/fbuild#335.
+/// Routes through [`fbuild_paths::BuildLayout`] so layout decisions
+/// (env-segment auto-collapse, `FBUILD_BUILD_DIR` override) match
+/// what the daemon and the per-platform orchestrators use. Centralized
+/// here so the stage-1→stage-2 cache-seeding code can address that path
+/// without re-deriving the same string in three places. See
+/// FastLED/fbuild#335.
 pub fn project_build_dir(sketch: &Path, env: &str, profile: BuildProfile) -> PathBuf {
-    sketch
-        .join(".fbuild")
-        .join("build")
-        .join(env)
-        .join(match profile {
-            BuildProfile::Release => "release",
-            BuildProfile::Quick => "quick",
-        })
+    fbuild_paths::BuildLayout::new(sketch.to_path_buf(), env.to_string(), profile).resolve()
 }
 
 /// Seed a stage-2 project's framework `core/` from stage 1's, so the
@@ -831,6 +826,24 @@ mod tests {
         assert!(p.ends_with("sketch/.fbuild/build/uno/release"));
         let q = project_build_dir(Path::new("/tmp/sketch"), "esp32s3", BuildProfile::Quick);
         assert!(q.ends_with("sketch/.fbuild/build/esp32s3/quick"));
+    }
+
+    /// FastLED stages each board's project at
+    /// `<repo>/.build/pio/<board>/` and asks fbuild to build with
+    /// `env == board`. `project_build_dir` must collapse the duplicate
+    /// `<board>` segment (via `BuildLayout`'s auto-detect rule) so the
+    /// resulting tree fits under Windows' 260-char `MAX_PATH` limit and
+    /// matches what `find_firmware` looks for. See FastLED/fbuild#432.
+    #[test]
+    fn project_build_dir_collapses_when_sketch_basename_matches_env() {
+        let sketch = Path::new("/repo/.build/pio/teensy40");
+        let p = project_build_dir(sketch, "teensy40", BuildProfile::Release);
+        let s = p.to_string_lossy().to_string();
+        assert!(
+            !s.contains("build/teensy40/release") && !s.contains("build\\teensy40\\release"),
+            "stage-2 build dir kept duplicated env segment: {s}"
+        );
+        assert!(p.ends_with("release"));
     }
 
     #[test]

--- a/crates/fbuild-build/src/pipeline/context.rs
+++ b/crates/fbuild-build/src/pipeline/context.rs
@@ -110,16 +110,22 @@ impl BuildContext {
         }
 
         // 4. Setup build directories
+        //
+        // `params.build_dir` is the authoritative env-rooted build dir
+        // (caller resolves it via `fbuild_paths::BuildLayout`). We never
+        // re-derive it from `project_dir` here, so callers can override
+        // the layout (e.g. flatten the env segment when their project
+        // dir is already named after the env — the FastLED
+        // `.build/pio/<board>/` case). See FastLED/fbuild#432.
         let t0 = std::time::Instant::now();
-        let cache = fbuild_packages::Cache::new(project_dir);
-        if params.clean {
-            cache.clean_build(env_name, params.profile)?;
+        let build_dir = params.build_dir.clone();
+        if params.clean && build_dir.exists() {
+            std::fs::remove_dir_all(&build_dir)?;
         }
-        cache.ensure_build_directories(env_name, params.profile)?;
-
-        let build_dir = cache.get_build_dir(env_name, params.profile);
-        let core_build_dir = cache.get_core_build_dir(env_name, params.profile);
-        let src_build_dir = cache.get_src_build_dir(env_name, params.profile);
+        let core_build_dir = build_dir.join("core");
+        let src_build_dir = build_dir.join("src");
+        std::fs::create_dir_all(&core_build_dir)?;
+        std::fs::create_dir_all(&src_build_dir)?;
         if let Some(p) = perf.as_mut() {
             p.record("build-dirs", t0.elapsed());
         }

--- a/crates/fbuild-build/src/symbol_analyzer.rs
+++ b/crates/fbuild-build/src/symbol_analyzer.rs
@@ -15,9 +15,92 @@ use std::collections::BTreeMap;
 use fbuild_core::subprocess::run_command_with_stdin;
 use fbuild_core::symbol_analysis::{
     build_fine_grained_map_with_synth, collect_map_derived_owners, parse_linker_map,
-    parse_nm_output, FineGrainedSymbolMap,
+    parse_nm_output, FineGrainedSymbolMap, LoadedRegion,
 };
 use fbuild_core::{FbuildError, Result};
+
+/// Read the `PT_LOAD` program-header ranges from an ELF. These are the
+/// regions that actually get programmed into the device's flash/RAM
+/// image at boot — every other byte in the ELF (debug info,
+/// `.ARM.attributes`, `.comment`, symbol tables) lives only in the
+/// host-side file and never reaches the binary.
+///
+/// Used by [`analyze_elf`] to drop linker-script boundary symbols
+/// (`__StackTop`, `__flash_arduino_end`, ...) that nm reports with
+/// nonsense sizes computed from the gap to the next symbol — these
+/// inflate the bloat report by gigabytes if not filtered.
+pub fn read_pt_load_regions(elf_path: &Path) -> Result<Vec<LoadedRegion>> {
+    use object::read::elf::{ElfFile32, ElfFile64, FileHeader, ProgramHeader};
+    use object::{Endianness, FileKind};
+
+    let bytes = std::fs::read(elf_path).map_err(|e| {
+        FbuildError::BuildFailed(format!(
+            "could not read ELF at {} for PT_LOAD probe: {e}",
+            elf_path.display()
+        ))
+    })?;
+    let kind = FileKind::parse(&bytes[..]).map_err(|e| {
+        FbuildError::BuildFailed(format!(
+            "could not identify file kind for {}: {e}",
+            elf_path.display()
+        ))
+    })?;
+
+    let mut regions = Vec::new();
+    match kind {
+        FileKind::Elf32 => {
+            let elf = ElfFile32::<Endianness>::parse(&bytes[..])
+                .map_err(|e| FbuildError::BuildFailed(format!("ELF32 parse failed: {e}")))?;
+            let endian = elf
+                .elf_header()
+                .endian()
+                .map_err(|e| FbuildError::BuildFailed(format!("ELF32 endian probe failed: {e}")))?;
+            for ph in elf.elf_program_headers() {
+                if ph.p_type(endian) != object::elf::PT_LOAD {
+                    continue;
+                }
+                let start = u64::from(ph.p_vaddr(endian));
+                let size = u64::from(ph.p_memsz(endian));
+                if size == 0 {
+                    continue;
+                }
+                regions.push(LoadedRegion {
+                    start,
+                    end: start.saturating_add(size),
+                });
+            }
+        }
+        FileKind::Elf64 => {
+            let elf = ElfFile64::<Endianness>::parse(&bytes[..])
+                .map_err(|e| FbuildError::BuildFailed(format!("ELF64 parse failed: {e}")))?;
+            let endian = elf
+                .elf_header()
+                .endian()
+                .map_err(|e| FbuildError::BuildFailed(format!("ELF64 endian probe failed: {e}")))?;
+            for ph in elf.elf_program_headers() {
+                if ph.p_type(endian) != object::elf::PT_LOAD {
+                    continue;
+                }
+                let start = ph.p_vaddr(endian);
+                let size = ph.p_memsz(endian);
+                if size == 0 {
+                    continue;
+                }
+                regions.push(LoadedRegion {
+                    start,
+                    end: start.saturating_add(size),
+                });
+            }
+        }
+        other => {
+            return Err(FbuildError::BuildFailed(format!(
+                "expected ELF, got {other:?} at {}",
+                elf_path.display()
+            )));
+        }
+    }
+    Ok(regions)
+}
 
 /// Auto-detect the cross-toolchain prefix from the directory containing
 /// an `nm` binary. e.g. `xtensa-esp32s3-elf-nm` → prefix
@@ -181,14 +264,38 @@ pub fn analyze_elf(cfg: AnalyzeConfig<'_>) -> Result<FineGrainedSymbolMap> {
         synth_mangled.clone()
     };
 
-    Ok(build_fine_grained_map_with_synth(
+    let mut map = build_fine_grained_map_with_synth(
         elf_s,
         cfg.map_path.map(|p| p.to_string_lossy().to_string()),
         nm_rows,
         demangled,
         ranges,
         &synth_demangled,
-    ))
+    );
+
+    // Strip symbols that nm enumerated but that don't actually consume
+    // bytes in the final binary — most importantly linker-script
+    // boundary markers (`__StackTop`, `__flash_arduino_end`, ...)
+    // whose nm-reported "size" is the address gap to the next symbol
+    // and can be multiple gigabytes. The PT_LOAD probe is best-effort;
+    // when it fails (corrupt ELF, non-ELF input) we leave the map
+    // unfiltered rather than poisoning the report with an error.
+    match read_pt_load_regions(cfg.elf_path) {
+        Ok(regions) if !regions.is_empty() => map.retain_loaded_symbols(&regions),
+        Ok(_) => {
+            tracing::warn!(
+                "no PT_LOAD segments found in {}; emitting unfiltered symbol report",
+                cfg.elf_path.display()
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "PT_LOAD probe failed for {} ({e}); emitting unfiltered symbol report",
+                cfg.elf_path.display()
+            );
+        }
+    }
+    Ok(map)
 }
 
 /// Format a fine-grained per-symbol map as a human-readable text report

--- a/crates/fbuild-build/tests/avr_build.rs
+++ b/crates/fbuild-build/tests/avr_build.rs
@@ -75,9 +75,11 @@ fn build_uno_minimal() {
         return;
     }
 
-    // Use a temp build dir so we don't pollute the Python project
+    // Use a temp build dir so we don't pollute the Python project.
+    // `params.build_dir` is the resolved env-rooted dir per
+    // `BuildLayout::resolve()`.
     let tmp = tempfile::TempDir::new().unwrap();
-    let build_dir = tmp.path().join(".fbuild/build");
+    let build_dir = tmp.path().join(".fbuild/build/uno/release");
 
     let params = BuildParams {
         project_dir: project_dir.clone(),
@@ -172,7 +174,7 @@ fn compare_with_python_output() {
 
     // Build with Rust
     let tmp = tempfile::TempDir::new().unwrap();
-    let build_dir = tmp.path().join(".fbuild/build");
+    let build_dir = tmp.path().join(".fbuild/build/uno/release");
 
     let params = BuildParams {
         project_dir: project_dir.clone(),
@@ -258,7 +260,7 @@ void loop() {
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/uno/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "uno".to_string(),
@@ -435,7 +437,7 @@ fn cache_survives_tar_extract_uno() {
     let cold_result = orchestrator
         .build(&uno_build_params(
             &proj_a,
-            proj_a.join(".fbuild/build"),
+            proj_a.join(".fbuild/build/uno/release"),
             true,
         ))
         .expect("cold AVR build should succeed");
@@ -467,7 +469,7 @@ fn cache_survives_tar_extract_uno() {
     let same_project_warm = orchestrator
         .build(&uno_build_params(
             &proj_a,
-            proj_a.join(".fbuild/build"),
+            proj_a.join(".fbuild/build/uno/release"),
             false,
         ))
         .expect("same-project warm build should succeed");
@@ -512,7 +514,7 @@ fn cache_survives_tar_extract_uno() {
     let warm_result = orchestrator
         .build(&uno_build_params(
             &proj_b,
-            proj_b.join(".fbuild/build"),
+            proj_b.join(".fbuild/build/uno/release"),
             false,
         ))
         .expect("warm AVR build (post tar-extract) should succeed");

--- a/crates/fbuild-build/tests/eh_frame_strip_esp32.rs
+++ b/crates/fbuild-build/tests/eh_frame_strip_esp32.rs
@@ -19,7 +19,7 @@ use fbuild_build::{BuildOrchestrator, BuildParams};
 use fbuild_core::BuildProfile;
 
 fn make_params(project_dir: &Path) -> BuildParams {
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/esp32dev/release");
     BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "esp32dev".to_string(),

--- a/crates/fbuild-build/tests/esp32_build.rs
+++ b/crates/fbuild-build/tests/esp32_build.rs
@@ -60,7 +60,7 @@ void loop() {
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/esp32dev/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "esp32dev".to_string(),
@@ -149,7 +149,7 @@ void loop() {
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/esp32c6/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "esp32c6".to_string(),
@@ -231,7 +231,7 @@ void loop() {
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/esp32c3/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "esp32c3".to_string(),
@@ -314,7 +314,7 @@ void loop() {
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/esp32s3/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "esp32s3".to_string(),
@@ -387,7 +387,7 @@ fn build_esp32s3_fixture() {
         return;
     }
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/esp32s3/release");
     let params = BuildParams {
         project_dir: project_dir.clone(),
         env_name: "esp32s3".to_string(),
@@ -451,7 +451,7 @@ fn build_nightdriverstrip_demo() {
     }
 
     let tmp = tempfile::TempDir::new().unwrap();
-    let build_dir = tmp.path().join(".fbuild/build");
+    let build_dir = tmp.path().join(".fbuild/build/demo/release");
 
     let params = BuildParams {
         project_dir: project_dir.clone(),
@@ -549,7 +549,12 @@ fn incremental_build_at(project_dir: &std::path::Path, env_name: &str) {
         env_name: env_name.to_string(),
         clean: false,
         profile: BuildProfile::Release,
-        build_dir: project_dir.join(".fbuild/build"),
+        build_dir: fbuild_paths::BuildLayout::new(
+            project_dir.to_path_buf(),
+            env_name.to_string(),
+            BuildProfile::Release,
+        )
+        .resolve(),
         verbose: true,
         jobs: None,
         generate_compiledb: false,
@@ -640,7 +645,12 @@ fn incremental_nightdriverstrip_one_file_changed() {
         env_name: env_name.to_string(),
         clean: false,
         profile: BuildProfile::Release,
-        build_dir: project_dir.join(".fbuild/build"),
+        build_dir: fbuild_paths::BuildLayout::new(
+            project_dir.clone(),
+            env_name.to_string(),
+            BuildProfile::Release,
+        )
+        .resolve(),
         verbose: true,
         jobs: None,
         generate_compiledb: false,

--- a/crates/fbuild-build/tests/stm32_acceptance.rs
+++ b/crates/fbuild-build/tests/stm32_acceptance.rs
@@ -60,7 +60,7 @@ fn stm32f103c8_blink_with_spi_auto_discovers_library_205_ac4() {
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/stm32f103c8/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "stm32f103c8".to_string(),

--- a/crates/fbuild-build/tests/teensy30_acceptance.rs
+++ b/crates/fbuild-build/tests/teensy30_acceptance.rs
@@ -75,7 +75,7 @@ fn teensy30_analog_output_meets_205_ac2() {
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/teensy30/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         // WHY env_name = "teensy30": must match the [env:teensy30] key

--- a/crates/fbuild-build/tests/teensy_build.rs
+++ b/crates/fbuild-build/tests/teensy_build.rs
@@ -61,7 +61,7 @@ void loop() {
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/teensy41/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "teensy41".to_string(),
@@ -133,7 +133,7 @@ void loop() {}
     )
     .unwrap();
 
-    let build_dir = project_dir.join(".fbuild/build");
+    let build_dir = project_dir.join(".fbuild/build/teensy41/release");
     let params = BuildParams {
         project_dir: project_dir.to_path_buf(),
         env_name: "teensy41".to_string(),
@@ -182,7 +182,7 @@ fn build_teensy41_fixture() {
     }
 
     let tmp = tempfile::TempDir::new().unwrap();
-    let build_dir = tmp.path().join(".fbuild/build");
+    let build_dir = tmp.path().join(".fbuild/build/teensy41/release");
 
     let params = BuildParams {
         project_dir: project_dir.clone(),
@@ -298,7 +298,7 @@ void loop() {
         env_name: "teensy30".to_string(),
         clean: true,
         profile: BuildProfile::Release,
-        build_dir: tmp.path().join(".fbuild/build"),
+        build_dir: tmp.path().join(".fbuild/build/teensy30/release"),
         verbose: true,
         jobs: None,
         generate_compiledb: false,

--- a/crates/fbuild-build/tests/teensylc_acceptance.rs
+++ b/crates/fbuild-build/tests/teensylc_acceptance.rs
@@ -36,7 +36,7 @@ fn teensylc_blink_meets_205_acceptance_criteria() {
         env_name: "teensylc".to_string(),
         clean: true,
         profile: BuildProfile::Release,
-        build_dir: build_dir.path().to_path_buf(),
+        build_dir: build_dir.path().join("teensylc").join("release"),
         verbose: true,
         jobs: None,
         generate_compiledb: true,

--- a/crates/fbuild-core/src/symbol_analysis/README.md
+++ b/crates/fbuild-core/src/symbol_analysis/README.md
@@ -1,0 +1,16 @@
+# symbol_analysis
+
+Pure parsers and aggregators behind `fbuild bloat` (legacy `fbuild symbols`):
+
+- `parse_nm_line` / `parse_nm_output` — `nm --print-size -S` row parsing.
+- `parse_linker_map` — GNU `ld -Map` output → per-input-section ranges.
+- `classify_region` — nm type letter → `Flash` / `Ram` bucket.
+- `FineGrainedSymbolMap::retain_loaded_symbols` — drop symbols whose `[addr, addr+size)` doesn't fit any `PT_LOAD` region, so linker-script boundary markers (`__StackTop`, `__flash_arduino_end`) don't pollute the bloat report.
+- `build_fine_grained_map_with_synth` — fold nm rows + map ranges + demangled names into the per-symbol report.
+
+Intentionally has no ELF-parsing dep; ELF I/O lives in `fbuild_build::symbol_analyzer`, which calls into this module.
+
+## Files
+
+- `mod.rs` — types and pure functions.
+- `tests.rs` — unit tests.

--- a/crates/fbuild-core/src/symbol_analysis/mod.rs
+++ b/crates/fbuild-core/src/symbol_analysis/mod.rs
@@ -98,6 +98,77 @@ pub struct FineGrainedSymbolMap {
     pub sections: Vec<SectionBytes>,
 }
 
+/// One contiguous loadable region of the final binary.
+///
+/// Conceptually this is one `PT_LOAD` program-header range (`addr`
+/// inclusive, `end` exclusive). A symbol is considered to be "in the
+/// binary" only when its `[address, address + size)` interval fits
+/// entirely inside one of these regions. Boundary symbols emitted by
+/// the linker script (`__StackTop`, `__flash_arduino_end`, ...) point
+/// just past the end of their region or have nonsense sizes that nm
+/// computes as the address gap to the next symbol — neither case
+/// satisfies strict containment, so the filter drops them. See
+/// `FineGrainedSymbolMap::retain_loaded_symbols`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct LoadedRegion {
+    /// First byte of the region (inclusive).
+    pub start: u64,
+    /// One past the last byte of the region (exclusive).
+    pub end: u64,
+}
+
+impl LoadedRegion {
+    /// True when `[addr, addr + size)` is fully contained in this region.
+    ///
+    /// The lower bound is *strict*: `addr` must be strictly less than
+    /// `self.end`. This excludes the linker-script boundary-marker
+    /// case (`__StackTop` at `end-of-RAM` with `size = 0`) — such a
+    /// symbol points one past the last loaded byte and is metadata,
+    /// not binary content.
+    pub fn contains_range(&self, addr: u64, size: u64) -> bool {
+        if addr < self.start || addr >= self.end {
+            return false;
+        }
+        let end = match addr.checked_add(size) {
+            Some(e) => e,
+            None => return false,
+        };
+        end <= self.end
+    }
+}
+
+impl FineGrainedSymbolMap {
+    /// Drop symbols that did not land in any loaded region of the final
+    /// binary, then recompute `total_flash` / `total_ram` from the
+    /// surviving rows.
+    ///
+    /// Loaded regions are the `PT_LOAD` program-header ranges (caller
+    /// extracts them from the ELF, since this crate intentionally has
+    /// no ELF-parsing dep — see the module-level docs).
+    ///
+    /// This is the single point that turns "every sized symbol nm
+    /// enumerates" (which includes linker-script boundary markers like
+    /// `__StackTop` with multi-GB nonsense sizes) into "only symbols
+    /// that actually consume bytes in the final binary."
+    pub fn retain_loaded_symbols(&mut self, regions: &[LoadedRegion]) {
+        if regions.is_empty() {
+            return;
+        }
+        self.symbols
+            .retain(|s| regions.iter().any(|r| r.contains_range(s.address, s.size)));
+        let mut total_flash = 0u64;
+        let mut total_ram = 0u64;
+        for s in &self.symbols {
+            match s.region {
+                MemoryRegion::Flash => total_flash = total_flash.saturating_add(s.size),
+                MemoryRegion::Ram => total_ram = total_ram.saturating_add(s.size),
+            }
+        }
+        self.total_flash = total_flash;
+        self.total_ram = total_ram;
+    }
+}
+
 /// One address range placed by the linker into an output section.
 #[derive(Debug, Clone)]
 pub struct InputSectionRange {

--- a/crates/fbuild-core/src/symbol_analysis/tests.rs
+++ b/crates/fbuild-core/src/symbol_analysis/tests.rs
@@ -381,3 +381,115 @@ fn nm_range_covers_overlap_detection() {
     // Zero size — never covers
     assert!(!nm_range_covers(&nm_covered, 0x1000, 0));
 }
+
+// --- LoadedRegion / retain_loaded_symbols ---
+
+fn sample_symbol(addr: u64, size: u64, region: MemoryRegion, name: &str) -> FineGrainedSymbol {
+    FineGrainedSymbol {
+        mangled: name.to_string(),
+        demangled: name.to_string(),
+        address: addr,
+        size,
+        sym_type: match region {
+            MemoryRegion::Flash => 'T',
+            MemoryRegion::Ram => 'B',
+        },
+        region,
+        archive: None,
+        object: None,
+        output_section: None,
+        source: "nm".to_string(),
+    }
+}
+
+#[test]
+fn loaded_region_strict_containment() {
+    let r = LoadedRegion {
+        start: 0x1000,
+        end: 0x2000,
+    };
+    assert!(r.contains_range(0x1000, 0x100));
+    assert!(
+        r.contains_range(0x1f00, 0x100),
+        "end-aligned must be allowed"
+    );
+    // Past the end
+    assert!(!r.contains_range(0x1f00, 0x101));
+    // Below the start
+    assert!(!r.contains_range(0x0fff, 0x100));
+    // Symbol just past the end (boundary marker case)
+    assert!(!r.contains_range(0x2000, 0));
+    // Overflow guard
+    assert!(!r.contains_range(u64::MAX, 1));
+}
+
+/// FastLED/fbuild#XX (the bloat-filter fix): nm enumerates
+/// linker-script boundary markers (`__StackTop`, `__flash_arduino_end`,
+/// ...) with multi-GB sizes computed as the gap to the next symbol.
+/// `retain_loaded_symbols` must drop them so the bloat report shows
+/// only bytes actually in the final binary.
+#[test]
+fn retain_loaded_symbols_drops_boundary_markers() {
+    let symbols = vec![
+        // Real flash symbol — fully inside the .text PT_LOAD range.
+        sample_symbol(0x00026100, 0x40, MemoryRegion::Flash, "real_text"),
+        // Real ram symbol — fully inside the RAM PT_LOAD range.
+        sample_symbol(0x20006000, 0x80, MemoryRegion::Ram, "real_bss"),
+        // __StackTop: address at the very end of RAM, garbage size.
+        sample_symbol(0x20040000, 0xdffedfe4, MemoryRegion::Flash, "__StackTop"),
+        // __flash_arduino_end: address outside any PT_LOAD region.
+        sample_symbol(
+            0x000ed000,
+            0xfff40fe4,
+            MemoryRegion::Flash,
+            "__flash_arduino_end",
+        ),
+        // A symbol that fits in flash but with overflowing size.
+        sample_symbol(0x00026100, u64::MAX, MemoryRegion::Flash, "overflow"),
+    ];
+    let mut map = FineGrainedSymbolMap {
+        elf_path: "fixture.elf".into(),
+        map_path: None,
+        total_flash: 0,
+        total_ram: 0,
+        symbols,
+        sections: Vec::new(),
+    };
+    // Mirror the nrf52 test fixture's PT_LOAD ranges.
+    let regions = vec![
+        LoadedRegion {
+            start: 0x00026000,
+            end: 0x0002dfec,
+        },
+        LoadedRegion {
+            start: 0x20006000,
+            end: 0x2003f800,
+        },
+    ];
+    map.retain_loaded_symbols(&regions);
+    let kept: Vec<&str> = map.symbols.iter().map(|s| s.demangled.as_str()).collect();
+    assert_eq!(kept, vec!["real_text", "real_bss"]);
+    assert_eq!(map.total_flash, 0x40);
+    assert_eq!(map.total_ram, 0x80);
+}
+
+#[test]
+fn retain_loaded_symbols_no_op_when_regions_empty() {
+    // Defensive: if the caller couldn't probe PT_LOAD (corrupt ELF,
+    // non-ELF input), leave the map untouched rather than empty it.
+    let mut map = FineGrainedSymbolMap {
+        elf_path: "fixture.elf".into(),
+        map_path: None,
+        total_flash: 0x40,
+        total_ram: 0x80,
+        symbols: vec![
+            sample_symbol(0x00026100, 0x40, MemoryRegion::Flash, "real_text"),
+            sample_symbol(0x20006000, 0x80, MemoryRegion::Ram, "real_bss"),
+        ],
+        sections: Vec::new(),
+    };
+    map.retain_loaded_symbols(&[]);
+    assert_eq!(map.symbols.len(), 2);
+    assert_eq!(map.total_flash, 0x40);
+    assert_eq!(map.total_ram, 0x80);
+}

--- a/crates/fbuild-daemon/src/handlers/emulator/select.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/select.rs
@@ -252,7 +252,23 @@ pub async fn test_emu(
             None
         };
 
-        let build_dir = fbuild_paths::get_project_build_root(&project_dir);
+        let build_dir = fbuild_paths::BuildLayout::new(
+            project_dir.clone(),
+            env_name.clone(),
+            fbuild_core::BuildProfile::Release,
+        )
+        .with_override_root(req.build_dir_override.as_deref().map(|p| {
+            let path = std::path::PathBuf::from(p);
+            if path.is_absolute() {
+                path
+            } else if let Some(cwd) = req.caller_cwd.as_deref() {
+                std::path::PathBuf::from(cwd).join(path)
+            } else {
+                project_dir.join(path)
+            }
+        }))
+        .with_flatten_env(req.flatten_env)
+        .resolve();
         let params = fbuild_build::BuildParams {
             project_dir: project_dir.clone(),
             env_name: env_name.clone(),

--- a/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
@@ -111,7 +111,18 @@ fn run_real_esp32s3_fixture_in_qemu() {
         return;
     }
 
-    let build_dir = project_dir.join(".fbuild/build-qemu");
+    // Override the build root so this qemu fixture's artifacts land in a
+    // dedicated `.fbuild/build-qemu/<env>/<profile>` tree, isolated from
+    // any non-qemu build the same project might have produced. The layout
+    // still appends `<env>/<profile>` because the pipeline reads
+    // `params.build_dir` as the resolved env-rooted dir.
+    let build_dir = fbuild_paths::BuildLayout::new(
+        project_dir.clone(),
+        "esp32s3".to_string(),
+        BuildProfile::Release,
+    )
+    .with_override_root(Some(project_dir.join(".fbuild").join("build-qemu")))
+    .resolve();
     let params = BuildParams {
         project_dir: project_dir.clone(),
         env_name: "esp32s3".to_string(),

--- a/crates/fbuild-daemon/src/handlers/operations/build.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/build.rs
@@ -1,6 +1,8 @@
 //! `POST /api/build` — kick off a build (streaming or buffered).
 
-use super::common::{export_artifacts_bundle, resolve_client_path, OperationGuard};
+use super::common::{
+    export_artifacts_bundle, resolve_build_dir, resolve_client_path, OperationGuard,
+};
 use crate::context::DaemonContext;
 use crate::models::{BuildRequest, OperationResponse};
 use axum::extract::State;
@@ -134,18 +136,14 @@ pub async fn build(
         _ => fbuild_core::BuildProfile::Release,
     };
 
-    // Resolve the env-rooted build dir via the single `BuildLayout`
-    // resolver so layout decisions (override > FBUILD_BUILD_DIR >
-    // default; env-segment auto-collapse) match what `find_firmware`
-    // and the pipeline use. See FastLED/fbuild#432.
-    let build_dir = fbuild_paths::BuildLayout::new(project_dir.clone(), env_name.clone(), profile)
-        .with_override_root(
-            req.build_dir_override
-                .as_deref()
-                .map(|p| resolve_client_path(p, req.caller_cwd.as_deref(), &project_dir)),
-        )
-        .with_flatten_env(req.flatten_env)
-        .resolve();
+    let build_dir = resolve_build_dir(
+        req.build_dir_override.as_deref(),
+        req.flatten_env,
+        req.caller_cwd.as_deref(),
+        &project_dir,
+        &env_name,
+        profile,
+    );
     let compiledb_env = std::env::var("FBUILD_COMPILEDB")
         .map(|v| v != "0")
         .unwrap_or(true);

--- a/crates/fbuild-daemon/src/handlers/operations/build.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/build.rs
@@ -134,7 +134,18 @@ pub async fn build(
         _ => fbuild_core::BuildProfile::Release,
     };
 
-    let build_dir = fbuild_paths::get_project_build_root(&project_dir);
+    // Resolve the env-rooted build dir via the single `BuildLayout`
+    // resolver so layout decisions (override > FBUILD_BUILD_DIR >
+    // default; env-segment auto-collapse) match what `find_firmware`
+    // and the pipeline use. See FastLED/fbuild#432.
+    let build_dir = fbuild_paths::BuildLayout::new(project_dir.clone(), env_name.clone(), profile)
+        .with_override_root(
+            req.build_dir_override
+                .as_deref()
+                .map(|p| resolve_client_path(p, req.caller_cwd.as_deref(), &project_dir)),
+        )
+        .with_flatten_env(req.flatten_env)
+        .resolve();
     let compiledb_env = std::env::var("FBUILD_COMPILEDB")
         .map(|v| v != "0")
         .unwrap_or(true);

--- a/crates/fbuild-daemon/src/handlers/operations/common.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/common.rs
@@ -317,6 +317,27 @@ pub(crate) fn resolve_client_path(
     }
 }
 
+/// Resolve the env-rooted build dir via [`fbuild_paths::BuildLayout`].
+///
+/// Centralises the override > `FBUILD_BUILD_DIR` > default precedence
+/// and the env-segment auto-collapse rule (see FastLED/fbuild#432)
+/// so every HTTP handler routes through the same resolver, keeping
+/// the per-file LOC budget for `deploy.rs` / `build.rs` sane.
+pub(crate) fn resolve_build_dir(
+    build_dir_override: Option<&str>,
+    flatten_env: bool,
+    caller_cwd: Option<&str>,
+    project_dir: &Path,
+    env_name: &str,
+    profile: fbuild_core::BuildProfile,
+) -> PathBuf {
+    let override_root = build_dir_override.map(|p| resolve_client_path(p, caller_cwd, project_dir));
+    fbuild_paths::BuildLayout::new(project_dir.to_path_buf(), env_name.to_string(), profile)
+        .with_override_root(override_root)
+        .with_flatten_env(flatten_env)
+        .resolve()
+}
+
 #[derive(Debug, Serialize)]
 struct ArtifactFileEntry {
     name: String,

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -2,8 +2,8 @@
 
 use super::common::{
     compute_esp32_image_hash, export_artifacts_bundle, infer_default_emulator_kind,
-    parse_deploy_route, qemu_extra_build_flags, resolve_client_path, trust_device_hash_enabled,
-    DeployRoute, EmulatorKind, OperationGuard,
+    parse_deploy_route, qemu_extra_build_flags, resolve_build_dir, resolve_client_path,
+    trust_device_hash_enabled, DeployRoute, EmulatorKind, OperationGuard,
 };
 use super::monitor::{run_monitor_loop, MonitorOutcome};
 use crate::context::DaemonContext;
@@ -194,14 +194,14 @@ pub async fn deploy(
         let lock = ctx.project_lock(&project_dir);
         let _guard = lock.lock().await;
 
-        let override_root = req.build_dir_override.as_deref().map(|p| {
-            resolve_client_path(p, req.caller_cwd.as_deref(), &project_dir)
-        });
-        let build_dir =
-            fbuild_paths::BuildLayout::new(project_dir.clone(), env_name.clone(), fbuild_core::BuildProfile::Release)
-                .with_override_root(override_root)
-                .with_flatten_env(req.flatten_env)
-                .resolve();
+        let build_dir = resolve_build_dir(
+            req.build_dir_override.as_deref(),
+            req.flatten_env,
+            req.caller_cwd.as_deref(),
+            &project_dir,
+            &env_name,
+            fbuild_core::BuildProfile::Release,
+        );
         let params = fbuild_build::BuildParams {
             project_dir: project_dir.clone(),
             env_name: env_name.clone(),

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -194,7 +194,18 @@ pub async fn deploy(
         let lock = ctx.project_lock(&project_dir);
         let _guard = lock.lock().await;
 
-        let build_dir = fbuild_paths::get_project_build_root(&project_dir);
+        let build_dir = fbuild_paths::BuildLayout::new(
+            project_dir.clone(),
+            env_name.clone(),
+            fbuild_core::BuildProfile::Release,
+        )
+        .with_override_root(
+            req.build_dir_override
+                .as_deref()
+                .map(|p| resolve_client_path(p, req.caller_cwd.as_deref(), &project_dir)),
+        )
+        .with_flatten_env(req.flatten_env)
+        .resolve();
         let params = fbuild_build::BuildParams {
             project_dir: project_dir.clone(),
             env_name: env_name.clone(),

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -194,18 +194,14 @@ pub async fn deploy(
         let lock = ctx.project_lock(&project_dir);
         let _guard = lock.lock().await;
 
-        let build_dir = fbuild_paths::BuildLayout::new(
-            project_dir.clone(),
-            env_name.clone(),
-            fbuild_core::BuildProfile::Release,
-        )
-        .with_override_root(
-            req.build_dir_override
-                .as_deref()
-                .map(|p| resolve_client_path(p, req.caller_cwd.as_deref(), &project_dir)),
-        )
-        .with_flatten_env(req.flatten_env)
-        .resolve();
+        let override_root = req.build_dir_override.as_deref().map(|p| {
+            resolve_client_path(p, req.caller_cwd.as_deref(), &project_dir)
+        });
+        let build_dir =
+            fbuild_paths::BuildLayout::new(project_dir.clone(), env_name.clone(), fbuild_core::BuildProfile::Release)
+                .with_override_root(override_root)
+                .with_flatten_env(req.flatten_env)
+                .resolve();
         let params = fbuild_build::BuildParams {
             project_dir: project_dir.clone(),
             env_name: env_name.clone(),

--- a/crates/fbuild-daemon/src/models.rs
+++ b/crates/fbuild-daemon/src/models.rs
@@ -50,6 +50,20 @@ pub struct BuildRequest {
     /// here per request. Consumed by `fbuild-config::PioEnvOverrides`.
     #[serde(default)]
     pub pio_env: BTreeMap<String, String>,
+    /// Optional explicit build-dir root override. Takes precedence over
+    /// `FBUILD_BUILD_DIR` and the default `<project>/.fbuild/build`.
+    /// `<env>/<profile>` is still appended (unless `flatten_env` is set).
+    /// See FastLED/fbuild#432.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_dir_override: Option<String>,
+    /// When true, drop the `<env>` segment of the build-dir path.
+    /// Useful when the project directory is already named after the env
+    /// (e.g. FastLED's `.build/pio/<board>/`). The auto-collapse rule
+    /// in [`fbuild_paths::BuildLayout`] does this automatically when the
+    /// project basename equals the env name; this flag lets callers force
+    /// the same behavior in other shapes.
+    #[serde(default)]
+    pub flatten_env: bool,
 }
 
 /// POST /api/deploy
@@ -96,6 +110,12 @@ pub struct DeployRequest {
     /// Snapshot of `PLATFORMIO_*` env vars from the CLI caller's environment.
     #[serde(default)]
     pub pio_env: BTreeMap<String, String>,
+    /// Optional explicit build-dir root override (see [`BuildRequest::build_dir_override`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_dir_override: Option<String>,
+    /// Drop the `<env>` segment of the build-dir path (see [`BuildRequest::flatten_env`]).
+    #[serde(default)]
+    pub flatten_env: bool,
 }
 
 fn default_qemu_timeout() -> u32 {
@@ -398,6 +418,12 @@ pub struct TestEmuRequest {
     /// Snapshot of `PLATFORMIO_*` env vars from the CLI caller's environment.
     #[serde(default)]
     pub pio_env: BTreeMap<String, String>,
+    /// Optional explicit build-dir root override (see [`BuildRequest::build_dir_override`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_dir_override: Option<String>,
+    /// Drop the `<env>` segment of the build-dir path (see [`BuildRequest::flatten_env`]).
+    #[serde(default)]
+    pub flatten_env: bool,
 }
 
 /// GET /api/cache/stats response.

--- a/crates/fbuild-daemon/tests/test_emu_endpoint.rs
+++ b/crates/fbuild-daemon/tests/test_emu_endpoint.rs
@@ -164,6 +164,8 @@ async fn test_emu_registers_operation_guard() {
         caller_pid: None,
         caller_cwd: None,
         pio_env: Default::default(),
+        build_dir_override: None,
+        flatten_env: false,
     };
 
     let ctx_clone = Arc::clone(&ctx);

--- a/crates/fbuild-packages/src/cache.rs
+++ b/crates/fbuild-packages/src/cache.rs
@@ -109,10 +109,16 @@ impl Cache {
     // --- Build directories (per-project) ---
 
     /// Get the build directory for an environment and profile.
+    ///
+    /// Routes through [`fbuild_paths::BuildLayout`] so layout decisions
+    /// (env-segment collapse when the project basename already matches
+    /// the env, `FBUILD_BUILD_DIR` override, etc.) are made in exactly
+    /// one place. Embedders that need a non-default layout should set
+    /// `params.build_dir` directly via [`fbuild_paths::BuildLayout`];
+    /// this convenience helper is for the default path only.
     pub fn get_build_dir(&self, env_name: &str, profile: BuildProfile) -> PathBuf {
-        fbuild_paths::get_project_build_root(&self.project_dir)
-            .join(env_name)
-            .join(profile.as_dir_name())
+        fbuild_paths::BuildLayout::new(self.project_dir.clone(), env_name.to_string(), profile)
+            .resolve()
     }
 
     /// Get the core build subdirectory (for compiled core .o files).

--- a/crates/fbuild-paths/README.md
+++ b/crates/fbuild-paths/README.md
@@ -11,7 +11,8 @@ Single source of truth for all `.fbuild` directory paths, with dev/prod isolatio
 - `get_daemon_port()` -- Port resolution with four-level priority: env var, current mode port file, cross-mode port file, default (8865 dev / 8765 prod)
 - `get_daemon_url()` -- Daemon HTTP URL (`http://127.0.0.1:{port}`)
 - `get_cache_root()` -- Global cache dir (`FBUILD_CACHE_DIR` override or `~/.fbuild/{mode}/cache`)
-- `get_project_build_root()` -- Per-project build dir (`FBUILD_BUILD_DIR` override or `<project>/.fbuild/build`)
+- `get_project_build_root()` -- Per-project build-dir root (`FBUILD_BUILD_DIR` override or `<project>/.fbuild/build`). Returns the *root* — does not append `<env>/<profile>`. Most callers should use `BuildLayout` instead.
+- `BuildLayout` -- Single source of truth for the env-and-profile-rooted build dir. Encapsulates: explicit per-request `override_root` (highest precedence), `FBUILD_BUILD_DIR` env var, default `<project>/.fbuild/build`, and the `<env>/<profile>` append. Drops the `<env>` segment when `flatten_env` is set or when `project_dir.file_name() == env_name` (the FastLED `.build/pio/<board>/` case, FastLED/fbuild#432).
 - `get_platformio_home()` / `get_platformio_package()` -- PlatformIO directory resolution
 - `find_firmware()` / `find_firmware_dir()` -- Firmware file discovery across profile subdirs and legacy `.pio/build`
 

--- a/crates/fbuild-paths/src/lib.rs
+++ b/crates/fbuild-paths/src/lib.rs
@@ -5,6 +5,8 @@
 
 use std::path::{Path, PathBuf};
 
+use fbuild_core::BuildProfile;
+
 /// Check if running in development mode.
 pub fn is_dev_mode() -> bool {
     std::env::var("FBUILD_DEV_MODE")
@@ -80,6 +82,101 @@ pub fn get_project_build_root(project_dir: &Path) -> PathBuf {
     get_project_fbuild_dir(project_dir).join("build")
 }
 
+/// Layout resolver for the per-environment build directory.
+///
+/// This is the single source of truth for "where does fbuild write
+/// `firmware.hex`, `core/`, `src/`, `libs/`?". Callers (daemon HTTP
+/// handlers, CLI, tests) construct a `BuildLayout` from the inputs
+/// they have, then ask it to resolve the on-disk path. The pipeline
+/// reads the resolved path off `BuildParams` instead of re-deriving
+/// it, which is why this struct exists rather than a free function.
+///
+/// Resolution precedence:
+///
+/// 1. `override_root` (an explicit per-request override from the HTTP
+///    API). Treated as the env-rooted dir base.
+/// 2. `FBUILD_BUILD_DIR` env var (process-wide override, primarily for
+///    Windows long-path workarounds).
+/// 3. `<project_dir>/.fbuild/build` (the default).
+///
+/// The `<env>/<profile>` segments are appended on top of whichever
+/// root was selected, *unless* `flatten_env` is true or the
+/// project_dir's basename already equals `env_name` — in which case
+/// the `<env>` segment is dropped to avoid path duplication like
+/// `.build/pio/teensy40/.fbuild/build/teensy40/release/`. See
+/// FastLED/fbuild#432.
+#[derive(Debug, Clone)]
+pub struct BuildLayout {
+    pub project_dir: PathBuf,
+    pub env_name: String,
+    pub profile: BuildProfile,
+    /// Explicit per-request override of the build root. When `Some`,
+    /// takes precedence over `FBUILD_BUILD_DIR` and the default.
+    pub override_root: Option<PathBuf>,
+    /// When true, the resolved path is `<root>/<profile>` — the `<env>`
+    /// segment is dropped. Embedders that already name their project
+    /// dir after the env (FastLED's `.build/pio/<board>/` convention)
+    /// should set this to keep paths short.
+    pub flatten_env: bool,
+}
+
+impl BuildLayout {
+    /// Construct a layout with the standard defaults (no override,
+    /// flatten only when project basename auto-matches env).
+    pub fn new(project_dir: PathBuf, env_name: String, profile: BuildProfile) -> Self {
+        Self {
+            project_dir,
+            env_name,
+            profile,
+            override_root: None,
+            flatten_env: false,
+        }
+    }
+
+    /// Builder: set an explicit per-request root override.
+    pub fn with_override_root(mut self, root: Option<PathBuf>) -> Self {
+        self.override_root = root;
+        self
+    }
+
+    /// Builder: force-flatten the `<env>` segment.
+    pub fn with_flatten_env(mut self, flatten: bool) -> Self {
+        self.flatten_env = flatten;
+        self
+    }
+
+    /// True when the project directory's basename already matches the
+    /// env name, so appending `<env>/` would duplicate the segment.
+    /// This is the FastLED `.build/pio/<board>/` shape.
+    pub fn project_basename_matches_env(&self) -> bool {
+        self.project_dir
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|name| name == self.env_name)
+            .unwrap_or(false)
+    }
+
+    /// Resolve the env-rooted build directory.
+    pub fn resolve(&self) -> PathBuf {
+        let root = if let Some(ref r) = self.override_root {
+            r.clone()
+        } else if let Ok(dir) = std::env::var("FBUILD_BUILD_DIR") {
+            PathBuf::from(dir)
+        } else {
+            get_project_fbuild_dir(&self.project_dir).join("build")
+        };
+
+        let collapse_env = self.flatten_env || self.project_basename_matches_env();
+
+        let with_env = if collapse_env {
+            root
+        } else {
+            root.join(&self.env_name)
+        };
+        with_env.join(self.profile.as_dir_name())
+    }
+}
+
 /// Read and validate a port number from a port file.
 fn read_port_from_file(path: &Path) -> Option<u16> {
     let content = std::fs::read_to_string(path).ok()?;
@@ -149,8 +246,8 @@ pub fn get_platformio_package(package_name: &str) -> PathBuf {
     get_platformio_home().join("packages").join(package_name)
 }
 
-/// Build profile names, ordered by preference for firmware discovery.
-const BUILD_PROFILES: &[&str] = &["release", "quick"];
+/// Build profiles enumerated in firmware-discovery preference order.
+const BUILD_PROFILE_ORDER: &[BuildProfile] = &[BuildProfile::Release, BuildProfile::Quick];
 
 /// Firmware file names, ordered by preference.
 const FIRMWARE_NAMES: &[&str] = &["firmware.bin", "firmware.hex", "firmware.elf"];
@@ -159,6 +256,10 @@ const FIRMWARE_NAMES: &[&str] = &["firmware.bin", "firmware.hex", "firmware.elf"
 ///
 /// Searches profile subdirectories (release, quick) first, then the base
 /// environment directory, then the legacy `.pio/build` directory.
+///
+/// Layout discovery routes through [`BuildLayout`] so it tracks exactly
+/// where production wrote the artifact — including the env-segment
+/// auto-collapse used for the FastLED `.build/pio/<board>/` shape.
 ///
 /// If `firmware_name` is `None`, searches for all known firmware names
 /// in preference order.
@@ -172,16 +273,24 @@ pub fn find_firmware(
         None => FIRMWARE_NAMES.to_vec(),
     };
 
-    let base_build_dir = get_project_build_root(project_dir).join(env_name);
+    let mut search_dirs: Vec<PathBuf> = Vec::new();
+    for profile in BUILD_PROFILE_ORDER {
+        let layout = BuildLayout::new(project_dir.to_path_buf(), env_name.to_string(), *profile);
+        search_dirs.push(layout.resolve());
+    }
+    // Also probe the env dir itself (no profile subdir) — covers
+    // legacy fbuild layouts and the rare orchestrator that drops
+    // firmware one level up.
+    let env_dir_layout = BuildLayout::new(
+        project_dir.to_path_buf(),
+        env_name.to_string(),
+        BuildProfile::Release,
+    );
+    if let Some(env_dir) = env_dir_layout.resolve().parent() {
+        search_dirs.push(env_dir.to_path_buf());
+    }
 
-    // Check profile subdirectories first (release, quick), then base env dir
-    let mut search_dirs: Vec<PathBuf> = BUILD_PROFILES
-        .iter()
-        .map(|profile| base_build_dir.join(profile))
-        .collect();
-    search_dirs.push(base_build_dir);
-
-    // Also check legacy .pio/build location
+    // Legacy PlatformIO output: `.pio/build/<env>/`.
     search_dirs.push(project_dir.join(".pio").join("build").join(env_name));
 
     for search_dir in &search_dirs {
@@ -315,6 +424,36 @@ mod tests {
         std::fs::remove_dir_all(&tmp).ok();
     }
 
+    /// Regression: FastLED stages each board's project under
+    /// `<repo>/.build/pio/<board>/` and asks fbuild to build it with
+    /// `env == board`. The on-disk layout must collapse the duplicate
+    /// `<board>` segment, and `find_firmware` must still locate the
+    /// firmware in that collapsed layout. See FastLED/fbuild#432.
+    #[test]
+    fn find_firmware_in_collapsed_layout_when_basename_matches_env() {
+        let tmp = std::env::temp_dir().join("fbuild_test_find_fw_collapsed");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let project_dir = tmp.join(".build").join("pio").join("teensy40");
+        // Collapsed layout: `<project_dir>/.fbuild/build/release/` —
+        // NO extra `teensy40/` segment.
+        let fw_dir = project_dir.join(".fbuild").join("build").join("release");
+        std::fs::create_dir_all(&fw_dir).unwrap();
+        std::fs::write(fw_dir.join("firmware.hex"), b"fake").unwrap();
+
+        let result = find_firmware(&project_dir, "teensy40", None).unwrap();
+        // The duplicated `teensy40` segment must NOT appear between
+        // `.fbuild/build/` and `release/`.
+        let s = result.to_string_lossy().to_string();
+        assert!(s.contains(".fbuild"));
+        assert!(s.contains("release"));
+        assert!(
+            !s.contains("build/teensy40/release") && !s.contains("build\\teensy40\\release"),
+            "find_firmware returned a duplicated-env path: {s}"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
     #[test]
     fn find_firmware_legacy_pio_build() {
         let tmp = std::env::temp_dir().join("fbuild_test_find_fw_pio");
@@ -339,5 +478,81 @@ mod tests {
     fn platformio_package_appends_packages_subdir() {
         let pkg = get_platformio_package("tool-avrdude");
         assert!(pkg.ends_with("packages/tool-avrdude") || pkg.ends_with("packages\\tool-avrdude"));
+    }
+
+    // --- BuildLayout ---
+
+    #[test]
+    fn build_layout_default_includes_env_and_profile() {
+        let project = PathBuf::from("/work/sketch");
+        let layout = BuildLayout::new(project.clone(), "esp32dev".into(), BuildProfile::Release);
+        let resolved = layout.resolve();
+        // Either: <project>/.fbuild/build/esp32dev/release
+        //     or: $FBUILD_BUILD_DIR/esp32dev/release (when env var is set in CI).
+        // Both must end with esp32dev/release.
+        assert!(
+            resolved.ends_with(PathBuf::from("esp32dev").join("release")),
+            "default layout must end with <env>/<profile>, got: {}",
+            resolved.display()
+        );
+    }
+
+    #[test]
+    fn build_layout_override_root_takes_precedence() {
+        let project = PathBuf::from("/work/sketch");
+        let override_root = PathBuf::from("/tmp/short-build-dir");
+        let layout = BuildLayout::new(project, "uno".into(), BuildProfile::Quick)
+            .with_override_root(Some(override_root.clone()));
+        let resolved = layout.resolve();
+        assert_eq!(resolved, override_root.join("uno").join("quick"));
+    }
+
+    /// When project_dir's basename already matches env_name, the env
+    /// segment is collapsed automatically. This is the FastLED
+    /// `.build/pio/<board>/` case that this refactor exists to fix.
+    /// See FastLED/fbuild#432.
+    #[test]
+    fn build_layout_auto_collapses_when_project_basename_matches_env() {
+        let project = PathBuf::from("/repo/.build/pio/teensy40");
+        let layout = BuildLayout::new(project, "teensy40".into(), BuildProfile::Release);
+        // The override path is used so the test isn't perturbed by
+        // FBUILD_BUILD_DIR in the surrounding environment.
+        let layout = layout.with_override_root(Some(PathBuf::from("/tmp/root")));
+        let resolved = layout.resolve();
+        assert_eq!(resolved, PathBuf::from("/tmp/root/release"));
+        // The duplicated teensy40 segment must NOT appear.
+        assert!(!resolved.to_string_lossy().contains("teensy40"));
+    }
+
+    #[test]
+    fn build_layout_explicit_flatten_env_drops_env_segment() {
+        let project = PathBuf::from("/repo/sketch");
+        let layout = BuildLayout::new(project, "esp32dev".into(), BuildProfile::Release)
+            .with_override_root(Some(PathBuf::from("/tmp/root")))
+            .with_flatten_env(true);
+        let resolved = layout.resolve();
+        assert_eq!(resolved, PathBuf::from("/tmp/root/release"));
+    }
+
+    #[test]
+    fn build_layout_project_basename_mismatch_keeps_env() {
+        let project = PathBuf::from("/repo/sketch_dir");
+        let layout = BuildLayout::new(project, "esp32dev".into(), BuildProfile::Release)
+            .with_override_root(Some(PathBuf::from("/tmp/root")));
+        let resolved = layout.resolve();
+        assert_eq!(resolved, PathBuf::from("/tmp/root/esp32dev/release"));
+    }
+
+    #[test]
+    fn build_layout_profile_dir_name_matches_buildprofile() {
+        let project = PathBuf::from("/p");
+        let release = BuildLayout::new(project.clone(), "e".into(), BuildProfile::Release)
+            .with_override_root(Some(PathBuf::from("/r")))
+            .resolve();
+        let quick = BuildLayout::new(project, "e".into(), BuildProfile::Quick)
+            .with_override_root(Some(PathBuf::from("/r")))
+            .resolve();
+        assert!(release.ends_with("release"));
+        assert!(quick.ends_with("quick"));
     }
 }

--- a/tasks/bloat-loaded-only-investigation.md
+++ b/tasks/bloat-loaded-only-investigation.md
@@ -1,0 +1,91 @@
+# `fbuild bloat` — does it report only loaded symbols?
+
+## Verdict
+
+**No.** The bloat report includes linker-script boundary symbols (e.g. `__StackTop`, `__flash_arduino_end`) that are not real bytes in the final binary. nm assigns them garbage "sizes" computed by subtracting from the next symbol's address, which inflates `total_flash` by **multiple gigabytes** and pollutes the top-N output.
+
+## What the tool does
+
+`fbuild symbols <elf>` (the current subcommand name; `bloat` rename in #443 only updated docs, the clap variant is still `Symbols`) runs:
+
+```
+nm --print-size --size-sort --reverse-sort -S <elf>
+```
+
+then routes the rows through `fbuild_core::symbol_analysis::build_fine_grained_map_with_synth`, which keeps only symbols whose nm type letter is `T t R r W w D d B b` via `classify_region` (`crates/fbuild-core/src/symbol_analysis/mod.rs:398-404`). Everything else (`A`, `U`, `N`, `?`, `C`, `V`, etc.) is dropped.
+
+That filter is necessary but **not sufficient**.
+
+## Empirical test: nrf52840 firmware
+
+ELF: `tests/platform/nrf52840_dk/.fbuild/build/nrf52840_dk/quick/firmware.elf` (71 KB on disk; real `.text` is 32,740 bytes per `readelf -SW`).
+
+Counts:
+
+| Source                                | Symbols |
+|---|---|
+| `nm <elf>` (all)                      | 540 |
+| `nm --print-size --size-sort -S <elf>` | 520 |
+| `fbuild symbols <elf>` reported       | **520** |
+
+The 20-symbol drop comes from nm's own filtering (size-0 markers and `A`-type absolute linker symbols). After that, `classify_region` doesn't reject any more rows — every surviving row is `T/t/R/r/W/w/D/d/B/b`, so all 520 make it into the report.
+
+### The leak: linker boundary symbols
+
+```
+$ nm --print-size --size-sort -S firmware.elf | grep -E "__flash_arduino_end|__StackTop|__HeapBase"
+20007ff8 00037808 B __HeapBase
+20040000 dffedfe4 T __StackTop
+000ed000 fff40fe4 T __flash_arduino_end
+```
+
+These are `PROVIDE(...)` statements in the linker script — address markers, not allocated bytes. nm computes their "size" from the gap to the next symbol, which produces:
+
+- `__flash_arduino_end`: 4,294,184,932 bytes (~4 GB)
+- `__StackTop`: 3,758,022,628 bytes (~3.5 GB)
+- `__HeapBase`: 227,336 bytes (the actual .heap region — borderline; .heap is NOBITS, so not in the flash payload either, but at least the number reflects allocated address space).
+
+Split:
+
+| Bucket                              | Count | Σ flash      | Σ ram   |
+|---|---|---|---|
+| Sane (size < 100,000)               | 517   | 32,965 B     | 8,166 B |
+| Bogus boundary symbols              | 3     | 8,052,207,560 B | 227,336 B |
+
+32,965 B aligns with `readelf -SW`'s real `.text` size (0x07fe4 = 32,740 B; the small overshoot is the few weak-aliased symbols counted twice). The 8 GB bogus number is the inflated total fbuild prints:
+
+```
+Wrote 520 symbols to bloat_nrf52.json (flash=8052240525 B, ram=235502 B)
+```
+
+A user reading the top-N output sees `__flash_arduino_end` and `__StackTop` as the top "functions" by size — totally misleading.
+
+## Root cause
+
+Two compounding issues:
+
+1. **`classify_region` is type-letter-only**, with no cross-check against the linker map's input-section ranges. A symbol with `output_section: null` (no map attribution) is still kept and counted.
+2. **No upper-bound sanity check.** A symbol whose reported size exceeds the largest PT_LOAD segment (here 32,748 B for flash, 235,520 B for RAM) is structurally impossible but currently passes through.
+
+## What a fix should do
+
+Order of cheapness:
+
+1. **Cheap (1-line fix in `build_fine_grained_map_with_synth`)**: drop any symbol whose `(addr + size)` extends past the end of the containing input-section range — or, lacking a range attribution (`InputSectionIndex::lookup` returns `None`) and size > 64 KB, drop it. The data is already collected; just gate the `symbols.push(...)`.
+2. **Robust (recommended)**: pass through PT_LOAD segment bounds (parse with the `object` crate, already a workspace dep) and clamp/reject anything whose `addr+size` straddles a segment boundary. Use `readelf -lW` semantics, not just `-SW`.
+3. **Belt-and-braces**: also subtract NOBITS sections from `total_flash` (so .bss/.heap symbols only count toward RAM, not flash payload).
+
+Affected files:
+- `crates/fbuild-core/src/symbol_analysis/mod.rs:540-567` (the main fold loop)
+- `crates/fbuild-core/src/symbol_analysis/mod.rs:398-404` (`classify_region`)
+- Tests in `crates/fbuild-core/src/symbol_analysis/tests.rs` should add a fixture row simulating `__StackTop`-style bogus size and assert it's filtered.
+
+## Side observation
+
+`fbuild symbols <project_dir>` is broken — it passes the directory to nm verbatim:
+
+```
+nm: Warning: 'C:/.../tests/platform/nrf52840_dk' is a directory
+```
+
+The ELF auto-discovery path appears unimplemented (or regressed). Worth its own ticket; not blocking the bloat filter fix.

--- a/tasks/build-path-robustness.md
+++ b/tasks/build-path-robustness.md
@@ -1,0 +1,140 @@
+# Build-path robustness refactor
+
+## Problem
+
+FastLED reported a build artifact path like:
+
+```
+.build/pio/teensy40/.fbuild/build/teensy40/release/firmware.hex
+```
+
+Two visible issues:
+
+1. **`teensy40` is duplicated** — once as FastLED's per-board project sandbox (`.build/pio/teensy40/`) and once as fbuild's env-name layer (`.fbuild/build/teensy40/`).
+2. **Nesting is gratuitously deep** — six directory levels (`.build/pio/<board>/.fbuild/build/<env>/<profile>/`) plus compile sub-trees (`core/`, `src/`, `libs/`) below it. On Windows this slams into the 260-char `MAX_PATH` limit, and other crates already work around it (`fbuild-build/src/zccache.rs:297`, `fbuild-packages/src/library/esp32_framework/libs.rs:136`).
+
+## Investigation findings
+
+### Where the layout comes from
+
+`fbuild-paths::get_project_build_root(project_dir)` returns `<project_dir>/.fbuild/build/` (`crates/fbuild-paths/src/lib.rs:76`). `fbuild-packages::Cache::get_build_dir(env, profile)` appends `<env>/<profile>` (`crates/fbuild-packages/src/cache.rs:112`). So the canonical layout the orchestrators write to is:
+
+```
+<project_dir>/.fbuild/build/<env>/<profile>/{firmware.hex,firmware.elf,...}
+                                         core/  src/  libs/  ...
+```
+
+`compile_many.rs:94` also hard-codes the same `<sketch>/.fbuild/build/<env>/<profile>` shape, *bypassing* `get_project_build_root` — that's a latent bug if `FBUILD_BUILD_DIR` is set.
+
+### Dead parameter: `BuildParams.build_dir`
+
+`crates/fbuild-build/src/lib.rs:151` declares `pub build_dir: PathBuf` on `BuildParams`. The daemon's HTTP handlers (`crates/fbuild-daemon/src/handlers/operations/build.rs:137`, `deploy.rs:197`, `emulator/select.rs:255`) carefully compute it via `get_project_build_root(&project_dir)` and pass it through.
+
+**No orchestrator or pipeline step ever reads it.** Grep confirms zero `params.build_dir` references in `crates/fbuild-build/src/**`. The pipeline re-derives the build dir via `Cache::new(project_dir).get_build_dir(env, profile)` (`pipeline/context.rs:120`). The daemon's plumbing is a no-op.
+
+This means today there is no path through which the daemon caller can actually override the build dir — only the `FBUILD_BUILD_DIR` env var works, and only because the env-var override lives inside `get_project_build_root` itself.
+
+### Why FastLED ended up with `<board>/.fbuild/build/<board>/`
+
+FastLED stages each board's PlatformIO project under `<repo>/.build/pio/<board>/` (`ci/compiler/pio.py:75`) and asks fbuild to build that directory. fbuild then automatically appends `.fbuild/build/<env>/<profile>/`, and on FastLED's matrix `env == board`. So the board name appears twice.
+
+FastLED can't easily flatten this — its analysis tools (`ci/util/fbuild_compiledb.py:44`) already enumerate three candidate layouts (`<build_root>/pio/<board>/.fbuild/build/<env>/release`, `<project>/.fbuild/build/<env>/release`, `<build_root>/.fbuild/build/<env>/release`) and pick whichever exists. They've been compensating for path drift for a while.
+
+### Why this matters beyond cosmetics
+
+- **Windows `MAX_PATH`.** `<sketch>/.fbuild/build/<env>/<profile>/core/<lib>/<file>.cpp.o` already pushes close to 260 chars on long sketch names. esp32_framework explicitly extracts to a short temp dir to dodge this (`esp32_framework/libs.rs:136`).
+- **Symbol-analysis / build-info consumers** look up paths by both an env-specific and a generic name (`build_info.rs:136`, FastLED `_find_build_info`). They're path-coupled; every layout change is a contract change.
+- **The daemon API claims you can pass a build dir, but you can't.** That's a foot-gun for anyone integrating fbuild via HTTP.
+
+## Goals
+
+1. **One source of truth.** Build-dir resolution lives in `fbuild-paths`; everyone else calls into it. No hard-coded `.fbuild/build/<env>/<profile>` strings.
+2. **`BuildParams.build_dir` is either load-bearing or removed.** No silently-ignored fields.
+3. **Allow flattening the env-name layer** when the caller has already named the project after the env (the FastLED case), without breaking standalone callers who *do* want `<env>` separation.
+4. **Make path length predictable and short.** Layout choice should be deterministic from inputs the caller can see.
+
+## Proposed design
+
+### A. Make `BuildParams.build_dir` load-bearing
+
+Define the field as the **environment-rooted build directory** (i.e. the dir that contains `firmware.hex`, `core/`, `src/`, `libs/`). The daemon already computes the right value at the boundary; pipeline just needs to use it.
+
+- `pipeline/context.rs:120`: replace `cache.get_build_dir(env_name, params.profile)` with `params.build_dir.clone()`.
+- `fbuild-packages::Cache::get_build_dir` becomes a thin helper that the *daemon* uses to compute the default; the orchestrator side stops calling it.
+- `compile_many.rs::project_build_dir` becomes a thin wrapper around `fbuild-paths`, not a string-literal duplicate.
+
+### B. Single resolver in `fbuild-paths`
+
+Add a single public function:
+
+```rust
+pub struct BuildLayout {
+    pub project_dir: PathBuf,
+    pub env_name: String,
+    pub profile: BuildProfile,
+    pub override_root: Option<PathBuf>,  // FBUILD_BUILD_DIR or HTTP override
+    pub flatten_env: bool,               // skip the <env>/ layer when project basename already matches
+}
+
+impl BuildLayout {
+    pub fn resolve(&self) -> PathBuf { ... }
+}
+```
+
+Resolution precedence:
+
+1. If `override_root` is set → use that, joined with `<env>/<profile>` unless `flatten_env`.
+2. Else if `FBUILD_BUILD_DIR` env is set → same.
+3. Else `<project_dir>/.fbuild/build/<env>/<profile>` (unchanged default).
+
+`flatten_env = true` collapses to `<root>/<profile>/` — gives FastLED a way to dodge the `.build/pio/teensy40/.fbuild/build/teensy40/` duplication.
+
+### C. Auto-detect duplication
+
+When `project_dir.file_name() == env_name`, the resolver can log once and silently flatten (or emit a `tracing::warn!` recommending callers set `flatten_env`). This catches the FastLED case automatically without an opt-in.
+
+### D. Stop hard-coding `.fbuild/build` in tests and docs
+
+`crates/fbuild-build/tests/{avr,teensy,esp32,eh_frame_strip_esp32}_build.rs` constructs build paths as `project_dir.join(".fbuild/build/<env>/release")`. Migrate these to call the new resolver so a layout change updates tests for free.
+
+### E. Update `find_firmware` to use the same resolver
+
+`fbuild-paths::find_firmware` currently re-derives the directory via `get_project_build_root().join(env_name)` (`lib.rs:175`). Switch it to `BuildLayout::resolve()` so firmware discovery follows the same rules as firmware *production*.
+
+### F. Document the contract
+
+Update `crates/fbuild-paths/README.md` and `docs/architecture/overview.md` with the resolved precedence list and the duplication-collapse rule. Mention `flatten_env` as the public knob for embedders like FastLED.
+
+## Step-by-step plan
+
+- [ ] **Audit** (1 hr) — confirm `params.build_dir` is unused by orchestrators (already done: zero refs in `fbuild-build/src/**`). Catalogue every hard-coded `.fbuild/build/` literal across the workspace.
+- [ ] **Introduce `BuildLayout`** in `fbuild-paths` with the resolver above, plus unit tests for: default layout, env-var override, `flatten_env=true`, duplication auto-detect.
+- [ ] **Wire `BuildLayout` through `BuildParams`.** Either replace `build_dir: PathBuf` with `layout: BuildLayout`, or keep `build_dir` and demand the daemon sets it from `BuildLayout::resolve()`. Prefer the former — fewer chances for the field to drift.
+- [ ] **Update `pipeline/context.rs:120`** to read from params instead of re-deriving via `Cache`.
+- [ ] **Update `Cache::get_build_dir`** to accept a pre-resolved `BuildLayout` (or delete it — callers can compute directly).
+- [ ] **Update `compile_many.rs::project_build_dir`** to call `BuildLayout::resolve`. Keep the same return type.
+- [ ] **Update `find_firmware` / `find_firmware_dir`** to use `BuildLayout`. Preserve the legacy `.pio/build/<env>` tail fallback.
+- [ ] **Update daemon HTTP handlers** (`build.rs:137`, `deploy.rs:197`, `emulator/select.rs:255`, `emulator/tests_process.rs:115`) to build a `BuildLayout` from request fields + env vars.
+- [ ] **Add request-side knob.** Expose `flatten_env` (or equivalent) in the build/deploy/test-emu request models so FastLED can opt in over HTTP without setting a global env var.
+- [ ] **Migrate tests** to the resolver; remove hard-coded `.fbuild/build/<env>/release` strings.
+- [ ] **Add a regression test** for the FastLED-shaped invocation: project_dir = `<tmp>/.build/pio/teensy40`, env = `teensy40`. Assert the resolver collapses the duplicate.
+- [ ] **Update docs** (`fbuild-paths/README.md`, `docs/architecture/overview.md`, `docs/CI_CACHE.md`).
+- [ ] **Coordinate with FastLED.** `ci/util/fbuild_compiledb.py:44` currently enumerates three candidate layouts. Once flattening is on by default for the duplication case, that list collapses to two; update FastLED in lockstep (see `clud-extern-repos`).
+
+## Out of scope
+
+- Switching away from `.fbuild/` as the dotdir name (cross-cutting; would invalidate every consumer at once).
+- Cache layout (`~/.fbuild/{dev|prod}/cache/`) — unaffected.
+- Daemon dev/prod mode isolation — unaffected.
+
+## Risks
+
+- **Hidden assumption that `<env>/` exists.** Some consumer (FastLED's `_create_board_info`, our own `find_firmware`) may rely on the `<env>` directory layer. The auto-flatten case must keep firmware discoverable; `find_firmware` migration covers our side, but FastLED needs a heads-up.
+- **`build_info_<env>.json` already lands at `project_dir/`**, not inside the build dir, so it's *not* affected — but worth double-checking when wiring `flatten_env` through.
+- **Symbol-analysis path** (`symbol_analysis_path`) is an absolute caller-resolved path (`build.rs:142`); independent of the build-dir refactor.
+
+## Acceptance
+
+- `params.build_dir` (or `params.layout`) is the only source the orchestrators read.
+- Re-running the FastLED teensy40 case produces a single `teensy40` segment in the path, not two.
+- All workspace tests still pass; the path-length workaround in `esp32_framework/libs.rs:136` either becomes redundant or is documented as defense-in-depth.

--- a/tasks/issue-417-investigation.md
+++ b/tasks/issue-417-investigation.md
@@ -1,0 +1,132 @@
+## Investigation report — pre-PR triage
+
+I picked this up via `/clud-fix` to merge a fix end-to-end, but the intake
+gate flagged it as a feature request with three different scopes (A, B, C)
+and no chosen "definition of fixed." A PR can't be opened until we agree on
+which path to land. Below is what I verified in the tree today, where the
+mechanics actually live, and a recommended cut-line — so the discussion can
+be about scope, not about whether the trap is real (it is) or whether fbuild
+has the raw materials to address it (it does).
+
+### What fbuild has today (verified against current `main`)
+
+- **No `size` / `analyze` / `bloat` / `symbols` top-level subcommand.** Confirmed
+  in `crates/fbuild-cli/src/cli/args.rs:65-389` — the subcommand enum is
+  `Build / Deploy / Monitor / Reset / Purge / Daemon / Show / Device / Mcp /
+  ClangTidy / Iwyu / TestEmu / ClangQuery / Lnk / LibSelect / CompileMany / Ci`.
+  Your `fbuild --help` claim in the issue matches the source.
+- **`Build` *does* already expose `--symbol-analysis [PATH]`** at
+  `crates/fbuild-cli/src/cli/args.rs:90-93` ("Run per-symbol memory analysis
+  after building; optionally write report to PATH instead of streaming to
+  console"). So fbuild already has a foothold for post-build symbol reporting
+  — it just operates on the ELF via `nm`, not on the `.map` file.
+- **`SymbolMap`** (`crates/fbuild-core/src/lib.rs:300-383`) is the existing
+  analyzer: parses `nm --print-size --size-sort --reverse-sort` output and
+  classifies symbols into Flash/RAM regions. **ELF-as-ground-truth path —
+  immune to the `0x00000000` trap by construction**, which is exactly the
+  property the issue advocates for.
+- **Map files *are* emitted** by every platform's linker via
+  `-Wl,-Map=firmware.map` (AVR `crates/fbuild-build/src/avr/avr_linker.rs:111`
+  and the equivalent in CH32V, ESP8266, generic ARM, NRF52, Renesas, SAM,
+  SiliconLabs, Teensy). So the map file is sitting on disk next to the ELF
+  in every build — it's available, just not parsed anywhere in fbuild.
+- **No map-file parser** anywhere in the workspace. No tests or examples
+  consume `firmware.map`. The "trap" you describe is therefore not present
+  in fbuild today because fbuild doesn't parse map files at all — but it
+  also doesn't prevent *consumers* (FastLED `ci/` scripts) from falling
+  into the trap when they reach for the map directly.
+- **`build_info.json`** (issue #297) lives in `crates/fbuild-build/src/build_info.rs:28-61`
+  (`BuildInfo` struct, `emit_build_info()` at line 136). It already publishes
+  `prog_path`, `cc_path`, `cxx_path`, `ar_path`, `objcopy_path`, `size_path`,
+  plus flags/defines/includes/libs. Adding a `map_path` field next to
+  `prog_path` would be a one-line schema change with high downstream value.
+- **Docs convention:** architecture docs live in `docs/architecture/*.md`
+  (overview, data-flow, deploy-preemption, library-selection, portability,
+  pyo3-bindings, runtime, serial). A "size analysis gotchas" page would fit
+  there or as a peer doc at `docs/SIZE_ANALYSIS.md`.
+- **Diagnostic-subcommand exception** is precedent for option A. Per
+  `crates/CLAUDE.md`, `clang-tidy / clang-query / iwyu / mcp / lnk / lib-select`
+  run in-process and intentionally bypass the daemon because they're
+  read-only diagnostics. A hypothetical `fbuild size` / `fbuild bloat`
+  fits that pattern cleanly — no HTTP round-trip needed.
+
+### The trap, restated to make sure I have it right
+
+GNU `ld` `--gc-sections` keeps the dropped section row in the `.map` for
+debugging, but writes its placement address as `0x00000000`. A naive
+sum-by-archive over `.rodata.*` rows in the map double-counts those dead
+sections. ELF-side tools (`nm`, `readelf`, `objdump`) never see them
+because the linker really did drop them, which is why
+`SymbolMap`-via-`nm` is already trap-immune. The risk surface is purely
+*map-file analyzers*. Your reproduction (`x509_crt_bundle 69,880 B`,
+`mesh_parent 11,108 B`, `huffTable 8,484 B`, `PLM_AUDIO_SYNTHESIS 2,048 B`,
+~95 KB total phantom-bloat) matches what I'd expect from xtensa-esp32s3-elf
+14.2.0 with `--gc-sections` on. I have no reason to doubt the numbers.
+
+### Scope read on the three options
+
+- **Option C (`fbuild_size_helpers.py`) — declined as written.** The repo's
+  language policy (`CLAUDE.md`: *"Python is only for CI scripts, packaging,
+  hooks, and PyO3 bindings. All tests, benchmarks, and application logic
+  must be written in Rust"*) puts a vendored Python helper module
+  out-of-bounds. The PyO3 surface (`fbuild-python`) is locked to
+  `SerialMonitor` / `Daemon`. Closest in-policy variant: ship a Rust
+  library (or expose it via the existing `--symbol-analysis` machinery)
+  that consumers shell out to via `fbuild` — i.e. option A in a thinner
+  jacket.
+- **Option B (docs only) — small, well-bounded, lossy.** ~1 doc page in
+  `docs/architecture/` or `docs/SIZE_ANALYSIS.md`, plus a one-line
+  callout in `crates/fbuild-build/src/build_info.rs` near where ELF
+  paths are emitted. Catches no analyzers automatically; relies on
+  reviewers remembering the rule. Total work: <100 LoC of markdown.
+- **Option A (`fbuild size` / `fbuild bloat`) — the goal-shaped fix,
+  but a real chunk of work.** Concretely it's: a map-file parser
+  with the `address != 0x00000000` filter, an ELF cross-check that
+  routes through the existing `SymbolMap`/`nm` plumbing, archive
+  attribution, JSON output for CI, optionally a `--diff PRIOR.json`
+  comparator. Realistic estimate: a new `fbuild-bloat` crate (or
+  a module under `fbuild-build/src/size/`) + a `Size` variant on
+  `Commands` + wiring through `fbuild-cli`, plus tests against
+  vendored map/ELF fixtures. Probably 600–1200 LoC of Rust + tests.
+  Fits the diagnostic-subcommand exception, so no daemon work.
+
+### Recommendation
+
+**Land B + a deliberately minimal slice of A in one PR; defer the
+full A to a follow-up.** Concretely:
+
+1. New `docs/SIZE_ANALYSIS.md` with the `0x00000000` filter rule, a
+   worked example using your `x509_crt_bundle` case, the vetted awk
+   one-liner, and a pointer at `build_info.json` as the
+   ELF-truth contract.
+2. Add `map_path` to `BuildInfo` (`crates/fbuild-build/src/build_info.rs`)
+   so downstream tooling has a single supported way to locate the map
+   without duplicating fbuild's pathing logic. One field, one assignment,
+   no behavior change.
+3. Defer the `fbuild size` subcommand to a follow-up issue with a
+   bounded design (map parser + filter + ELF cross-check via existing
+   `SymbolMap`).
+
+This makes step 7 of `/clud-fix` (validate the reproduction) tractable:
+the doc + `map_path` makes it possible for someone running the issue's
+exact awk snippet to land on the correct version on the first try, and
+the follow-up issue is what closes the door entirely.
+
+### What I need from you before opening a PR
+
+1. **Which path?** B-plus-thin-A as recommended, full A in one PR, or
+   pure-B with no schema change?
+2. **Doc location**: `docs/SIZE_ANALYSIS.md` (peer to ROADMAP/WHY) or
+   `docs/architecture/size-analysis.md` (with the other architecture
+   docs)? Repo convention slightly prefers the latter but the topic is
+   more "guide" than "architecture."
+3. **If A is in scope**: should the subcommand be named `size`, `bloat`,
+   or `analyze`? `size` collides with the GNU `size` binary; `bloat`
+   matches `cargo-bloat` precedent and is unambiguous.
+4. **Anything I'm wrong about above** — particularly: is the existing
+   `Build --symbol-analysis` flag the place this should hook in, or
+   should it be a standalone subcommand from day one?
+
+I'll wait for direction here before opening a PR. If you'd rather just
+say "ship option A as one big PR," that's also fine — I just don't want
+to guess the scope on a feature request with three explicit branches.


### PR DESCRIPTION
Two related correctness fixes bundled into one PR.

## 1. `refactor(paths)`: make `BuildLayout` the single source of truth

Closes the FastLED-shaped path bug FastLED/fbuild#432: a project staged at `<repo>/.build/pio/<board>/` and built with `env == board` was yielding `.build/pio/<board>/.fbuild/build/<board>/release/firmware.hex` — board name duplicated, path deep enough to threaten Windows' 260-char MAX_PATH limit.

While investigating I found `BuildParams.build_dir` was **dead code**: the daemon HTTP handlers carefully computed it and passed it through, but `pipeline/context.rs` re-derived its own via `Cache::new(project_dir).get_build_dir(env, profile)` and ignored the field. HTTP callers had no way to actually override the build dir even though the API claimed otherwise.

**Changes**

- `fbuild-paths::BuildLayout`: single resolver. Precedence `override_root` > `FBUILD_BUILD_DIR` > `<project>/.fbuild/build`, then appends `<env>/<profile>`. Drops the `<env>` segment when `flatten_env` is set *or* when `project_dir.file_name() == env_name` — the FastLED case auto-collapses with zero consumer-side change.
- `pipeline/context.rs` now reads `params.build_dir` directly. The field is finally load-bearing.
- `Cache::get_build_dir`, `compile_many::project_build_dir`, `find_firmware` all route through `BuildLayout`.
- `BuildRequest` / `DeployRequest` / `TestEmuRequest` got `build_dir_override` + `flatten_env` knobs for HTTP embedders.
- Regression tests pin the collapse rule on both crate boundaries.

## 2. `fix(symbols)`: drop symbols outside PT_LOAD regions

`fbuild bloat` / `fbuild symbols` was reporting nm's full symbol table, including linker-script boundary markers (`__StackTop`, `__flash_arduino_end`) whose nm-computed "size" is the gap to the next symbol — often multi-GB. On an nrf52840 firmware with real `.text` = 32,740 B, the report claimed flash = **8,052,240,525 B (~8 GB)** with the two markers topping the list.

**Changes**

- `fbuild_core::symbol_analysis::LoadedRegion` + `FineGrainedSymbolMap::retain_loaded_symbols`: filter symbols to those whose `[addr, addr+size)` is fully contained in some PT_LOAD region, then recompute totals. Strict lower bound (`addr < end`) so boundary markers at end-of-segment get excluded.
- `fbuild_build::symbol_analyzer::read_pt_load_regions`: parses ELF32 + ELF64 PT_LOAD segments via the `object` crate (promoted from dev-dep to dep). Failures degrade to a `tracing::warn!` + unfiltered output.
- `analyze_elf` calls the filter automatically — every consumer benefits.

**After the fix** on the same nrf52840 ELF:
- 520 → 519 symbols
- `total_flash` 8 GB → **33,083 B** (within 1% of `readelf`'s real `.text` of 32,740 B)
- `__flash_arduino_end` and `__StackTop` no longer appear
- `__HeapBase` correctly remains under RAM

3 new unit tests pin the filter behavior: strict containment, boundary-marker drop, no-op when regions empty.

## Verification

- `soldr cargo clippy --workspace --all-targets -- -D warnings` — clean
- `soldr cargo test --workspace` — 52 test suites, zero failures
- Manually verified `fbuild symbols` output on a real nrf52840 firmware before/after; numbers above are from that run.

Two commits in this branch (one per fix) for reviewability. Squash-merge will collapse them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build directory override and environment flattening options for custom artifact organization.
  * Improved symbol analysis with PT_LOAD region filtering to eliminate invalid symbols from bloat reports.

* **Bug Fixes**
  * Enhanced firmware discovery and build directory resolution for better multi-environment support.

* **Documentation**
  * Updated build-paths documentation to clarify environment-specific directory layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->