### PR TITLE
feat(bloat): expose linker --cref back-references as referenced_by (#459)

### DIFF
--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -107,8 +107,13 @@ jobs:
         run: fbuild build ${{ inputs.test-dir }} -e ${{ inputs.env-name }} --quick
 
       - name: Verify quick firmware output
+        # `tests/platform/<env>/` has basename == env-name, so
+        # BuildLayout collapses the `<env>` segment (PR #455 / issue
+        # FastLED/fbuild#432). The output lives at
+        # `<test-dir>/.fbuild/build/<profile>/firmware.<ext>` with no
+        # `<env>` directory in between.
         run: |
-          test -f ${{ inputs.test-dir }}/.fbuild/build/${{ inputs.env-name }}/quick/firmware.${{ inputs.firmware-ext }}
+          test -f ${{ inputs.test-dir }}/.fbuild/build/quick/firmware.${{ inputs.firmware-ext }}
           echo "Quick build successful - firmware.${{ inputs.firmware-ext }} generated"
 
       - name: Build ${{ inputs.workflow-name }} (release)
@@ -116,7 +121,7 @@ jobs:
 
       - name: Verify release firmware output
         run: |
-          test -f ${{ inputs.test-dir }}/.fbuild/build/${{ inputs.env-name }}/release/firmware.${{ inputs.firmware-ext }}
+          test -f ${{ inputs.test-dir }}/.fbuild/build/release/firmware.${{ inputs.firmware-ext }}
           echo "Release build successful - firmware.${{ inputs.firmware-ext }} generated"
 
       - name: Save fbuild toolchains

--- a/.github/workflows/template_build.yml
+++ b/.github/workflows/template_build.yml
@@ -107,22 +107,26 @@ jobs:
         run: fbuild build ${{ inputs.test-dir }} -e ${{ inputs.env-name }} --quick
 
       - name: Verify quick firmware output
-        # `tests/platform/<env>/` has basename == env-name, so
-        # BuildLayout collapses the `<env>` segment (PR #455 / issue
-        # FastLED/fbuild#432). The output lives at
-        # `<test-dir>/.fbuild/build/<profile>/firmware.<ext>` with no
-        # `<env>` directory in between.
+        # BuildLayout (PR #455, FastLED/fbuild#432) collapses the
+        # `<env>` segment when the sketch dir basename == env-name.
+        # `tests/platform/lpc845/` (env `lpc845`) → collapses to
+        # `.fbuild/build/quick/firmware.<ext>`; but
+        # `tests/platform/giga_r1_m7/` (env `giga_r1`) → stays as
+        # `.fbuild/build/giga_r1/quick/firmware.<ext>`. Find both
+        # layouts so the verify works either way.
         run: |
-          test -f ${{ inputs.test-dir }}/.fbuild/build/quick/firmware.${{ inputs.firmware-ext }}
-          echo "Quick build successful - firmware.${{ inputs.firmware-ext }} generated"
+          firmware=$(find ${{ inputs.test-dir }}/.fbuild/build -type f -name "firmware.${{ inputs.firmware-ext }}" -path "*/quick/*" 2>/dev/null | head -1)
+          test -n "$firmware" && test -f "$firmware"
+          echo "Quick build successful - firmware.${{ inputs.firmware-ext }} at $firmware"
 
       - name: Build ${{ inputs.workflow-name }} (release)
         run: fbuild build ${{ inputs.test-dir }} -e ${{ inputs.env-name }} --release
 
       - name: Verify release firmware output
         run: |
-          test -f ${{ inputs.test-dir }}/.fbuild/build/release/firmware.${{ inputs.firmware-ext }}
-          echo "Release build successful - firmware.${{ inputs.firmware-ext }} generated"
+          firmware=$(find ${{ inputs.test-dir }}/.fbuild/build -type f -name "firmware.${{ inputs.firmware-ext }}" -path "*/release/*" 2>/dev/null | head -1)
+          test -n "$firmware" && test -f "$firmware"
+          echo "Release build successful - firmware.${{ inputs.firmware-ext }} at $firmware"
 
       - name: Save fbuild toolchains
         if: always()

--- a/crates/fbuild-build/src/symbol_analyzer.rs
+++ b/crates/fbuild-build/src/symbol_analyzer.rs
@@ -14,8 +14,8 @@ use std::collections::BTreeMap;
 
 use fbuild_core::subprocess::run_command_with_stdin;
 use fbuild_core::symbol_analysis::{
-    build_fine_grained_map_with_synth, collect_map_derived_owners, parse_linker_map,
-    parse_nm_output, FineGrainedSymbolMap, LoadedRegion,
+    build_fine_grained_map_with_synth, collect_map_derived_owners, parse_cref_table,
+    parse_linker_map, parse_nm_output, FineGrainedSymbolMap, LoadedRegion, SymbolReference,
 };
 use fbuild_core::{FbuildError, Result};
 
@@ -226,19 +226,20 @@ pub fn analyze_elf(cfg: AnalyzeConfig<'_>) -> Result<FineGrainedSymbolMap> {
         mangled.clone()
     };
 
-    let ranges = if let Some(map_path) = cfg.map_path {
+    let (ranges, cref_map) = if let Some(map_path) = cfg.map_path {
         match std::fs::read_to_string(map_path) {
-            Ok(text) => parse_linker_map(&text),
+            Ok(text) => (parse_linker_map(&text), parse_cref_table(&text)),
             Err(e) => {
                 tracing::warn!(
-                    "could not read map file {}: {e}; archive attribution will be unavailable",
+                    "could not read map file {}: {e}; archive attribution and \
+                     referenced_by will be unavailable",
                     map_path.display()
                 );
-                Vec::new()
+                (Vec::new(), BTreeMap::<String, Vec<SymbolReference>>::new())
             }
         }
     } else {
-        Vec::new()
+        (Vec::new(), BTreeMap::<String, Vec<SymbolReference>>::new())
     };
 
     // Pre-walk the ranges to collect mangled owners for map-derived
@@ -271,6 +272,7 @@ pub fn analyze_elf(cfg: AnalyzeConfig<'_>) -> Result<FineGrainedSymbolMap> {
         demangled,
         ranges,
         &synth_demangled,
+        &cref_map,
     );
 
     // Strip symbols that nm enumerated but that don't actually consume
@@ -457,9 +459,9 @@ pub fn format_markdown_report(map: &FineGrainedSymbolMap, top_n: usize) -> Strin
         let _ = writeln!(out);
         let _ = writeln!(
             out,
-            "| Bytes | Archive | Object | Section | Source | Symbol |"
+            "| Bytes | Archive | Object | Section | Source | Referenced by | Symbol |"
         );
-        let _ = writeln!(out, "|---:|---|---|---|---|---|");
+        let _ = writeln!(out, "|---:|---|---|---|---|---|---|");
         for s in syms.into_iter().take(top_n) {
             let archive = s.archive.as_deref().unwrap_or("(none)");
             let object = s.object.as_deref().unwrap_or("-");
@@ -467,10 +469,11 @@ pub fn format_markdown_report(map: &FineGrainedSymbolMap, top_n: usize) -> Strin
             // Pipe-escape the demangled name so it doesn't break MD
             // table parsing (rare but possible with operator overloads).
             let name = s.demangled.replace('|', "\\|");
+            let refs = format_referenced_by(&s.referenced_by, 3);
             let _ = writeln!(
                 out,
-                "| {} | {} | {} | {} | {} | `{}` |",
-                s.size, archive, object, sect, s.source, name
+                "| {} | {} | {} | {} | {} | {} | `{}` |",
+                s.size, archive, object, sect, s.source, refs, name
             );
         }
         let _ = writeln!(out);
@@ -605,6 +608,40 @@ fn walk_for_elf(dir: &Path, newest: &mut Option<(std::time::SystemTime, PathBuf)
     }
 }
 
+/// Format up to `top_k` `referenced_by` entries for a Markdown table
+/// cell. Each referencer is rendered as `archive(object)` (or just
+/// `object` for bare TUs with no archive) and joined with `, `. When
+/// the list exceeds `top_k`, append ` (… and N more)`. Returns `-`
+/// for an empty list so the column stays scannable.
+///
+/// `top_k = 3` is the column-friendly default — the issue proposes
+/// K=5 as a follow-up-table value, but five `lib.a(obj.o)` strings
+/// per row makes the GitHub-rendered table awkward. Three keeps the
+/// signal-to-width ratio readable while still surfacing the most
+/// common "libc internal wrapper escapes to an ESP-IDF/mbedTLS TU"
+/// pattern documented in #459.
+fn format_referenced_by(
+    refs: &[fbuild_core::symbol_analysis::SymbolReference],
+    top_k: usize,
+) -> String {
+    if refs.is_empty() {
+        return "-".to_string();
+    }
+    let mut parts: Vec<String> = refs
+        .iter()
+        .take(top_k)
+        .map(|r| match &r.archive {
+            Some(a) => format!("{a}({})", r.object),
+            None => r.object.clone(),
+        })
+        .collect();
+    if refs.len() > top_k {
+        parts.push(format!("(… and {} more)", refs.len() - top_k));
+    }
+    // Pipe-escape so the joined string doesn't break MD table cells.
+    parts.join(", ").replace('|', "\\|")
+}
+
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
@@ -732,6 +769,7 @@ mod tests {
                     object: Some("foo.o".into()),
                     output_section: Some(".flash.text".into()),
                     source: "nm".into(),
+                    referenced_by: Vec::new(),
                 },
                 FineGrainedSymbol {
                     mangled: "_Z3barv".into(),
@@ -744,6 +782,7 @@ mod tests {
                     object: Some("bar.o".into()),
                     output_section: Some(".dram0.bss".into()),
                     source: "nm".into(),
+                    referenced_by: Vec::new(),
                 },
             ],
             sections: Vec::<SectionBytes>::new(),
@@ -754,9 +793,9 @@ mod tests {
         assert!(md.contains("**Flash**: 100 B"));
         assert!(md.contains("**RAM**: 50 B"));
         assert!(md.contains("## Top 1 flash symbols"));
-        assert!(md.contains("| 100 | libA.a | foo.o | .flash.text | nm | `foo(int)` |"));
+        assert!(md.contains("| 100 | libA.a | foo.o | .flash.text | nm | - | `foo(int)` |"));
         assert!(md.contains("## Top 1 ram symbols"));
-        assert!(md.contains("| 50 | libB.a | bar.o | .dram0.bss | nm | `bar()` |"));
+        assert!(md.contains("| 50 | libB.a | bar.o | .dram0.bss | nm | - | `bar()` |"));
         assert!(md.contains("## Flash bytes by archive"));
         assert!(md.contains("| 100 | libA.a |"));
     }
@@ -781,10 +820,103 @@ mod tests {
                 object: None,
                 output_section: None,
                 source: "nm".into(),
+                referenced_by: Vec::new(),
             }],
             sections: Vec::<SectionBytes>::new(),
         };
         let md = format_markdown_report(&map, 5);
         assert!(md.contains("operator\\|(int const&, int const&)"));
