### PR TITLE
fix(hooks): use PEP 723 inline-metadata so hooks bypass project sync (#464)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run ci/hooks/board_context.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/board_context.py",
             "timeout": 5
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run ci/hooks/tool_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/tool_guard.py",
             "timeout": 5
           }
         ]
@@ -29,12 +29,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run ci/hooks/lint.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/lint.py",
             "timeout": 120
           },
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run ci/hooks/readme_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/readme_guard.py",
             "timeout": 5
           }
         ]
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run ci/hooks/check-on-start.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/check-on-start.py",
             "timeout": 10
           }
         ]
@@ -56,12 +56,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run ci/hooks/code-review-on-stop.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/code-review-on-stop.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run ci/hooks/check-on-stop.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/check-on-stop.py",
             "timeout": 600
           }
         ]

--- a/ci/hooks/board_context.py
+++ b/ci/hooks/board_context.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
 """UserPromptSubmit hook: inject board-support skill guidance when the prompt
 mentions boards, hardware, or board-related errors.
 

--- a/ci/hooks/check-on-start.py
+++ b/ci/hooks/check-on-start.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
 """SessionStart hook: captures repo state fingerprint.
 
 Saves a fingerprint of the current git status so the Stop hook

--- a/ci/hooks/check-on-stop.py
+++ b/ci/hooks/check-on-stop.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
 """Stop hook: runs lint and tests scoped to the crates touched this session.
 
 Smart mode: only runs if files were actually changed during this session.

--- a/ci/hooks/code-review-on-stop.py
+++ b/ci/hooks/code-review-on-stop.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
 """Stop hook: triggers code review on session end.
 
 Detects whether source files were changed during this session.

--- a/ci/hooks/lint.py
+++ b/ci/hooks/lint.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
 """PostToolUse hook: runs per-file lint on edited Rust files.
 
 Delegates to ./lint in single-file mode for speed.

--- a/ci/hooks/readme_guard.py
+++ b/ci/hooks/readme_guard.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
 """PostToolUse hook: enforces README.md in every directory.
 
 After any Edit/Write, checks that the directory containing the edited

--- a/ci/hooks/tool_guard.py
+++ b/ci/hooks/tool_guard.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
 """PreToolUse hook: blocks bare Rust commands and bare python/pip.
 
 All cargo/rustc/rustfmt must go through a globally-installed `soldr`


### PR DESCRIPTION
Closes #464.

## Summary

All \`ci/hooks/*.py\` scripts are stdlib-only but were registered as
\`uv run ci/hooks/<name>.py\` — the project form. That made every hook
invocation trigger \`uv sync\` → editable wheel build → \`setup.py\` →
\`soldr cargo build --release -p fbuild-cli\`. On every Stop, every
PostToolUse, every UserPromptSubmit.

When \`setup.py\` itself broke (as in #461 before its merge), the chain
collapsed and every hook failed even though none needed the package.

## Fix

Each hook now has the standard PEP 723 shape (already used by
\`ci/lint.py\` / \`ci/test.py\`):

\`\`\`python
#!/usr/bin/env -S uv run --script
# /// script
# requires-python = ">=3.10"
# ///
\`\`\`

And \`.claude/settings.json\` invokes them with the matching
\`uv run --script ci/hooks/<name>.py\` form.

\`uv run --script\` resolves only the declared inline metadata
(\`requires-python\`, no deps) and runs an ephemeral interpreter — no
project sync, no setup.py, no cargo build, no dependency on the
package being installable.

## Files

- \`ci/hooks/board_context.py\`
- \`ci/hooks/check-on-start.py\`
- \`ci/hooks/check-on-stop.py\`
- \`ci/hooks/code-review-on-stop.py\`
- \`ci/hooks/lint.py\`
- \`ci/hooks/readme_guard.py\`
- \`ci/hooks/tool_guard.py\`
- \`.claude/settings.json\`

## Test plan

- [x] \`time uv run --script ci/hooks/check-on-start.py\` runs cleanly in <1s
- [x] No \`uv sync\` / setup.py invocation observed during hook run
- [x] Hooks are completely independent of \`fbuild\` package install state

🤖 Generated with [Claude Code](https://claude.com/claude-code)