+    }
+
+    #[test]
+    fn format_markdown_report_renders_referenced_by_column() {
+        // The motivating #459 case: a libc symbol like `_vfprintf_r`
+        // shows its non-libc referencers so the agent can answer
+        // "who pulled this in?" without spawning a separate query.
+        use fbuild_core::symbol_analysis::{
+            FineGrainedSymbol, FineGrainedSymbolMap, SectionBytes, SymbolReference,
+        };
+        let map = FineGrainedSymbolMap {
+            elf_path: "fw.elf".into(),
+            map_path: None,
+            total_flash: 11309,
+            total_ram: 0,
+            symbols: vec![FineGrainedSymbol {
+                mangled: "_vfprintf_r".into(),
+                demangled: "_vfprintf_r".into(),
+                address: 0x4000,
+                size: 11309,
+                sym_type: 'T',
+                region: fbuild_core::MemoryRegion::Flash,
+                archive: Some("libc.a".into()),
+                object: Some("libc_a-vfprintf.o".into()),
+                output_section: Some(".flash.text".into()),
+                source: "nm".into(),
+                referenced_by: vec![
+                    SymbolReference {
+                        archive: Some("libc.a".into()),
+                        object: "libc_a-vprintf.o".into(),
+                    },
+                    SymbolReference {
+                        archive: Some("libc.a".into()),
+                        object: "libc_a-printf.o".into(),
+                    },
+                    SymbolReference {
+                        archive: Some("libc.a".into()),
+                        object: "libc_a-fprintf.o".into(),
+                    },
+                    SymbolReference {
+                        archive: Some("liblog.a".into()),
+                        object: "log_write.c.obj".into(),
+                    },
+                    SymbolReference {
+                        archive: Some("libmbedcrypto.a".into()),
+                        object: "sha512.c.obj".into(),
+                    },
+                ],
+            }],
+            sections: Vec::<SectionBytes>::new(),
+        };
+        let md = format_markdown_report(&map, 5);
+        // Header includes the new column.
+        assert!(
+            md.contains("| Bytes | Archive | Object | Section | Source | Referenced by | Symbol |")
+        );
+        // Cell shows top-3 referencers + "(… and 2 more)" overflow.
+        assert!(
+            md.contains("libc.a(libc_a-vprintf.o), libc.a(libc_a-printf.o), libc.a(libc_a-fprintf.o), (… and 2 more)"),
+            "expected top-3 + overflow in referenced_by cell, got:\n{md}"
+        );
+    }
+
+    #[test]
+    fn format_markdown_report_referenced_by_empty_renders_dash() {
+        use fbuild_core::symbol_analysis::{FineGrainedSymbol, FineGrainedSymbolMap, SectionBytes};
+        let map = FineGrainedSymbolMap {
+            elf_path: "fw.elf".into(),
+            map_path: None,
+            total_flash: 10,
+            total_ram: 0,
+            symbols: vec![FineGrainedSymbol {
+                mangled: "main".into(),
+                demangled: "main".into(),
+                address: 0x4000,
+                size: 10,
+                sym_type: 'T',
+                region: fbuild_core::MemoryRegion::Flash,
+                archive: None,
+                object: Some("main.cpp.o".into()),
+                output_section: Some(".flash.text".into()),
+                source: "nm".into(),
+                referenced_by: Vec::new(),
+            }],
+            sections: Vec::<SectionBytes>::new(),
+        };
+        let md = format_markdown_report(&map, 5);
+        // The "Referenced by" cell is `-` when no cref data exists.
+        assert!(
+            md.contains("| 10 | (none) | main.cpp.o | .flash.text | nm | - | `main` |"),
+            "expected dash in referenced_by cell, got:\n{md}"
+        );
     }
 }

--- a/crates/fbuild-core/src/symbol_analysis/README.md
+++ b/crates/fbuild-core/src/symbol_analysis/README.md
@@ -4,13 +4,17 @@ Pure parsers and aggregators behind `fbuild bloat` (legacy `fbuild symbols`):
 
 - `parse_nm_line` / `parse_nm_output` — `nm --print-size -S` row parsing.
 - `parse_linker_map` — GNU `ld -Map` output → per-input-section ranges.
+- `parse_cref_table` — GNU `ld --cref` `Cross Reference Table` block → mangled-symbol → referencer `(archive, object)` list. See [#459](https://github.com/FastLED/fbuild/issues/459). Empty result when the map lacks a cref block (older `ld`, `-Wl,--no-cref`) — never a hard error.
 - `classify_region` — nm type letter → `Flash` / `Ram` bucket.
 - `FineGrainedSymbolMap::retain_loaded_symbols` — drop symbols whose `[addr, addr+size)` doesn't fit any `PT_LOAD` region, so linker-script boundary markers (`__StackTop`, `__flash_arduino_end`) don't pollute the bloat report.
-- `build_fine_grained_map_with_synth` — fold nm rows + map ranges + demangled names into the per-symbol report.
+- `build_fine_grained_map_with_synth` — fold nm rows + map ranges + demangled names + cref into the per-symbol report.
+
+Each `FineGrainedSymbol` row carries a `referenced_by: Vec<SymbolReference>` field populated from the cref table. Granularity is `(archive, object)`, not per-symbol — that's a property of `ld --cref` itself.
 
 Intentionally has no ELF-parsing dep; ELF I/O lives in `fbuild_build::symbol_analyzer`, which calls into this module.
 
 ## Files
 
 - `mod.rs` — types and pure functions.
+- `cref.rs` — `Cross Reference Table` parser.
 - `tests.rs` — unit tests.

--- a/crates/fbuild-core/src/symbol_analysis/cref.rs
+++ b/crates/fbuild-core/src/symbol_analysis/cref.rs
@@ -1,0 +1,338 @@
+//! Parser for GNU `ld --cref` Cross Reference Table sections of a map file.
+//!
+//! `ld` emits the cref block at the end of the map file. Each top-level
+//! entry has the form:
+//!
+//! ```text
+//! Cross Reference Table
+//!
+//! Symbol                                            File
+//! _vfprintf_r                                       libc.a(libc_a-vfprintf.o)
+//!                                                   libc.a(libc_a-vprintf.o)
+//!                                                   libc.a(libc_a-printf.o)
+//! ```
+//!
+//! The first file is the translation unit that defines the symbol;
+//! every subsequent indented file is a translation unit that references
+//! it. We store only the **referencers** under `referenced_by` so a
+//! bloat report can answer "why was this symbol linked?" without the
+//! definer noise (which is already on the row itself as `archive` +
+//! `object`).
+//!
+//! cref granularity is **archive-member (`.o`), not symbol** — that's a
+//! property of `ld --cref` itself, not a fbuild limitation. Consumers
+//! shouldn't expect per-symbol back-references.
+//!
+//! Symbol names in the cref table are *mangled* (the linker doesn't
+//! demangle for `--cref`). We key the returned map on the mangled name
+//! so callers can join against `FineGrainedSymbol::mangled`.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::extract_archive_and_object;
+
+/// A back-reference parsed from the linker `--cref` table.
+///
+/// `archive` is `None` when the referencing TU is a bare object file on
+/// disk (e.g. `src/main.cpp.o`). `object` is the archive member name
+/// (`libc_a-vprintf.o`) or the bare object's basename.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SymbolReference {
+    pub archive: Option<String>,
+    pub object: String,
+}
+
+/// Parse the `Cross Reference Table` block of a GNU `ld` map file.
+///
+/// Returns a `mangled_symbol -> Vec<SymbolReference>` map of
+/// *referencers* (the defining TU is intentionally excluded — that
+/// information is already carried by the symbol row's own `archive`
+/// + `object` fields). Returns an empty map when:
+///
+/// - the `Cross Reference Table` header is absent (older `ld`, or
+///   the build ran with `-Wl,--no-cref`);
+/// - the map file is well-formed but lists no symbols in the table.
+///
+/// Never panics on malformed input — best-effort parsing yields fewer
+/// back-references rather than a hard error. The downstream contract
+/// in [`super::FineGrainedSymbol::referenced_by`] is "empty vec means
+/// no information", not "empty vec means error".
+pub fn parse_cref_table(map_text: &str) -> BTreeMap<String, Vec<SymbolReference>> {
+    let mut out: BTreeMap<String, Vec<SymbolReference>> = BTreeMap::new();
+    let mut lines = map_text.lines();
+
+    // Walk to the cref header.
+    let mut found_header = false;
+    for line in lines.by_ref() {
+        if line.trim_start().starts_with("Cross Reference Table") {
+            found_header = true;
+            break;
+        }
+    }
+    if !found_header {
+        return out;
+    }
+    // Skip blank lines + the "Symbol ... File" column header.
+    let mut saw_columns = false;
+    for line in lines.by_ref() {
+        let t = line.trim_start();
+        if t.is_empty() {
+            continue;
+        }
+        if t.starts_with("Symbol") {
+            saw_columns = true;
+            break;
+        }
+        // No column header — older emitters sometimes omit it. Treat
+        // this line as the first symbol row.
+        process_first_line(line, &mut out);
+        break;
+    }
+    if !saw_columns && out.is_empty() {
+        // We may have consumed nothing usable above; fall through to
+        // the body-loop in case the iterator still has rows.
+    }
+
+    let mut current: Option<String> = None;
+    let mut current_has_definer = false;
+    for raw in lines {
+        if raw.trim().is_empty() {
+            // Blank line between groups — end the current group but
+            // keep walking the table.
+            current = None;
+            current_has_definer = false;
+            continue;
+        }
+        if raw.starts_with(char::is_whitespace) {
+            // Continuation: file path only.
+            let path = raw.trim();
+            if path.is_empty() {
+                continue;
+            }
+            let Some(sym) = current.as_ref() else {
+                continue;
+            };
+            if !current_has_definer {
+                // First file under the symbol is the defining TU;
+                // skip it (the row already carries that attribution).
+                current_has_definer = true;
+                continue;
+            }
+            let (archive, object) = extract_archive_and_object(path);
+            push_referencer(&mut out, sym, SymbolReference { archive, object });
+            continue;
+        }
+        // New symbol row.
+        let (sym, definer_seen) = process_symbol_row(raw, &mut out);
+        current = Some(sym);
+        current_has_definer = definer_seen;
+    }
+
+    out
+}
+
+/// Same as [`parse_cref_table`]'s symbol-row branch, but standalone for
+/// the edge case where the cref block is missing its `Symbol ... File`
+/// column header line.
+fn process_first_line(raw: &str, out: &mut BTreeMap<String, Vec<SymbolReference>>) {
+    let _ = process_symbol_row(raw, out);
+}
+
+/// Handle a non-indented symbol row. Returns `(symbol_name,
+/// definer_seen_on_same_line)`. The symbol always gets a (possibly
+/// still-empty) entry in `out` so subsequent indented referencer rows
+/// have a key to attach to.
+fn process_symbol_row(
+    raw: &str,
+    out: &mut BTreeMap<String, Vec<SymbolReference>>,
+) -> (String, bool) {
+    let mut parts = raw.splitn(2, char::is_whitespace);
+    let symbol = parts.next().unwrap_or("").to_string();
+    if symbol.is_empty() {
+        return (String::new(), false);
+    }
+    let rest = parts.next().unwrap_or("").trim();
+    out.entry(symbol.clone()).or_default();
+    // The first file on this line (if any) is the definer — we
+    // deliberately do NOT add it to `referenced_by`.
+    let definer_seen = !rest.is_empty();
+    (symbol, definer_seen)
+}
+
+fn push_referencer(
+    out: &mut BTreeMap<String, Vec<SymbolReference>>,
+    sym: &str,
+    candidate: SymbolReference,
+) {
+    let refs = out.entry(sym.to_string()).or_default();
+    if !refs.contains(&candidate) {
+        refs.push(candidate);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn refr(archive: Option<&str>, object: &str) -> SymbolReference {
+        SymbolReference {
+            archive: archive.map(|s| s.to_string()),
+            object: object.to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_returns_empty_when_no_cref_header() {
+        let text = "\
+Linker script and memory map
+
+.flash.text     0x42000020    0x4026c
+ .text.foo      0x42000020       0x10 path/libFastLED.a(foo.cpp.o)
+";
+        assert!(parse_cref_table(text).is_empty());
+    }
+
+    #[test]
+    fn parse_basic_inline_layout() {
+        // The dominant shape: definer + file on the same line as the
+        // symbol name, referencers on indented continuation lines.
+        let text = "\
+Cross Reference Table
+
+Symbol                                            File
+_vfprintf_r                                       /tools/libc.a(libc_a-vfprintf.o)
+                                                  /tools/libc.a(libc_a-vprintf.o)
+                                                  /tools/libc.a(libc_a-printf.o)
+                                                  /tools/libc.a(libc_a-fprintf.o)
+vprintf                                           /tools/libc.a(libc_a-vprintf.o)
+                                                  /tools/liblog.a(log_write.c.obj)
+";
+        let map = parse_cref_table(text);
+        let vfprintf = map.get("_vfprintf_r").expect("_vfprintf_r missing");
+        // Definer (vfprintf.o) excluded; referencers only.
+        assert_eq!(
+            vfprintf,
+            &vec![
+                refr(Some("libc.a"), "libc_a-vprintf.o"),
+                refr(Some("libc.a"), "libc_a-printf.o"),
+                refr(Some("libc.a"), "libc_a-fprintf.o"),
+            ]
+        );
+        let vprintf = map.get("vprintf").expect("vprintf missing");
+        assert_eq!(vprintf, &vec![refr(Some("liblog.a"), "log_write.c.obj")]);
+    }
+
+    #[test]
+    fn parse_split_definer_layout() {
+        // Long symbol name pushes the definer file onto the next
+        // indented line. The first indented file is still the definer
+        // — must be skipped.
+        let text = "\
+Cross Reference Table
+
+Symbol                                            File
+_ZNVeryLongMangledSymbolNameThatBlowsThroughTheCrefColumn
+                                                  /tools/libc.a(libc_a-vfprintf.o)
+                                                  /tools/libc.a(libc_a-vprintf.o)
+                                                  /tools/libc.a(libc_a-printf.o)
+";
+        let map = parse_cref_table(text);
+        let entry = map
+            .get("_ZNVeryLongMangledSymbolNameThatBlowsThroughTheCrefColumn")
+            .expect("symbol missing");
+        // Three indented lines: first is the definer, last two are
+        // the only referencers we should keep.
+        assert_eq!(
+            entry,
+            &vec![
+                refr(Some("libc.a"), "libc_a-vprintf.o"),
+                refr(Some("libc.a"), "libc_a-printf.o"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_bare_object_referencer_has_no_archive() {
+        // App-side referencers are bare `.o` paths with no archive.
+        let text = "\
+Cross Reference Table
+
+Symbol                                            File
+FastLED_ctor                                      .pio/build/esp32s3/lib0d9/libFastLED.a(fl.cpp.o)
+                                                  .pio/build/esp32s3/src/main.cpp.o
+";
+        let map = parse_cref_table(text);
+        let entry = map.get("FastLED_ctor").expect("symbol missing");
+        assert_eq!(entry, &vec![refr(None, "main.cpp.o")]);
+    }
+
+    #[test]
+    fn parse_deduplicates_repeated_referencers() {
+        // Same TU referencing the symbol from multiple sites only
+        // appears once in cref output, but defend against malformed
+        // duplicates anyway.
+        let text = "\
+Cross Reference Table
+
+Symbol                                            File
+printf                                            /tools/libc.a(libc_a-printf.o)
+                                                  /tools/libmbedcrypto.a(sha512.c.obj)
+                                                  /tools/libmbedcrypto.a(sha512.c.obj)
+                                                  /tools/libheap.a(tlsf.c.obj)
+";
+        let map = parse_cref_table(text);
+        let entry = map.get("printf").expect("printf missing");
+        assert_eq!(
+            entry,
+            &vec![
+                refr(Some("libmbedcrypto.a"), "sha512.c.obj"),
+                refr(Some("libheap.a"), "tlsf.c.obj"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_groups_separated_by_blank_lines() {
+        // Some emitters insert a blank line between groups; we must
+        // not lose subsequent symbols.
+        let text = "\
+Cross Reference Table
+
+Symbol                                            File
+foo                                               libA.a(foo.o)
+                                                  libB.a(uses_foo.o)
+
+bar                                               libA.a(bar.o)
+                                                  libC.a(uses_bar.o)
+";
+        let map = parse_cref_table(text);
+        assert_eq!(
+            map.get("foo").unwrap(),
+            &vec![refr(Some("libB.a"), "uses_foo.o")]
+        );
+        assert_eq!(
+            map.get("bar").unwrap(),
+            &vec![refr(Some("libC.a"), "uses_bar.o")]
+        );
+    }
+
+    #[test]
+    fn parse_symbol_with_no_referencers_yields_empty_vec() {
+        // A symbol that's defined but never referenced (it's reachable
+        // via some other root, e.g. `KEEP()` in the linker script).
+        let text = "\
+Cross Reference Table
+
+Symbol                                            File
+__StackTop                                        firmware.ld
+";
+        let map = parse_cref_table(text);
+        // We still record the key so callers can distinguish "in the
+        // cref but unreferenced" from "absent from cref entirely".
+        // Either is rendered as "no referencers" in the report.
+        let entry = map.get("__StackTop").expect("__StackTop missing");
+        assert!(entry.is_empty(), "got {entry:?}");
+    }
+}

--- a/crates/fbuild-core/src/symbol_analysis/mod.rs
+++ b/crates/fbuild-core/src/symbol_analysis/mod.rs
@@ -19,9 +19,13 @@
 //! no fs I/O for tool invocation) so it can be unit-tested without a
 //! cross toolchain. Subprocess drivers live in `fbuild_build`.
 
+pub mod cref;
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+
+pub use cref::{parse_cref_table, SymbolReference};
 
 use crate::MemoryRegion;
 
@@ -62,6 +66,15 @@ pub struct FineGrainedSymbol {
     /// versions of `fbuild symbols`.
     #[serde(default = "default_source_nm")]
     pub source: String,
+    /// Translation units that *referenced* this symbol, as parsed from
+    /// GNU ld's `Cross Reference Table` block in the map file.
+    /// Excludes the defining TU (already on `archive` + `object`).
+    /// Empty when the linker map lacks a cref block (older `ld`, or
+    /// `-Wl,--no-cref`), or when nothing references the symbol — both
+    /// cases are non-errors. Granularity is `(archive, object)`, not
+    /// per-symbol; that's a property of `ld --cref` itself.
+    #[serde(default)]
+    pub referenced_by: Vec<SymbolReference>,
 }
 
 fn default_source_nm() -> String {
@@ -576,7 +589,15 @@ pub fn build_fine_grained_map(
     demangled: Vec<String>,
     ranges: Vec<InputSectionRange>,
 ) -> FineGrainedSymbolMap {
-    build_fine_grained_map_with_synth(elf_path, map_path, nm_rows, demangled, ranges, &[])
+    build_fine_grained_map_with_synth(
+        elf_path,
+        map_path,
+        nm_rows,
+        demangled,
+        ranges,
+        &[],
+        &BTreeMap::new(),
+    )
 }
 
 /// Build a per-symbol view, optionally consuming pre-demangled names
@@ -587,6 +608,10 @@ pub fn build_fine_grained_map(
 /// [`collect_map_derived_owners`] returns). When empty, synthetic
 /// rows carry their mangled name in the `demangled` field; callers
 /// who want demangled C++ names should pass the c++filt output.
+///
+/// `cref` maps mangled-symbol-name → referencer list (see
+/// [`parse_cref_table`]). Empty when the map file has no cref block;
+/// in that case every row's `referenced_by` field is `[]`.
 pub fn build_fine_grained_map_with_synth(
     elf_path: String,
     map_path: Option<String>,
@@ -594,6 +619,7 @@ pub fn build_fine_grained_map_with_synth(
     demangled: Vec<String>,
     ranges: Vec<InputSectionRange>,
     synth_demangled: &[String],
+    cref: &BTreeMap<String, Vec<SymbolReference>>,
 ) -> FineGrainedSymbolMap {
     assert_eq!(
         nm_rows.len(),
@@ -623,6 +649,7 @@ pub fn build_fine_grained_map_with_synth(
             MemoryRegion::Ram => total_ram += size,
         }
         let attribution = index.lookup(addr);
+        let referenced_by = cref.get(&mangled).cloned().unwrap_or_default();
         symbols.push(FineGrainedSymbol {
             mangled,
             demangled,
@@ -634,6 +661,7 @@ pub fn build_fine_grained_map_with_synth(
             object: attribution.map(|r| r.object.clone()),
             output_section: attribution.map(|r| r.output_section.clone()),
             source: "nm".to_string(),
+            referenced_by,
         });
     }
 
@@ -664,6 +692,7 @@ pub fn build_fine_grained_map_with_synth(
         // canonical 'T' from nm if anywhere). Rodata/literal → 'r'.
         // Data → 'd'. BSS → 'b'.
         let sym_type = sym_type_for_synth(&r.output_section);
+        let referenced_by = cref.get(mangled).cloned().unwrap_or_default();
         symbols.push(FineGrainedSymbol {
             mangled: mangled.clone(),
             demangled: demangled.clone(),
@@ -675,6 +704,7 @@ pub fn build_fine_grained_map_with_synth(
             object: Some(r.object.clone()),
             output_section: Some(r.output_section.clone()),
             source: "map-derived".to_string(),
+            referenced_by,
         });
     }
     FineGrainedSymbolMap {

--- a/crates/fbuild-core/src/symbol_analysis/tests.rs
+++ b/crates/fbuild-core/src/symbol_analysis/tests.rs
@@ -399,6 +399,7 @@ fn sample_symbol(addr: u64, size: u64, region: MemoryRegion, name: &str) -> Fine
         object: None,
         output_section: None,
         source: "nm".to_string(),
+        referenced_by: Vec::new(),
     }
 }
 
@@ -471,6 +472,157 @@ fn retain_loaded_symbols_drops_boundary_markers() {
     assert_eq!(kept, vec!["real_text", "real_bss"]);
     assert_eq!(map.total_flash, 0x40);
     assert_eq!(map.total_ram, 0x80);
+}
+
+// ---- Issue #459: cref `referenced_by` integration -----------------
+
+#[test]
+fn build_fine_grained_map_populates_referenced_by_from_cref() {
+    // End-to-end check: an nm symbol whose mangled name appears in
+    // the cref table picks up its `referenced_by` list. The defining
+    // TU is excluded — it's already on the row's own attribution.
+    let ranges = vec![InputSectionRange {
+        addr: 0x42000020,
+        size: 0x40,
+        output_section: ".flash.text".into(),
+        input_section: ".text._vfprintf_r".into(),
+        archive: Some("libc.a".into()),
+        object: "libc_a-vfprintf.o".into(),
+    }];
+    let nm = vec![(0x42000020u64, 0x40u64, 'T', "_vfprintf_r".to_string())];
+    let demangled = vec!["_vfprintf_r".to_string()];
+    let mut cref: BTreeMap<String, Vec<SymbolReference>> = BTreeMap::new();
+    cref.insert(
+        "_vfprintf_r".to_string(),
+        vec![
+            SymbolReference {
+                archive: Some("libc.a".into()),
+                object: "libc_a-vprintf.o".into(),
+            },
+            SymbolReference {
+                archive: Some("libc.a".into()),
+                object: "libc_a-printf.o".into(),
+            },
+        ],
+    );
+    let map = build_fine_grained_map_with_synth(
+        "fw.elf".into(),
+        Some("fw.map".into()),
+        nm,
+        demangled,
+        ranges,
+        &[],
+        &cref,
+    );
+    assert_eq!(map.symbols.len(), 1);
+    assert_eq!(
+        map.symbols[0].referenced_by,
+        vec![
+            SymbolReference {
+                archive: Some("libc.a".into()),
+                object: "libc_a-vprintf.o".into(),
+            },
+            SymbolReference {
+                archive: Some("libc.a".into()),
+                object: "libc_a-printf.o".into(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn build_fine_grained_map_referenced_by_empty_when_no_cref() {
+    // The acceptance contract from #459: missing cref data → empty
+    // `referenced_by`, never an error. Uses the convenience wrapper
+    // `build_fine_grained_map` which passes an empty cref map.
+    let ranges = vec![InputSectionRange {
+        addr: 0x42000020,
+        size: 0x40,
+        output_section: ".flash.text".into(),
+        input_section: ".text.foo".into(),
+        archive: Some("libA.a".into()),
+        object: "foo.o".into(),
+    }];
+    let nm = vec![(0x42000020u64, 0x40u64, 'T', "foo".to_string())];
+    let demangled = vec!["foo".to_string()];
+    let map = build_fine_grained_map("fw.elf".into(), None, nm, demangled, ranges);
+    assert_eq!(map.symbols.len(), 1);
+    assert!(
+        map.symbols[0].referenced_by.is_empty(),
+        "expected [] referenced_by when no cref data, got {:?}",
+        map.symbols[0].referenced_by
+    );
+}
+
+#[test]
+fn build_fine_grained_map_populates_referenced_by_on_synth_rows() {
+    // Map-derived synthetic rows (anonymous rodata pool case) also
+    // pick up cref data when the owning symbol is in the table.
+    let ranges = vec![
+        InputSectionRange {
+            addr: 0x42000020,
+            size: 0x40,
+            output_section: ".flash.text".into(),
+            input_section: ".text.foo".into(),
+            archive: Some("libA.a".into()),
+            object: "foo.o".into(),
+        },
+        InputSectionRange {
+            addr: 0x3c050000,
+            size: 0x10,
+            output_section: ".flash.rodata".into(),
+            input_section: ".rodata.foo.str1.1".into(),
+            archive: Some("libA.a".into()),
+            object: "foo.o".into(),
+        },
+    ];
+    let nm = vec![(0x42000020u64, 0x40u64, 'T', "foo".to_string())];
+    let demangled = vec!["foo".to_string()];
+    let mut cref: BTreeMap<String, Vec<SymbolReference>> = BTreeMap::new();
+    cref.insert(
+        "foo".to_string(),
+        vec![SymbolReference {
+            archive: None,
+            object: "main.cpp.o".into(),
+        }],
+    );
+    let map = build_fine_grained_map_with_synth(
+        "fw.elf".into(),
+        Some("fw.map".into()),
+        nm,
+        demangled,
+        ranges,
+        &[],
+        &cref,
+    );
+    // Both the nm row and the synthetic rodata row carry the same
+    // referenced_by since they share a mangled owner.
+    for sym in &map.symbols {
+        assert_eq!(sym.referenced_by.len(), 1, "row missing cref: {sym:?}");
+        assert_eq!(sym.referenced_by[0].object, "main.cpp.o");
+    }
+}
+
+#[test]
+fn fine_grained_symbol_json_roundtrip_with_legacy_schema() {
+    // Pre-#459 JSON omits `referenced_by` entirely; deserialise must
+    // tolerate the missing field by defaulting to an empty vec, so
+    // older `report.json` files keep loading after the upgrade.
+    let legacy_json = r#"{
+        "mangled": "foo",
+        "demangled": "foo",
+        "address": 16384,
+        "size": 64,
+        "sym_type": "T",
+        "region": "flash",
+        "archive": "libA.a",
+        "object": "foo.o",
+        "output_section": ".flash.text",
+        "source": "nm"
+    }"#;
+    let sym: FineGrainedSymbol =
+        serde_json::from_str(legacy_json).expect("legacy schema must still parse");
+    assert!(sym.referenced_by.is_empty());
 }
 
 #[test]

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -116,11 +116,52 @@ both PIO- and fbuild-built artifacts uniformly:
 Alias keys are only present when the corresponding path is non-empty;
 consumers can rely on `"nm" in aliases` meaning the path is real.
 
+## `referenced_by` — who pulled this symbol in?
+
+Every row in `report.json` carries a `referenced_by` array of
+translation units that referenced the symbol, parsed from GNU `ld`'s
+`Cross Reference Table` block in the linker map:
+
+```json
+{
+  "demangled": "_vfprintf_r",
+  "size": 11309,
+  "archive": "libc.a",
+  "object": "libc_a-vfprintf.o",
+  "source": "nm",
+  "referenced_by": [
+    { "archive": "libc.a", "object": "libc_a-vprintf.o" },
+    { "archive": "libc.a", "object": "libc_a-printf.o" },
+    { "archive": "libc.a", "object": "libc_a-fprintf.o" }
+  ]
+}
+```
+
+The defining TU is intentionally omitted — that information is already
+on the row's own `archive` + `object` fields. The list contains only
+*referencers*, so a bloat audit can answer "why was this symbol
+linked?" without grepping the map file by hand.
+
+`report.md` exposes the same data as a `Referenced by` column on the
+top-N tables, rendered as `archive(object)` strings truncated to the
+top three with a `(… and N more)` overflow. The cell is `-` when the
+linker map has no `Cross Reference Table` block — possible with older
+`ld` versions or when the build was linked with `-Wl,--no-cref`.
+
+cref granularity is **archive-member (`.o`), not symbol** — that's a
+property of `ld --cref` itself. fbuild does not synthesize per-symbol
+back-references; ask `nm`/`objdump`/`addr2line` for that.
+
+See [#459](https://github.com/FastLED/fbuild/issues/459) for the
+motivating bloat audit.
+
 ## Related
 
 - Issue [#428](https://github.com/FastLED/fbuild/issues/428) —
   toolchain-path schema and CLI auto-discovery (this doc).
 - Issue [#434](https://github.com/FastLED/fbuild/issues/434) — the
   `fbuild bloat` meta that subsumes `symbols`.
+- Issue [#459](https://github.com/FastLED/fbuild/issues/459) —
+  `referenced_by` cref back-references on every row.
 - PR [#424] / PR [#427] — the fine-grained analyzer and map-derived
   rodata attribution this CLI drives.


### PR DESCRIPTION
Closes #459 (Part 1).

## Summary

`fbuild bloat` now answers "why was this symbol linked?" by parsing
GNU `ld`'s `Cross Reference Table` block from the linker map and
attaching a `referenced_by: Vec<{archive, object}>` field to every
row of `report.json` / `report.md`. The defining TU is excluded —
that info is already on the row's own attribution.

The motivating case from [FastLED#2886](https://github.com/FastLED/FastLED/issues/2886):
libc symbols like `_vfprintf_r` (11 KB) now show their non-libc
referencers (ESP-IDF `log_write`, mbedTLS `sha512`, heap `tlsf`),
not just an `n/a` column.

## Scope: Part 1 only

The issue describes two parts:

1. **`referenced_by` in `report.json` + a column in `report.md`** —
   shipped here. All four Part 1 acceptance items are covered.
2. **`fbuild bloat graph` subcommand for graphviz `.dot` export** —
   the issue itself marks this as "optional follow-up." Skipped to
   keep the PR reviewable; the JSON field shipped here is the data
   prerequisite, so a graph subcommand becomes a pure rendering PR.

## Implementation notes

- **New module:** `fbuild_core::symbol_analysis::cref` with
  `parse_cref_table()` + `SymbolReference`. Handles the dominant
  inline layout (`symbol  defining-file` on one line, referencers
  indented below) and the split-definer case for symbols whose
  mangled name overflows the cref column.
- **Plumbing:** `build_fine_grained_map_with_synth()` takes a cref
  map and looks up each row by mangled name. Both nm rows and
  synthetic (map-derived) rows pick up cref data.
- **Driver:** `analyze_elf()` parses cref + ranges from the same
  map-file read — single I/O.
- **Markdown:** "Referenced by" column shows top-3 `archive(object)`
  strings with `(… and N more)` overflow. K=3 was chosen over the
  issue's K=5 example because five lib(obj) strings per row makes
  the GitHub table awkward; the rationale is in a doc-comment on
  `format_referenced_by`.
- **Backwards compat:** `referenced_by` is `#[serde(default)]`, so
  legacy `report.json` without the field still deserialises. A test
  pins this contract.

## Acceptance

- [x] `report.json` rows carry `referenced_by: [{archive, object}, ...]`.
- [x] `report.md` top-N tables answer "why is this linked?" via a
      new column (no `n/a` for libc/IDF rows).
- [x] `fbuild symbols` still works when the map has no
      `Cross Reference Table` block — `referenced_by` is `[]`, not
      an error. Covered by `parse_returns_empty_when_no_cref_header`
      and `build_fine_grained_map_referenced_by_empty_when_no_cref`.
- [ ] (Part 2 — out of scope per above) `fbuild bloat graph`.

## Test plan

- [x] `soldr cargo test -p fbuild-core --lib symbol_analysis` — 36
      passed, 0 failed (7 new cref-parser tests + 4 new integration
      tests + 25 pre-existing).
- [x] `soldr cargo test -p fbuild-build --lib symbol_analyzer` — 12
      passed, 0 failed (2 new markdown tests + 10 pre-existing).
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
      — clean.
- [x] `soldr cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New "Referenced by" column in markdown reports shows which files reference each symbol
  * Data sourced from GNU linker's cross-reference table; displays `-` when unavailable

* **Documentation**
  * Updated documentation for the new "Referenced by" field in symbol reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->