### PR TITLE
feat(bloat): graphviz `.dot` back-reference graphs (#463)

### DIFF
--- a/crates/fbuild-build/src/symbol_analyzer.rs
+++ b/crates/fbuild-build/src/symbol_analyzer.rs
@@ -15,7 +15,8 @@ use std::collections::BTreeMap;
 use fbuild_core::subprocess::run_command_with_stdin;
 use fbuild_core::symbol_analysis::{
     build_fine_grained_map_with_synth, collect_map_derived_owners, parse_cref_table,
-    parse_linker_map, parse_nm_output, FineGrainedSymbolMap, LoadedRegion, SymbolReference,
+    parse_linker_map, parse_nm_output, sanitize_filename, BackrefGraph, FineGrainedSymbolMap,
+    GraphConfig, LoadedRegion, SymbolReference, TuIndex,
 };
 use fbuild_core::{FbuildError, Result};
 
@@ -405,12 +406,62 @@ pub fn format_text_report(map: &FineGrainedSymbolMap, top_n: usize) -> String {
     lines.join("\n")
 }
 
+/// Knobs controlling whether `format_markdown_report` embeds inline
+/// Graphviz `.dot` blocks for the top symbols and how the walker
+/// behaves while building them. `enabled = false` reproduces the
+/// pre-#463 markdown shape byte-for-byte.
+#[derive(Debug, Clone)]
+pub struct MarkdownGraphOptions {
+    /// Embed `.dot` fenced blocks under `<details>` summaries for
+    /// the top symbols.
+    pub enabled: bool,
+    /// How many top symbols (by flash bytes) get an embedded graph.
+    /// Capped further by the report's own `top_n`.
+    pub graph_top: usize,
+    /// Walker / rendering configuration for each embedded graph.
+    pub config: GraphConfig,
+}
+
+impl Default for MarkdownGraphOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            graph_top: 10,
+            config: GraphConfig::default(),
+        }
+    }
+}
+
 /// Format the same fine-grained map as Markdown — same content as
 /// `format_text_report` but with real table syntax + headers so it
 /// renders nicely in GitHub / VS Code / any MD viewer. Designed to
 /// be saved as `report.md` alongside `report.json` so humans and
 /// scripts can consume the same analysis without diverging.
+///
+/// Pre-existing surface; defers to
+/// [`format_markdown_report_with_graphs`] with graphs disabled. Kept
+/// for legacy callers that don't (yet) want the embedded-graph view.
 pub fn format_markdown_report(map: &FineGrainedSymbolMap, top_n: usize) -> String {
+    format_markdown_report_with_graphs(
+        map,
+        top_n,
+        &MarkdownGraphOptions {
+            enabled: false,
+            graph_top: 0,
+            config: GraphConfig::default(),
+        },
+    )
+}
+
+/// Same as [`format_markdown_report`] but optionally embeds inline
+/// Graphviz `.dot` blocks under each top-N symbol entry (fbuild #463).
+/// AI-friendly: a single self-contained `report.md` answers "what
+/// pulls in X?" without forcing the agent to fetch a sidecar file.
+pub fn format_markdown_report_with_graphs(
+    map: &FineGrainedSymbolMap,
+    top_n: usize,
+    graph_opts: &MarkdownGraphOptions,
+) -> String {
     let mut out = String::new();
     use std::fmt::Write as _;
     let flash_count = map
@@ -488,6 +539,10 @@ pub fn format_markdown_report(map: &FineGrainedSymbolMap, top_n: usize) -> Strin
     );
     emit_md_table(&mut out, map, fbuild_core::MemoryRegion::Ram, top_n, "RAM");
 
+    if graph_opts.enabled && graph_opts.graph_top > 0 {
+        emit_backref_graph_section(&mut out, map, top_n, graph_opts);
+    }
+
     // Per-archive flash roll-up.
     let mut by_archive: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
     for s in &map.symbols {
@@ -508,6 +563,132 @@ pub fn format_markdown_report(map: &FineGrainedSymbolMap, top_n: usize) -> Strin
     }
 
     out
+}
+
+/// Render embedded back-reference graphs for the top symbols
+/// directly into the markdown body. Each entry lives under a
+/// `<details>` so a long top-10 doesn't crowd the report's eye-line
+/// for users who only want the table.
+fn emit_backref_graph_section(
+    out: &mut String,
+    map: &FineGrainedSymbolMap,
+    top_n: usize,
+    graph_opts: &MarkdownGraphOptions,
+) {
+    use std::fmt::Write as _;
+    let mut syms: Vec<_> = map.symbols.iter().collect();
+    syms.sort_by(|a, b| b.size.cmp(&a.size));
+    let limit = graph_opts.graph_top.min(top_n).min(syms.len());
+    if limit == 0 {
+        return;
+    }
+    let _ = writeln!(
+        out,
+        "## Top {limit} back-reference graphs\n\n\
+         For each symbol below, the embedded `dot` block traces \"who pulled \
+         this in?\" outward from the symbol's `referenced_by` data. \
+         See fbuild #463 for the walker design (cross-archive termination + \
+         fan-out cap + collapse rules)."
+    );
+    let _ = writeln!(out);
+    let index = TuIndex::build(map);
+    for (rank, s) in syms.iter().take(limit).enumerate() {
+        let archive = s.archive.as_deref().unwrap_or("(none)");
+        let object = s.object.as_deref().unwrap_or("-");
+        let sect = s.output_section.as_deref().unwrap_or("-");
+        let _ = writeln!(
+            out,
+            "### #{} `{}` — {} B",
+            rank + 1,
+            s.demangled.replace('|', "\\|"),
+            s.size
+        );
+        let _ = writeln!(out, "- **Archive**: `{archive}`");
+        let _ = writeln!(out, "- **Object**: `{object}`");
+        let _ = writeln!(out, "- **Section**: `{sect}`");
+        let _ = writeln!(out, "- **Referenced by**: {} TUs", s.referenced_by.len());
+        let _ = writeln!(out);
+        let graph = BackrefGraph::build_with_index(map, &index, &s.mangled, &graph_opts.config);
+        let _ = writeln!(out, "<details>");
+        let _ = writeln!(out, "<summary>Back-reference graph (Graphviz)</summary>");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "```dot");
+        out.push_str(&graph.to_dot());
+        let _ = writeln!(out, "```");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "</details>");
+        let _ = writeln!(out);
+    }
+}
+
+/// Configuration for [`write_sidecar_dot_files`].
+#[derive(Debug, Clone)]
+pub struct SidecarOptions {
+    pub enabled: bool,
+    /// Minimum symbol size (bytes) for a sidecar `.dot` file to be
+    /// emitted. Default 256 — keeps the output directory to symbols
+    /// that meaningfully contribute to flash.
+    pub min_bytes: u64,
+    /// Walker / rendering configuration shared with the embedded
+    /// markdown graphs.
+    pub config: GraphConfig,
+}
+
+impl Default for SidecarOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            min_bytes: 256,
+            config: GraphConfig::default(),
+        }
+    }
+}
+
+/// Write sidecar `.dot` files for every symbol whose size meets
+/// `options.min_bytes`. Files live at `<output_dir>/graphs/<rank>_<sanitized>.dot`
+/// where `rank` is the symbol's index in the size-descending order
+/// (1-based). Returns the number of files written.
+///
+/// Best-effort — never fails the whole report just because one
+/// filesystem write errored; logs a `tracing::warn!` and moves on.
+pub fn write_sidecar_dot_files(
+    map: &FineGrainedSymbolMap,
+    output_dir: &Path,
+    options: &SidecarOptions,
+) -> Result<usize> {
+    if !options.enabled {
+        return Ok(0);
+    }
+    let graphs_dir = output_dir.join("graphs");
+    std::fs::create_dir_all(&graphs_dir).map_err(|e| {
+        FbuildError::Io(std::io::Error::new(
+            e.kind(),
+            format!("create {}: {e}", graphs_dir.display()),
+        ))
+    })?;
+    let mut syms: Vec<_> = map.symbols.iter().collect();
+    syms.sort_by(|a, b| b.size.cmp(&a.size));
+    let index = TuIndex::build(map);
+    let mut written = 0usize;
+    for (i, s) in syms.iter().enumerate() {
+        if s.size < options.min_bytes {
+            continue;
+        }
+        let rank = i + 1;
+        let stem = sanitize_filename(&s.demangled);
+        let path = graphs_dir.join(format!("{rank:04}_{stem}.dot"));
+        let graph = BackrefGraph::build_with_index(map, &index, &s.mangled, &options.config);
+        let dot = graph.to_dot();
+        if let Err(e) = std::fs::write(&path, dot) {
+            tracing::warn!(
+                "sidecar graph {}: write failed ({e}); skipping",
+                path.display()
+            );
+            continue;
+        }
+        written += 1;
+    }
+    Ok(written)
 }
 
 /// Best-effort discovery of a `firmware.elf` (or any `.elf`) under
@@ -887,6 +1068,204 @@ mod tests {
             md.contains("libc.a(libc_a-vprintf.o), libc.a(libc_a-printf.o), libc.a(libc_a-fprintf.o), (… and 2 more)"),
             "expected top-3 + overflow in referenced_by cell, got:\n{md}"
         );
+    }
+
+    /// fbuild #463: when graph embedding is enabled, the top-N
+    /// symbols carry an inline `dot` fenced block under a
+    /// `<details>` summary. AI-friendliness is the design goal —
+    /// a fresh agent should be able to answer "what pulls in X?"
+    /// from `report.md` alone.
+    #[test]
+    fn markdown_report_with_graphs_embeds_dot_blocks_for_top_symbols() {
+        use fbuild_core::symbol_analysis::{
+            FineGrainedSymbol, FineGrainedSymbolMap, GraphConfig, SectionBytes, SymbolReference,
+        };
+        let map = FineGrainedSymbolMap {
+            elf_path: "fw.elf".into(),
+            map_path: None,
+            total_flash: 11_309,
+            total_ram: 0,
+            symbols: vec![FineGrainedSymbol {
+                mangled: "_vfprintf_r".into(),
+                demangled: "_vfprintf_r".into(),
+                address: 0x4000,
+                size: 11_309,
+                sym_type: 'T',
+                region: fbuild_core::MemoryRegion::Flash,
+                archive: Some("libc.a".into()),
+                object: Some("libc_a-vfprintf.o".into()),
+                output_section: Some(".flash.text".into()),
+                source: "nm".into(),
+                referenced_by: vec![SymbolReference {
+                    archive: Some("liblog.a".into()),
+                    object: "log_write.c.obj".into(),
+                }],
+            }],
+            sections: Vec::<SectionBytes>::new(),
+        };
+        let md = format_markdown_report_with_graphs(
+            &map,
+            5,
+            &MarkdownGraphOptions {
+                enabled: true,
+                graph_top: 10,
+                config: GraphConfig::default(),
+            },
+        );
+        assert!(
+            md.contains("## Top 1 back-reference graphs"),
+            "missing back-ref section header in:\n{md}"
+        );
+        assert!(
+            md.contains("<details>") && md.contains("<summary>Back-reference graph (Graphviz)"),
+            "missing details summary in:\n{md}"
+        );
+        assert!(
+            md.contains("```dot") && md.contains("digraph backref"),
+            "missing fenced dot block in:\n{md}"
+        );
+        // Closure tag is present so the embedded block doesn't bleed
+        // into the next section.
+        assert!(md.contains("</details>"));
+    }
+
+    /// `format_markdown_report` (without `_with_graphs`) MUST NOT
+    /// embed graphs — protects pre-#463 markdown for callers that
+    /// haven't opted in.
+    #[test]
+    fn markdown_report_legacy_path_skips_graph_blocks() {
+        use fbuild_core::symbol_analysis::{FineGrainedSymbol, FineGrainedSymbolMap, SectionBytes};
+        let map = FineGrainedSymbolMap {
+            elf_path: "fw.elf".into(),
+            map_path: None,
+            total_flash: 10,
+            total_ram: 0,
+            symbols: vec![FineGrainedSymbol {
+                mangled: "main".into(),
+                demangled: "main".into(),
+                address: 0x4000,
+                size: 10,
+                sym_type: 'T',
+                region: fbuild_core::MemoryRegion::Flash,
+                archive: None,
+                object: Some("main.cpp.o".into()),
+                output_section: Some(".flash.text".into()),
+                source: "nm".into(),
+                referenced_by: Vec::new(),
+            }],
+            sections: Vec::<SectionBytes>::new(),
+        };
+        let md = format_markdown_report(&map, 5);
+        assert!(!md.contains("```dot"));
+        assert!(!md.contains("back-reference graphs"));
+    }
+
+    #[test]
+    fn sidecar_dot_files_written_for_symbols_above_min_bytes() {
+        use fbuild_core::symbol_analysis::{
+            FineGrainedSymbol, FineGrainedSymbolMap, GraphConfig, SectionBytes,
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let map = FineGrainedSymbolMap {
+            elf_path: "fw.elf".into(),
+            map_path: None,
+            total_flash: 1_200,
+            total_ram: 0,
+            symbols: vec![
+                FineGrainedSymbol {
+                    mangled: "big".into(),
+                    demangled: "big".into(),
+                    address: 0x1000,
+                    size: 1_000,
+                    sym_type: 'T',
+                    region: fbuild_core::MemoryRegion::Flash,
+                    archive: None,
+                    object: Some("main.o".into()),
+                    output_section: Some(".text".into()),
+                    source: "nm".into(),
+                    referenced_by: Vec::new(),
+                },
+                FineGrainedSymbol {
+                    mangled: "tiny".into(),
+                    demangled: "tiny".into(),
+                    address: 0x2000,
+                    size: 100,
+                    sym_type: 'T',
+                    region: fbuild_core::MemoryRegion::Flash,
+                    archive: None,
+                    object: Some("main.o".into()),
+                    output_section: Some(".text".into()),
+                    source: "nm".into(),
+                    referenced_by: Vec::new(),
+                },
+            ],
+            sections: Vec::<SectionBytes>::new(),
+        };
+        let written = write_sidecar_dot_files(
+            &map,
+            tmp.path(),
+            &SidecarOptions {
+                enabled: true,
+                min_bytes: 500,
+                config: GraphConfig::default(),
+            },
+        )
+        .unwrap();
+        assert_eq!(written, 1, "only `big` (1000 B) clears the 500 B threshold");
+        // Locate the sidecar — rank 1 (largest), demangled "big".
+        let graphs = tmp.path().join("graphs");
+        assert!(graphs.is_dir());
+        let entries: Vec<_> = std::fs::read_dir(&graphs).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+        let path = entries[0].as_ref().unwrap().path();
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        assert!(
+            name.starts_with("0001_") && name.ends_with(".dot"),
+            "got {name}"
+        );
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.starts_with("digraph"));
+    }
+
+    #[test]
+    fn sidecar_disabled_writes_nothing() {
+        use fbuild_core::symbol_analysis::{
+            FineGrainedSymbol, FineGrainedSymbolMap, GraphConfig, SectionBytes,
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let map = FineGrainedSymbolMap {
+            elf_path: "fw.elf".into(),
+            map_path: None,
+            total_flash: 1_000,
+            total_ram: 0,
+            symbols: vec![FineGrainedSymbol {
+                mangled: "x".into(),
+                demangled: "x".into(),
+                address: 0x1000,
+                size: 1_000,
+                sym_type: 'T',
+                region: fbuild_core::MemoryRegion::Flash,
+                archive: None,
+                object: Some("x.o".into()),
+                output_section: Some(".text".into()),
+                source: "nm".into(),
+                referenced_by: Vec::new(),
+            }],
+            sections: Vec::<SectionBytes>::new(),
+        };
+        let written = write_sidecar_dot_files(
+            &map,
+            tmp.path(),
+            &SidecarOptions {
+                enabled: false,
+                min_bytes: 0,
+                config: GraphConfig::default(),
+            },
+        )
+        .unwrap();
+        assert_eq!(written, 0);
+        // graphs/ dir should not have been created either.
+        assert!(!tmp.path().join("graphs").exists());
     }
 
     #[test]

--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -118,6 +118,46 @@ pub enum Commands {
         /// markdown report.
         #[arg(long, default_value = "25")]
         top: usize,
+        /// Skip embedded Graphviz `.dot` blocks in `report.md` and
+        /// don't write sidecar `graphs/*.dot` files. Use when a slim
+        /// report is preferred (e.g. CI bloat-budget gates that diff
+        /// only the JSON).
+        #[arg(long = "no-graph")]
+        no_graph: bool,
+        /// How many top symbols get an embedded back-reference graph
+        /// in `report.md` (default 10, capped by `--top`).
+        #[arg(long = "graph-top", default_value = "10")]
+        graph_top: usize,
+        /// Minimum size in bytes for a sidecar `.dot` file to be
+        /// written under `<output-dir>/graphs/`. Default 256 keeps
+        /// the per-symbol output to non-trivial contributors.
+        #[arg(long = "graph-min-bytes", default_value = "256")]
+        graph_min_bytes: u64,
+        /// Traversal depth: `adaptive` stops the first time a branch
+        /// leaves the root archive; `<N>` forces an exact hop count.
+        #[arg(long = "graph-depth", default_value = "adaptive")]
+        graph_depth: String,
+        /// Per-node fan-out cap (default 5). Excess referencers
+        /// collapse into a single `(… and N more)` super-node.
+        #[arg(long = "graph-fan-out", default_value = "5")]
+        graph_fan_out: usize,
+        /// Comma-separated archive list to collapse into per-archive
+        /// super-nodes. Default `libc.a,libgcc.a` hides the libc
+        /// internal-wrapper layer so non-libc callers stand out.
+        #[arg(long = "graph-collapse-archive", default_value = "libc.a,libgcc.a")]
+        graph_collapse_archive: String,
+        /// Comma-separated archive list to drop from the graph
+        /// entirely. Default empty.
+        #[arg(long = "graph-exclude-archive", default_value = "")]
+        graph_exclude_archive: String,
+    },
+    /// Bloat-related subcommands. Today this hosts `graph` (back-
+    /// reference Graphviz export, fbuild #463); when #434 lands the
+    /// report-rename, the existing `fbuild symbols` becomes
+    /// `fbuild bloat` and lives here as a sibling subcommand.
+    Bloat {
+        #[command(subcommand)]
+        cmd: BloatCmd,
     },
     /// Build firmware
     Build {
@@ -558,6 +598,61 @@ pub enum DaemonAction {
     },
 }
 
+/// Subcommands under `fbuild bloat`. The parent enum lives so future
+/// `bloat`-themed actions (report, diff, budget gate) cohabit cleanly;
+/// today only `graph` ships — see fbuild #463.
+#[derive(Subcommand)]
+pub enum BloatCmd {
+    /// Render a Graphviz `.dot` back-reference graph rooted at one
+    /// symbol. Walks the `referenced_by` data emitted by
+    /// `fbuild symbols` (#459) outward, applying cross-archive
+    /// termination + per-node fan-out caps + collapse-archive rules
+    /// so dense hubs like `printf` stay readable.
+    Graph {
+        /// ELF file OR project directory (same resolution as
+        /// `fbuild symbols`).
+        input: String,
+        /// Target symbol (mangled OR demangled — fbuild matches on
+        /// either).
+        #[arg(long, short = 's')]
+        symbol: String,
+        /// Path to the linker map (auto-detected if omitted).
+        #[arg(long)]
+        map: Option<String>,
+        /// Cross-toolchain `nm` (auto-resolved when omitted).
+        #[arg(long)]
+        nm: Option<String>,
+        /// Cross-toolchain `c++filt` (derived from `nm` stem when
+        /// omitted).
+        #[arg(long = "cppfilt")]
+        cppfilt: Option<String>,
+        /// Path to a `build_info.json` that carries toolchain paths.
+        #[arg(long = "build-info")]
+        build_info: Option<String>,
+        /// Output path for the `.dot` file. Defaults to stdout.
+        #[arg(short = 'o', long = "output")]
+        output: Option<String>,
+        /// Traversal depth: `adaptive` (default) or `<N>` for a fixed
+        /// hop count.
+        #[arg(long, default_value = "adaptive")]
+        depth: String,
+        /// Per-node fan-out cap (excess collapses into a `(… and N
+        /// more)` super-node).
+        #[arg(long = "fan-out", default_value = "5")]
+        fan_out: usize,
+        /// Hard cap on traversal depth (safety belt for adaptive).
+        #[arg(long = "max-depth", default_value = "4")]
+        max_depth: u32,
+        /// Comma-separated archive list to collapse into per-archive
+        /// super-nodes.
+        #[arg(long = "collapse-archive", default_value = "libc.a,libgcc.a")]
+        collapse_archive: String,
+        /// Comma-separated archive list to drop from the graph.
+        #[arg(long = "exclude-archive", default_value = "")]
+        exclude_archive: String,
+    },
+}
+
 /// Resolve project_dir: prefer the subcommand's value, fall back to the top-level positional arg,
 /// then default to ".".  This lets callers write either `fbuild build <dir>` or `fbuild <dir> build`.
 pub fn resolve_project_dir(
@@ -587,6 +682,8 @@ pub const KNOWN_SUBCOMMANDS: &[&str] = &[
     "lib-select",
     "compile-many",
     "ci",
+    "symbols",
+    "bloat",
 ];
 
 /// Rewrite `fbuild <dir> <subcommand> ...` → `fbuild <subcommand> <dir> ...`

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 
 use crate::{daemon_client, lib_select, mcp};
 
-use super::args::{resolve_project_dir, rewrite_args, Cli, Commands};
+use super::args::{resolve_project_dir, rewrite_args, BloatCmd, Cli, Commands};
 use super::build::run_build;
 use super::clang_tools::{run_clang_tool, run_iwyu};
 use super::compile_many::{
@@ -14,6 +14,7 @@ use super::compile_many::{
 use super::daemon_cmd::run_daemon;
 use super::deploy::{run_deploy, run_monitor, run_test_emu};
 use super::device::run_device;
+use super::graph_cmd::run_bloat_graph;
 use super::lnk::run_lnk;
 use super::monitor_parse::parse_monitor_flags;
 use super::pio::{pio_build, pio_deploy, pio_monitor};
@@ -65,7 +66,59 @@ pub async fn async_main() {
             json,
             output_dir,
             top,
-        }) => run_symbols(input, map, nm, cppfilt, build_info, json, output_dir, top),
+            no_graph,
+            graph_top,
+            graph_min_bytes,
+            graph_depth,
+            graph_fan_out,
+            graph_collapse_archive,
+            graph_exclude_archive,
+        }) => run_symbols(
+            input,
+            map,
+            nm,
+            cppfilt,
+            build_info,
+            json,
+            output_dir,
+            top,
+            no_graph,
+            graph_top,
+            graph_min_bytes,
+            graph_depth,
+            graph_fan_out,
+            graph_collapse_archive,
+            graph_exclude_archive,
+        ),
+        Some(Commands::Bloat { cmd }) => match cmd {
+            BloatCmd::Graph {
+                input,
+                symbol,
+                map,
+                nm,
+                cppfilt,
+                build_info,
+                output,
+                depth,
+                fan_out,
+                max_depth,
+                collapse_archive,
+                exclude_archive,
+            } => run_bloat_graph(
+                input,
+                symbol,
+                map,
+                nm,
+                cppfilt,
+                build_info,
+                output,
+                depth,
+                fan_out,
+                max_depth,
+                collapse_archive,
+                exclude_archive,
+            ),
+        },
         Some(Commands::Build {
             project_dir,
             environment,

--- a/crates/fbuild-cli/src/cli/graph_cmd.rs
+++ b/crates/fbuild-cli/src/cli/graph_cmd.rs
@@ -1,0 +1,180 @@
+//! `fbuild bloat graph` — render a back-reference graph for one
+//! symbol as Graphviz `.dot`.
+//!
+//! Consumes the same toolchain resolution as `fbuild symbols` (#428)
+//! so callers don't have to wire `--nm` / `--cppfilt` twice. Walks
+//! the symbol's transitive `referenced_by` data outward using the
+//! adaptive strategy documented in
+//! [`fbuild_core::symbol_analysis::graph`].
+//!
+//! Output goes either to `-o <path>` or stdout. The walker is pure
+//! (no I/O); this module is only the CLI glue.
+
+use std::path::PathBuf;
+
+use fbuild_build::symbol_analyzer::{
+    analyze_elf, default_map_path, discover_elf_in_project, AnalyzeConfig,
+};
+use fbuild_core::symbol_analysis::{BackrefGraph, GraphConfig, GraphDepth};
+use fbuild_core::{FbuildError, Result};
+
+use super::symbols_cmd::resolve_tool_paths_public;
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_bloat_graph(
+    input: String,
+    symbol: String,
+    map: Option<String>,
+    nm: Option<String>,
+    cppfilt: Option<String>,
+    build_info: Option<String>,
+    output: Option<String>,
+    depth: String,
+    fan_out: usize,
+    max_depth: u32,
+    collapse_archive: String,
+    exclude_archive: String,
+) -> Result<()> {
+    let input_path = PathBuf::from(&input);
+    if !input_path.exists() {
+        return Err(FbuildError::BuildFailed(format!(
+            "input not found: {}",
+            input_path.display()
+        )));
+    }
+    let elf_path = if input_path.is_dir() {
+        discover_elf_in_project(&input_path).ok_or_else(|| {
+            FbuildError::BuildFailed(format!("no ELF found under {}", input_path.display()))
+        })?
+    } else {
+        input_path
+    };
+
+    let (nm_path, cppfilt_path) = resolve_tool_paths_public(
+        &elf_path,
+        nm.as_deref(),
+        cppfilt.as_deref(),
+        build_info.as_deref(),
+    )?;
+
+    let map_path_owned = map
+        .map(PathBuf::from)
+        .or_else(|| default_map_path(&elf_path));
+
+    let cfg = AnalyzeConfig {
+        elf_path: &elf_path,
+        map_path: map_path_owned.as_deref(),
+        nm_path: &nm_path,
+        cppfilt_path: cppfilt_path.as_deref(),
+    };
+    let report = analyze_elf(cfg)?;
+
+    let graph_config = parse_graph_config(
+        &depth,
+        fan_out,
+        max_depth,
+        &collapse_archive,
+        &exclude_archive,
+    )?;
+    let graph = BackrefGraph::build(&report, &symbol, &graph_config);
+    let dot = graph.to_dot();
+
+    match output {
+        Some(path) => {
+            std::fs::write(&path, &dot).map_err(|e| {
+                FbuildError::Io(std::io::Error::new(e.kind(), format!("write {path}: {e}")))
+            })?;
+            println!(
+                "Wrote back-reference graph for {symbol} to {path} ({} nodes, {} edges)",
+                graph.nodes.len(),
+                graph.edges.len()
+            );
+        }
+        None => {
+            print!("{dot}");
+        }
+    }
+    Ok(())
+}
+
+/// Parse the user-facing flag strings into a fully-populated
+/// [`GraphConfig`]. Public-ish helper because the report-embed path
+/// in `symbols_cmd.rs` parses the same flag shapes for the
+/// `--graph-*` set.
+pub fn parse_graph_config(
+    depth: &str,
+    fan_out: usize,
+    max_depth: u32,
+    collapse_archive: &str,
+    exclude_archive: &str,
+) -> Result<GraphConfig> {
+    let depth = match depth.trim().to_ascii_lowercase().as_str() {
+        "adaptive" | "auto" | "" => GraphDepth::Adaptive,
+        s => match s.parse::<u32>() {
+            Ok(n) => GraphDepth::Fixed(n),
+            Err(_) => {
+                return Err(FbuildError::BuildFailed(format!(
+                    "graph --depth: expected 'adaptive' or a non-negative \
+                     integer, got `{s}`"
+                )))
+            }
+        },
+    };
+    let collapse_archives: Vec<String> = split_archive_list(collapse_archive);
+    let exclude_archives: Vec<String> = split_archive_list(exclude_archive);
+    Ok(GraphConfig {
+        depth,
+        fan_out: fan_out.max(1),
+        max_depth: max_depth.max(1),
+        collapse_archives,
+        exclude_archives,
+    })
+}
+
+fn split_archive_list(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(|x| x.trim())
+        .filter(|x| !x.is_empty())
+        .map(|x| x.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_graph_config_adaptive_default() {
+        let c = parse_graph_config("adaptive", 5, 4, "libc.a,libgcc.a", "").unwrap();
+        assert!(matches!(c.depth, GraphDepth::Adaptive));
+        assert_eq!(c.fan_out, 5);
+        assert_eq!(c.max_depth, 4);
+        assert_eq!(c.collapse_archives, vec!["libc.a", "libgcc.a"]);
+        assert!(c.exclude_archives.is_empty());
+    }
+
+    #[test]
+    fn parse_graph_config_fixed_depth() {
+        let c = parse_graph_config("3", 5, 4, "", "").unwrap();
+        assert!(matches!(c.depth, GraphDepth::Fixed(3)));
+    }
+
+    #[test]
+    fn parse_graph_config_rejects_garbage_depth() {
+        let err = parse_graph_config("woof", 5, 4, "", "").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("graph --depth"), "got: {msg}");
+    }
+
+    #[test]
+    fn split_archive_list_handles_spaces_and_empties() {
+        let v = split_archive_list("libc.a, libgcc.a ,, libm.a");
+        assert_eq!(v, vec!["libc.a", "libgcc.a", "libm.a"]);
+    }
+
+    #[test]
+    fn fan_out_zero_clamps_to_one() {
+        let c = parse_graph_config("adaptive", 0, 4, "", "").unwrap();
+        assert_eq!(c.fan_out, 1);
+    }
+}

--- a/crates/fbuild-cli/src/cli/mod.rs
+++ b/crates/fbuild-cli/src/cli/mod.rs
@@ -17,6 +17,7 @@ pub mod daemon_cmd;
 pub mod deploy;
 pub mod device;
 pub mod dispatch;
+pub mod graph_cmd;
 pub mod lnk;
 pub mod monitor_parse;
 pub mod pio;

--- a/crates/fbuild-cli/src/cli/symbols_cmd.rs
+++ b/crates/fbuild-cli/src/cli/symbols_cmd.rs
@@ -19,9 +19,12 @@ use std::path::{Path, PathBuf};
 use fbuild_build::build_info::{find_build_info_near, load_build_info};
 use fbuild_build::symbol_analyzer::{
     analyze_elf, default_map_path, derive_cppfilt_path, discover_elf_in_project,
-    format_markdown_report, format_text_report, AnalyzeConfig,
+    format_markdown_report, format_markdown_report_with_graphs, format_text_report,
+    write_sidecar_dot_files, AnalyzeConfig, MarkdownGraphOptions, SidecarOptions,
 };
 use fbuild_core::{FbuildError, Result};
+
+use super::graph_cmd::parse_graph_config;
 
 #[allow(clippy::too_many_arguments)]
 pub fn run_symbols(
@@ -33,6 +36,13 @@ pub fn run_symbols(
     json_out: Option<String>,
     output_dir: Option<String>,
     top: usize,
+    no_graph: bool,
+    graph_top: usize,
+    graph_min_bytes: u64,
+    graph_depth: String,
+    graph_fan_out: usize,
+    graph_collapse_archive: String,
+    graph_exclude_archive: String,
 ) -> Result<()> {
     let input_path = PathBuf::from(&input);
     if !input_path.exists() {
@@ -102,20 +112,53 @@ pub fn run_symbols(
         let json_target = dir.join("report.json");
         let md_target = dir.join("report.md");
         write_json(&report, &json_target.to_string_lossy())?;
-        let md = format_markdown_report(&report, top);
+        let graph_config = parse_graph_config(
+            &graph_depth,
+            graph_fan_out,
+            /*max_depth=*/ 4,
+            &graph_collapse_archive,
+            &graph_exclude_archive,
+        )?;
+        let md = if no_graph {
+            format_markdown_report(&report, top)
+        } else {
+            format_markdown_report_with_graphs(
+                &report,
+                top,
+                &MarkdownGraphOptions {
+                    enabled: true,
+                    graph_top,
+                    config: graph_config.clone(),
+                },
+            )
+        };
         std::fs::write(&md_target, md).map_err(|e| {
             FbuildError::Io(std::io::Error::new(
                 e.kind(),
                 format!("write {}: {e}", md_target.display()),
             ))
         })?;
+        let sidecar_count = if no_graph {
+            0
+        } else {
+            write_sidecar_dot_files(
+                &report,
+                &dir,
+                &SidecarOptions {
+                    enabled: true,
+                    min_bytes: graph_min_bytes,
+                    config: graph_config,
+                },
+            )?
+        };
         println!(
-            "Wrote {} symbols to {} and {} (flash={} B, ram={} B)",
+            "Wrote {} symbols to {} and {} (flash={} B, ram={} B); {} sidecar graphs",
             report.symbols.len(),
             json_target.display(),
             md_target.display(),
             report.total_flash,
-            report.total_ram
+            report.total_ram,
+            sidecar_count,
         );
         wrote_anything = true;
     }
@@ -238,6 +281,27 @@ impl ToolPaths {
 
         Ok(Self { nm, cppfilt })
     }
+}
+
+/// Public wrapper around the internal toolchain resolver — used by
+/// `fbuild bloat graph` (`graph_cmd.rs`) so it shares the exact
+/// `--nm` / `--cppfilt` / `--build-info` resolution semantics as
+/// `fbuild symbols`. Returns `(nm_path, optional_cppfilt_path)`.
+pub fn resolve_tool_paths_public(
+    elf_path: &Path,
+    nm: Option<&str>,
+    cppfilt: Option<&str>,
+    build_info_arg: Option<&str>,
+) -> Result<(PathBuf, Option<PathBuf>)> {
+    let resolved = ToolPaths::resolve(elf_path, nm, cppfilt, build_info_arg)?;
+    if !resolved.nm.exists() {
+        return Err(FbuildError::BuildFailed(format!(
+            "nm not found at {}\n\
+             Pass --nm explicitly or run `fbuild build` first so build_info.json carries nm_path.",
+            resolved.nm.display()
+        )));
+    }
+    Ok((resolved.nm, resolved.cppfilt))
 }
 
 /// Treat an empty BuildInfo path field (the schema's "missing"

--- a/crates/fbuild-core/src/symbol_analysis/README.md
+++ b/crates/fbuild-core/src/symbol_analysis/README.md
@@ -5,6 +5,7 @@ Pure parsers and aggregators behind `fbuild bloat` (legacy `fbuild symbols`):
 - `parse_nm_line` / `parse_nm_output` — `nm --print-size -S` row parsing.
 - `parse_linker_map` — GNU `ld -Map` output → per-input-section ranges.
 - `parse_cref_table` — GNU `ld --cref` `Cross Reference Table` block → mangled-symbol → referencer `(archive, object)` list. See [#459](https://github.com/FastLED/fbuild/issues/459). Empty result when the map lacks a cref block (older `ld`, `-Wl,--no-cref`) — never a hard error.
+- `graph::BackrefGraph` — back-reference graph + Graphviz `.dot` rendering rooted at a target symbol. Consumes the cref `referenced_by` data, applies adaptive depth termination + per-node fan-out caps + collapse-archive rules so dense hubs (`printf` has ~25 mbedTLS referencers on ESP32-P4) stay readable. See [#463](https://github.com/FastLED/fbuild/issues/463).
 - `classify_region` — nm type letter → `Flash` / `Ram` bucket.
 - `FineGrainedSymbolMap::retain_loaded_symbols` — drop symbols whose `[addr, addr+size)` doesn't fit any `PT_LOAD` region, so linker-script boundary markers (`__StackTop`, `__flash_arduino_end`) don't pollute the bloat report.
 - `build_fine_grained_map_with_synth` — fold nm rows + map ranges + demangled names + cref into the per-symbol report.
@@ -17,4 +18,5 @@ Intentionally has no ELF-parsing dep; ELF I/O lives in `fbuild_build::symbol_ana
 
 - `mod.rs` — types and pure functions.
 - `cref.rs` — `Cross Reference Table` parser.
+- `graph.rs` — back-reference graph walker + `.dot` renderer.
 - `tests.rs` — unit tests.

--- a/crates/fbuild-core/src/symbol_analysis/graph.rs
+++ b/crates/fbuild-core/src/symbol_analysis/graph.rs
@@ -1,0 +1,986 @@
+//! Back-reference graph synthesis + Graphviz `.dot` rendering.
+//!
+//! Consumes the `referenced_by` field that [`super::cref`] populates and
+//! walks outward from a target symbol to surface "who pulled this in?".
+//! Output is a Graphviz `.dot` string suitable for `dot -Tsvg`, inline
+//! embedding in a Markdown report, or AI consumers parsing back-edges
+//! directly from the textual form.
+//!
+//! The walker is **pure** — no I/O, no subprocess — so unit tests
+//! exercise the full traversal and serialization path. The CLI and
+//! markdown integrations in `fbuild-build` / `fbuild-cli` are thin
+//! wrappers around this module.
+//!
+//! ## Termination strategy
+//!
+//! `ld --cref` gives us TU-granularity back-references. A naive
+//! breadth-first walk explodes for hub symbols (`printf` has ~25
+//! mbedTLS referencers; expanding two more hops produces an
+//! unreadable wall). The default policy mixes three predicates so the
+//! resulting graph stays readable without per-symbol tuning:
+//!
+//! 1. **Cross-archive termination.** Stop expanding a branch the
+//!    first time it crosses out of the root symbol's archive. This
+//!    surfaces the boundary where the symbol "escapes" its own
+//!    library — exactly what bloat analysts want. `Fixed(N)` skips
+//!    this rule.
+//! 2. **Fan-out cap `K`.** Per node, sort referencing TUs by their
+//!    *own* attributed flash bytes (sum of symbol sizes defined in
+//!    that TU), keep the top `K`, and collapse the rest into a
+//!    `[… and M more]` super-node.
+//! 3. **Hard depth cap.** If neither of the above has fired by depth
+//!    `max_depth`, bail. Default 4 — enough to escape one library +
+//!    two intermediate hops + one app TU, but not enough to enumerate
+//!    an IDF subsystem's entire fan-in.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use super::{FineGrainedSymbolMap, SymbolReference};
+
+/// Traversal-depth policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GraphDepth {
+    /// Stop expanding the first time a branch leaves the root
+    /// symbol's archive. Still respects [`GraphConfig::max_depth`]
+    /// as a safety belt.
+    #[default]
+    Adaptive,
+    /// Walk exactly `N` hops outward, regardless of archive
+    /// transitions. Useful when the caller wants a uniform-depth
+    /// view (e.g. `--depth 2` for "everyone two hops out").
+    Fixed(u32),
+}
+
+/// User-visible knobs for back-reference graph synthesis.
+#[derive(Debug, Clone)]
+pub struct GraphConfig {
+    pub depth: GraphDepth,
+    /// Per-node fan-out cap. Excess referencers collapse into a
+    /// single `[… and N more]` super-node so dense hubs don't blow
+    /// the graph up. Default 5.
+    pub fan_out: usize,
+    /// Hard cap on traversal depth even when `Adaptive` hasn't
+    /// terminated. Default 4.
+    pub max_depth: u32,
+    /// Archives whose hops collapse into a single super-node per
+    /// archive. Useful for the libc internal-wrapper case
+    /// (`_vfprintf_r` → `libc_a-vprintf.o` → `libc_a-printf.o` →
+    /// …); collapsing `libc.a` skips straight to the non-libc edges.
+    pub collapse_archives: Vec<String>,
+    /// Archives whose branches are dropped entirely. Use when the
+    /// caller only cares about non-system referencers.
+    pub exclude_archives: Vec<String>,
+}
+
+impl Default for GraphConfig {
+    fn default() -> Self {
+        Self {
+            depth: GraphDepth::Adaptive,
+            fan_out: 5,
+            max_depth: 4,
+            collapse_archives: vec!["libc.a".to_string(), "libgcc.a".to_string()],
+            exclude_archives: Vec::new(),
+        }
+    }
+}
+
+/// One node in the back-reference graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphNode {
+    /// Stable id used as the `.dot` node name.
+    pub id: String,
+    /// Display label rendered inside the node box.
+    pub label: String,
+    /// Archive group for coloring (`libc.a`, `libFastLED.a`, …).
+    pub archive: Option<String>,
+    /// Object file name (for non-collapsed nodes).
+    pub object: Option<String>,
+    pub kind: NodeKind,
+    /// BFS distance from the root symbol (0 = root).
+    pub depth: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeKind {
+    /// The target symbol we're tracing. Always exactly one of these.
+    RootSymbol { demangled: String, size: u64 },
+    /// A translation unit that (transitively) references the root.
+    /// `size_hint` is the sum of symbol sizes attributed to this TU
+    /// in the report, used both for fan-out ranking and node sizing.
+    TranslationUnit { size_hint: Option<u64> },
+    /// A super-node bundling multiple TUs from the same archive
+    /// because of `collapse_archives` OR fan-out overflow.
+    Collapsed { archive: String, count: usize },
+}
+
+/// Directed edge from a referencer toward what it references.
+/// (`from` referenced `to`.)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphEdge {
+    pub from: String,
+    pub to: String,
+}
+
+/// Back-reference graph rooted at a single target symbol.
+#[derive(Debug, Clone)]
+pub struct BackrefGraph {
+    pub root_id: String,
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+/// Index over a symbol map for fast "what symbols live in this TU?"
+/// lookups during graph synthesis. Built once per analysis run.
+pub struct TuIndex<'a> {
+    /// `(archive, object) -> Vec<&FineGrainedSymbol>`. `archive: None`
+    /// keeps bare-object TUs separate (`main.cpp.o` has no archive).
+    by_tu: BTreeMap<(Option<String>, String), Vec<&'a super::FineGrainedSymbol>>,
+}
+
+impl<'a> TuIndex<'a> {
+    pub fn build(map: &'a FineGrainedSymbolMap) -> Self {
+        let mut by_tu: BTreeMap<(Option<String>, String), Vec<&'a super::FineGrainedSymbol>> =
+            BTreeMap::new();
+        for s in &map.symbols {
+            let Some(obj) = s.object.as_ref() else {
+                continue;
+            };
+            by_tu
+                .entry((s.archive.clone(), obj.clone()))
+                .or_default()
+                .push(s);
+        }
+        Self { by_tu }
+    }
+
+    /// All symbols defined in a TU.
+    pub fn symbols_in(&self, tu: &SymbolReference) -> &[&'a super::FineGrainedSymbol] {
+        self.by_tu
+            .get(&(tu.archive.clone(), tu.object.clone()))
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Total flash + ram bytes attributed to a TU. Used both for
+    /// fan-out ranking (bigger contributors rank higher) and for
+    /// node sizing in the rendered graph.
+    pub fn bytes_in(&self, tu: &SymbolReference) -> u64 {
+        self.symbols_in(tu).iter().map(|s| s.size).sum()
+    }
+
+    /// Aggregate every TU's contributed bytes for callers that want
+    /// a global ranking (e.g. sidecar-file selection).
+    pub fn tu_total_bytes(&self) -> BTreeMap<(Option<String>, String), u64> {
+        let mut out: BTreeMap<(Option<String>, String), u64> = BTreeMap::new();
+        for (key, syms) in &self.by_tu {
+            let total: u64 = syms.iter().map(|s| s.size).sum();
+            out.insert(key.clone(), total);
+        }
+        out
+    }
+}
+
+impl BackrefGraph {
+    /// Build the graph rooted at a target symbol (looked up by
+    /// **mangled** name — matches `FineGrainedSymbol::mangled`).
+    /// Returns a single-node graph when the symbol is unknown or
+    /// has no referencers (the report should still embed something
+    /// rather than crash; "no referencers" is a valid finding).
+    pub fn build(map: &FineGrainedSymbolMap, target_mangled: &str, config: &GraphConfig) -> Self {
+        let index = TuIndex::build(map);
+        Self::build_with_index(map, &index, target_mangled, config)
+    }
+
+    /// Same as [`build`] but reuses a pre-built index — useful when
+    /// emitting graphs for every top-N symbol (the per-symbol index
+    /// rebuild would be O(N²)).
+    pub fn build_with_index(
+        map: &FineGrainedSymbolMap,
+        index: &TuIndex<'_>,
+        target_mangled: &str,
+        config: &GraphConfig,
+    ) -> Self {
+        // Resolve the root symbol from the map.
+        let root = map
+            .symbols
+            .iter()
+            .find(|s| s.mangled == target_mangled || s.demangled == target_mangled);
+        let Some(root) = root else {
+            // Unknown symbol: emit a single isolated node so the
+            // caller still gets a renderable .dot, not a parse error.
+            let root_id = sanitize_id(target_mangled);
+            return Self {
+                root_id: root_id.clone(),
+                nodes: vec![GraphNode {
+                    id: root_id,
+                    label: format!("{target_mangled}\n(not in symbol map)"),
+                    archive: None,
+                    object: None,
+                    kind: NodeKind::RootSymbol {
+                        demangled: target_mangled.to_string(),
+                        size: 0,
+                    },
+                    depth: 0,
+                }],
+                edges: Vec::new(),
+            };
+        };
+
+        let root_archive = root.archive.clone();
+        let root_id = format!("sym__{}", sanitize_id(&root.mangled));
+        let mut nodes: Vec<GraphNode> = vec![GraphNode {
+            id: root_id.clone(),
+            label: format_root_label(&root.demangled, root.size),
+            archive: root.archive.clone(),
+            object: root.object.clone(),
+            kind: NodeKind::RootSymbol {
+                demangled: root.demangled.clone(),
+                size: root.size,
+            },
+            depth: 0,
+        }];
+        let mut edges: Vec<GraphEdge> = Vec::new();
+        let mut node_id_by_tu: BTreeMap<(Option<String>, String), String> = BTreeMap::new();
+        let mut visited_tus: BTreeSet<(Option<String>, String)> = BTreeSet::new();
+
+        // BFS queue. Each entry: (current TU, target node id it points to, depth).
+        let mut queue: VecDeque<((Option<String>, String), String, u32)> = VecDeque::new();
+
+        // Seed level 1: every TU that directly references the root.
+        let level1 = rank_and_cap_referencers(
+            &root.referenced_by,
+            index,
+            config,
+            &root_archive,
+            /*depth=*/ 1,
+        );
+        for entry in level1 {
+            match entry {
+                CappedReferencer::Tu(tu_ref) => {
+                    let key = (tu_ref.archive.clone(), tu_ref.object.clone());
+                    if visited_tus.insert(key.clone()) {
+                        let node_id = format!("tu__{}", sanitize_id(&tu_id_str(&tu_ref)));
+                        let label = format_tu_label(&tu_ref, index.bytes_in(&tu_ref));
+                        let size_hint = Some(index.bytes_in(&tu_ref));
+                        nodes.push(GraphNode {
+                            id: node_id.clone(),
+                            label,
+                            archive: tu_ref.archive.clone(),
+                            object: Some(tu_ref.object.clone()),
+                            kind: NodeKind::TranslationUnit { size_hint },
+                            depth: 1,
+                        });
+                        node_id_by_tu.insert(key.clone(), node_id.clone());
+                        edges.push(GraphEdge {
+                            from: node_id.clone(),
+                            to: root_id.clone(),
+                        });
+                        queue.push_back((key, node_id, 1));
+                    }
+                }
+                CappedReferencer::CollapsedArchive { archive, count } => {
+                    let node_id = format!("col__{}__d1", sanitize_id(&archive));
+                    if !nodes.iter().any(|n| n.id == node_id) {
+                        nodes.push(GraphNode {
+                            id: node_id.clone(),
+                            label: format!("[{archive}]\n{count} TUs"),
+                            archive: Some(archive.clone()),
+                            object: None,
+                            kind: NodeKind::Collapsed { archive, count },
+                            depth: 1,
+                        });
+                    }
+                    edges.push(GraphEdge {
+                        from: node_id,
+                        to: root_id.clone(),
+                    });
+                }
+                CappedReferencer::FanOutOverflow { count } => {
+                    let node_id = format!("ovf__d1__{}", count);
+                    nodes.push(GraphNode {
+                        id: node_id.clone(),
+                        label: format!("(… and {count} more)"),
+                        archive: None,
+                        object: None,
+                        kind: NodeKind::Collapsed {
+                            archive: "(overflow)".to_string(),
+                            count,
+                        },
+                        depth: 1,
+                    });
+                    edges.push(GraphEdge {
+                        from: node_id,
+                        to: root_id.clone(),
+                    });
+                }
+            }
+        }
+
+        // Expand: each TU's parents are the union of `referenced_by`
+        // across every symbol defined in that TU.
+        while let Some((current_key, current_id, depth)) = queue.pop_front() {
+            if depth >= config.max_depth {
+                continue;
+            }
+            // Adaptive termination: if we've already left the root
+            // archive (and the root had an archive at all), stop
+            // expanding past this node. Fixed-depth ignores this.
+            let current_archive = current_key.0.clone();
+            if matches!(config.depth, GraphDepth::Adaptive)
+                && depth >= 1
+                && root_archive.is_some()
+                && current_archive != root_archive
+            {
+                continue;
+            }
+            let current_tu = SymbolReference {
+                archive: current_key.0.clone(),
+                object: current_key.1.clone(),
+            };
+            // Collect parent TUs ranked by their own attributed bytes.
+            let mut parent_refs: Vec<SymbolReference> = Vec::new();
+            let mut seen: BTreeSet<(Option<String>, String)> = BTreeSet::new();
+            for sym in index.symbols_in(&current_tu) {
+                for r in &sym.referenced_by {
+                    let key = (r.archive.clone(), r.object.clone());
+                    if key == current_key {
+                        continue; // self-reference, skip
+                    }
+                    if seen.insert(key) {
+                        parent_refs.push(r.clone());
+                    }
+                }
+            }
+            let next_depth = depth + 1;
+            let capped =
+                rank_and_cap_referencers(&parent_refs, index, config, &root_archive, next_depth);
+            for entry in capped {
+                match entry {
+                    CappedReferencer::Tu(tu_ref) => {
+                        let key = (tu_ref.archive.clone(), tu_ref.object.clone());
+                        if !visited_tus.insert(key.clone()) {
+                            // Already in the graph — just add the edge.
+                            if let Some(target_id) = node_id_by_tu.get(&key) {
+                                push_edge_dedup(
+                                    &mut edges,
+                                    GraphEdge {
+                                        from: target_id.clone(),
+                                        to: current_id.clone(),
+                                    },
+                                );
+                            }
+                            continue;
+                        }
+                        let node_id = format!("tu__{}", sanitize_id(&tu_id_str(&tu_ref)));
+                        let label = format_tu_label(&tu_ref, index.bytes_in(&tu_ref));
+                        let size_hint = Some(index.bytes_in(&tu_ref));
+                        nodes.push(GraphNode {
+                            id: node_id.clone(),
+                            label,
+                            archive: tu_ref.archive.clone(),
+                            object: Some(tu_ref.object.clone()),
+                            kind: NodeKind::TranslationUnit { size_hint },
+                            depth: next_depth,
+                        });
+                        node_id_by_tu.insert(key.clone(), node_id.clone());
+                        edges.push(GraphEdge {
+                            from: node_id.clone(),
+                            to: current_id.clone(),
+                        });
+                        queue.push_back((key, node_id, next_depth));
+                    }
+                    CappedReferencer::CollapsedArchive { archive, count } => {
+                        let node_id = format!("col__{}__d{}", sanitize_id(&archive), next_depth);
+                        if !nodes.iter().any(|n| n.id == node_id) {
+                            nodes.push(GraphNode {
+                                id: node_id.clone(),
+                                label: format!("[{archive}]\n{count} TUs"),
+                                archive: Some(archive.clone()),
+                                object: None,
+                                kind: NodeKind::Collapsed { archive, count },
+                                depth: next_depth,
+                            });
+                        }
+                        push_edge_dedup(
+                            &mut edges,
+                            GraphEdge {
+                                from: node_id,
+                                to: current_id.clone(),
+                            },
+                        );
+                    }
+                    CappedReferencer::FanOutOverflow { count } => {
+                        let node_id = format!(
+                            "ovf__d{}__{}__{}",
+                            next_depth,
+                            sanitize_id(&current_id),
+                            count
+                        );
+                        nodes.push(GraphNode {
+                            id: node_id.clone(),
+                            label: format!("(… and {count} more)"),
+                            archive: None,
+                            object: None,
+                            kind: NodeKind::Collapsed {
+                                archive: "(overflow)".to_string(),
+                                count,
+                            },
+                            depth: next_depth,
+                        });
+                        edges.push(GraphEdge {
+                            from: node_id,
+                            to: current_id.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        Self {
+            root_id,
+            nodes,
+            edges,
+        }
+    }
+
+    /// Render the graph as a Graphviz `digraph` string.
+    pub fn to_dot(&self) -> String {
+        let mut out = String::new();
+        out.push_str("digraph backref {\n");
+        out.push_str("  rankdir=LR;\n");
+        out.push_str("  node [shape=box, style=\"filled,rounded\", fontname=\"Helvetica\"];\n");
+        out.push_str("  edge [fontname=\"Helvetica\", fontsize=10];\n");
+        for n in &self.nodes {
+            let color = node_color(n);
+            let label = escape_dot_label(&n.label);
+            let width = node_width(n);
+            out.push_str(&format!(
+                "  \"{}\" [label=\"{}\", fillcolor=\"{}\"{}];\n",
+                n.id,
+                label,
+                color,
+                if let Some(w) = width {
+                    format!(", width={w:.2}")
+                } else {
+                    String::new()
+                },
+            ));
+        }
+        for e in &self.edges {
+            out.push_str(&format!("  \"{}\" -> \"{}\";\n", e.from, e.to));
+        }
+        out.push_str("}\n");
+        out
+    }
+}
+
+/// Result of ranking and capping a single layer of referencers.
+enum CappedReferencer {
+    Tu(SymbolReference),
+    CollapsedArchive { archive: String, count: usize },
+    FanOutOverflow { count: usize },
+}
+
+/// Apply `exclude_archives`, `collapse_archives`, and the fan-out cap.
+/// Returns a vector of survivors / collapsed buckets / overflow.
+fn rank_and_cap_referencers(
+    refs: &[SymbolReference],
+    index: &TuIndex<'_>,
+    config: &GraphConfig,
+    _root_archive: &Option<String>,
+    _depth: u32,
+) -> Vec<CappedReferencer> {
+    if refs.is_empty() {
+        return Vec::new();
+    }
+    // 1. Drop excluded archives entirely.
+    let mut kept: Vec<SymbolReference> = refs
+        .iter()
+        .filter(|r| {
+            !r.archive
+                .as_ref()
+                .map(|a| config.exclude_archives.iter().any(|x| x == a))
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect();
+    if kept.is_empty() {
+        return Vec::new();
+    }
+    // 2. Collapse archives into super-nodes (one super-node per
+    //    archive at this layer; the remaining TUs in non-collapsed
+    //    archives fall through to fan-out ranking).
+    let mut by_collapse: BTreeMap<String, Vec<SymbolReference>> = BTreeMap::new();
+    let mut non_collapsed: Vec<SymbolReference> = Vec::new();
+    for r in kept.drain(..) {
+        let collapse_match = r
+            .archive
+            .as_ref()
+            .map(|a| config.collapse_archives.iter().any(|x| x == a));
+        if let Some(true) = collapse_match {
+            let key = r.archive.clone().unwrap_or_default();
+            by_collapse.entry(key).or_default().push(r);
+        } else {
+            non_collapsed.push(r);
+        }
+    }
+    // 3. Rank non-collapsed by attributed bytes desc; apply K cap.
+    non_collapsed.sort_by_key(|b| std::cmp::Reverse(index.bytes_in(b)));
+    let mut out: Vec<CappedReferencer> = Vec::new();
+    let total = non_collapsed.len();
+    let take_n = config.fan_out.min(total);
+    for tu in non_collapsed.into_iter().take(take_n) {
+        out.push(CappedReferencer::Tu(tu));
+    }
+    let overflow = total.saturating_sub(take_n);
+    if overflow > 0 {
+        out.push(CappedReferencer::FanOutOverflow { count: overflow });
+    }
+    // 4. Emit collapsed super-nodes.
+    for (archive, tus) in by_collapse {
+        out.push(CappedReferencer::CollapsedArchive {
+            archive,
+            count: tus.len(),
+        });
+    }
+    out
+}
+
+fn push_edge_dedup(edges: &mut Vec<GraphEdge>, candidate: GraphEdge) {
+    if !edges
+        .iter()
+        .any(|e| e.from == candidate.from && e.to == candidate.to)
+    {
+        edges.push(candidate);
+    }
+}
+
+/// Map an archive name to a Graphviz fill color. Coloring follows
+/// the ecosystem the archive lives in so the eye jumps to the
+/// non-system edges.
+fn node_color(n: &GraphNode) -> &'static str {
+    match (&n.kind, n.archive.as_deref()) {
+        (NodeKind::RootSymbol { .. }, _) => "#ff6b6b", // red — the target
+        (NodeKind::Collapsed { .. }, _) => "#e0e0e0",  // gray — super-node
+        (_, Some("libc.a" | "libgcc.a" | "libm.a")) => "#cccccc",
+        (_, Some(a)) if a.starts_with("libstdc++") => "#cccccc",
+        (_, Some("libFastLED.a")) => "#ffd166",
+        (_, Some(a)) if a.starts_with("libArduino") => "#06d6a0",
+        (_, Some(a)) if a.starts_with("libesp") || a.starts_with("libfreertos") => "#118ab2",
+        (_, Some(a)) if a.starts_with("libmbed") => "#a463f2",
+        (_, Some(a)) if a.starts_with("liblog") => "#83c5be",
+        (_, Some(a)) if a.starts_with("libheap") => "#f4a261",
+        (_, None) => "#fdfdfd", // app-side (bare object), near-white
+        _ => "#cfe2ff",         // other libs, soft blue
+    }
+}
+
+/// Compute a Graphviz `width=` value sized by `log10(bytes + 1)`. Keeps
+/// the visual size comparable across builds (huge symbols stay big
+/// but don't dominate the page).
+fn node_width(n: &GraphNode) -> Option<f64> {
+    let bytes = match &n.kind {
+        NodeKind::RootSymbol { size, .. } => *size,
+        NodeKind::TranslationUnit {
+            size_hint: Some(b), ..
+        } => *b,
+        _ => return None,
+    };
+    if bytes == 0 {
+        return Some(1.0);
+    }
+    let base = (bytes as f64).log10().max(1.0);
+    Some((base * 0.7).clamp(1.0, 4.5))
+}
+
+fn format_root_label(demangled: &str, size: u64) -> String {
+    let truncated = if demangled.len() > 64 {
+        format!("{}…", &demangled[..63])
+    } else {
+        demangled.to_string()
+    };
+    format!("{truncated}\n{size} B")
+}
+
+fn format_tu_label(tu: &SymbolReference, bytes: u64) -> String {
+    match &tu.archive {
+        Some(a) => format!("{}\n{a}\n{bytes} B", tu.object),
+        None => format!("{}\n(app)\n{bytes} B", tu.object),
+    }
+}
+
+fn tu_id_str(tu: &SymbolReference) -> String {
+    match &tu.archive {
+        Some(a) => format!("{a}__{}", tu.object),
+        None => tu.object.clone(),
+    }
+}
+
+/// Map any string into a Graphviz-safe id (alphanumerics + `_`).
+pub fn sanitize_id(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            out.push(c);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push_str("anon");
+    }
+    out
+}
+
+/// Map a demangled symbol name into a filesystem-safe filename
+/// component (sidecar `.dot` file naming). Truncates at 80 chars so
+/// long C++ template names don't blow the filesystem name limit.
+pub fn sanitize_filename(symbol: &str) -> String {
+    let mut out = String::with_capacity(symbol.len().min(80));
+    for c in symbol.chars().take(80) {
+        let safe = match c {
+            '/' | '\\' | ':' | '<' | '>' | '"' | '|' | '?' | '*' | ' ' | '\t' | '\n' | '('
+            | ')' | ',' | '&' | '#' | ';' => '_',
+            other => other,
+        };
+        out.push(safe);
+    }
+    if out.is_empty() {
+        out.push_str("sym");
+    }
+    out
+}
+
+fn escape_dot_label(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::symbol_analysis::{FineGrainedSymbol, FineGrainedSymbolMap, SectionBytes};
+    use crate::MemoryRegion;
+
+    fn sym(
+        mangled: &str,
+        demangled: &str,
+        size: u64,
+        archive: Option<&str>,
+        object: &str,
+        refs: Vec<SymbolReference>,
+    ) -> FineGrainedSymbol {
+        FineGrainedSymbol {
+            mangled: mangled.to_string(),
+            demangled: demangled.to_string(),
+            address: 0x1000,
+            size,
+            sym_type: 'T',
+            region: MemoryRegion::Flash,
+            archive: archive.map(|s| s.to_string()),
+            object: Some(object.to_string()),
+            output_section: Some(".flash.text".to_string()),
+            source: "nm".to_string(),
+            referenced_by: refs,
+        }
+    }
+
+    fn refr(archive: Option<&str>, object: &str) -> SymbolReference {
+        SymbolReference {
+            archive: archive.map(|s| s.to_string()),
+            object: object.to_string(),
+        }
+    }
+
+    fn map(symbols: Vec<FineGrainedSymbol>) -> FineGrainedSymbolMap {
+        FineGrainedSymbolMap {
+            elf_path: "test.elf".to_string(),
+            map_path: None,
+            total_flash: symbols.iter().map(|s| s.size).sum(),
+            total_ram: 0,
+            symbols,
+            sections: Vec::<SectionBytes>::new(),
+        }
+    }
+
+    #[test]
+    fn unknown_symbol_yields_single_node_graph() {
+        let m = map(vec![sym(
+            "main",
+            "main",
+            10,
+            None,
+            "main.cpp.o",
+            Vec::new(),
+        )]);
+        let g = BackrefGraph::build(&m, "does_not_exist", &GraphConfig::default());
+        assert_eq!(g.nodes.len(), 1);
+        assert_eq!(g.edges.len(), 0);
+        assert!(g.nodes[0].label.contains("not in symbol map"));
+        // Renders without panicking.
+        let dot = g.to_dot();
+        assert!(dot.contains("digraph"));
+    }
+
+    #[test]
+    fn symbol_with_no_referencers_yields_root_only() {
+        let m = map(vec![sym(
+            "__StackTop",
+            "__StackTop",
+            0,
+            None,
+            "linker.ld",
+            Vec::new(),
+        )]);
+        let g = BackrefGraph::build(&m, "__StackTop", &GraphConfig::default());
+        assert_eq!(g.nodes.len(), 1);
+        assert!(g.edges.is_empty());
+        assert!(matches!(g.nodes[0].kind, NodeKind::RootSymbol { .. }));
+    }
+
+    /// Issue #463 motivating case: `_vfprintf_r` defined in libc,
+    /// referenced by libc-internal wrappers. Default config collapses
+    /// libc.a so we see straight to the non-libc consumers.
+    #[test]
+    fn vfprintf_r_collapses_libc_chain() {
+        let symbols = vec![
+            sym(
+                "_vfprintf_r",
+                "_vfprintf_r",
+                11_309,
+                Some("libc.a"),
+                "libc_a-vfprintf.o",
+                vec![
+                    refr(Some("libc.a"), "libc_a-vprintf.o"),
+                    refr(Some("libc.a"), "libc_a-printf.o"),
+                    refr(Some("libc.a"), "libc_a-fprintf.o"),
+                ],
+            ),
+            sym(
+                "vprintf",
+                "vprintf",
+                500,
+                Some("libc.a"),
+                "libc_a-vprintf.o",
+                vec![refr(Some("liblog.a"), "log_write.c.obj")],
+            ),
+            sym(
+                "printf",
+                "printf",
+                500,
+                Some("libc.a"),
+                "libc_a-printf.o",
+                vec![refr(Some("libmbedcrypto.a"), "sha512.c.obj")],
+            ),
+            sym(
+                "fprintf",
+                "fprintf",
+                500,
+                Some("libc.a"),
+                "libc_a-fprintf.o",
+                vec![refr(Some("libsdmmc.a"), "sdmmc_io.c.obj")],
+            ),
+        ];
+        let g = BackrefGraph::build(&map(symbols), "_vfprintf_r", &GraphConfig::default());
+        // Root + one collapsed-libc super-node ⇒ no individual libc
+        // referencer should appear at depth 1.
+        let libc_internal_tus: Vec<_> = g
+            .nodes
+            .iter()
+            .filter(|n| {
+                matches!(n.kind, NodeKind::TranslationUnit { .. })
+                    && n.archive.as_deref() == Some("libc.a")
+            })
+            .collect();
+        assert!(
+            libc_internal_tus.is_empty(),
+            "libc.a should be collapsed; got {libc_internal_tus:?}"
+        );
+        let collapsed: Vec<_> = g
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Collapsed { .. }))
+            .collect();
+        assert!(!collapsed.is_empty(), "expected collapsed super-node");
+    }
+
+    /// FastLED ctor case: app-side TU references the ctor directly.
+    /// Adaptive termination ends at depth 1 because main.cpp.o is
+    /// outside libFastLED.a.
+    #[test]
+    fn fastled_ctor_adaptive_terminates_at_app() {
+        let symbols = vec![
+            sym(
+                "_ZN8FastLED5beginEv",
+                "FastLED::begin()",
+                400,
+                Some("libFastLED.a"),
+                "fl.cpp.o",
+                vec![refr(None, "main.cpp.o")],
+            ),
+            sym(
+                "setup",
+                "setup",
+                30,
+                None,
+                "main.cpp.o",
+                vec![refr(None, "main.cpp.o")], // self-ref noise
+            ),
+        ];
+        let g = BackrefGraph::build(
+            &map(symbols),
+            "_ZN8FastLED5beginEv",
+            &GraphConfig::default(),
+        );
+        // root + main.cpp.o
+        assert_eq!(g.nodes.len(), 2);
+        assert!(g
+            .nodes
+            .iter()
+            .any(|n| n.object.as_deref() == Some("main.cpp.o")));
+    }
+
+    #[test]
+    fn fan_out_cap_overflow_emits_super_node() {
+        // 10 referencers, cap = 3 ⇒ 3 TUs + 1 overflow super-node.
+        let mut refs = Vec::new();
+        for i in 0..10 {
+            refs.push(refr(Some("libapp.a"), &format!("caller_{i}.o")));
+        }
+        let mut symbols = vec![sym(
+            "hub",
+            "hub",
+            100,
+            Some("libcore.a"),
+            "core.o",
+            refs.clone(),
+        )];
+        // Give each caller a distinct attributed-bytes ranking so the
+        // top-K selection is deterministic.
+        for (i, _) in refs.iter().enumerate() {
+            symbols.push(sym(
+                &format!("caller_{i}_sym"),
+                &format!("caller_{i}_sym"),
+                (10 - i) as u64,
+                Some("libapp.a"),
+                &format!("caller_{i}.o"),
+                Vec::new(),
+            ));
+        }
+        let cfg = GraphConfig {
+            fan_out: 3,
+            collapse_archives: Vec::new(),
+            ..GraphConfig::default()
+        };
+        let g = BackrefGraph::build(&map(symbols), "hub", &cfg);
+        let tu_nodes = g
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::TranslationUnit { .. }))
+            .count();
+        assert_eq!(tu_nodes, 3, "expected exactly 3 TUs after fan-out cap");
+        let overflow = g.nodes.iter().find(
+            |n| matches!(&n.kind, NodeKind::Collapsed { archive, .. } if archive == "(overflow)"),
+        );
+        assert!(overflow.is_some(), "expected an overflow super-node");
+        assert!(overflow.unwrap().label.contains("7 more"));
+    }
+
+    #[test]
+    fn exclude_archive_drops_branches() {
+        let symbols = vec![
+            sym(
+                "target",
+                "target",
+                100,
+                None,
+                "main.o",
+                vec![
+                    refr(Some("libdrop.a"), "dropped.o"),
+                    refr(Some("libkeep.a"), "kept.o"),
+                ],
+            ),
+            sym(
+                "dropped_sym",
+                "dropped_sym",
+                5,
+                Some("libdrop.a"),
+                "dropped.o",
+                Vec::new(),
+            ),
+            sym(
+                "kept_sym",
+                "kept_sym",
+                5,
+                Some("libkeep.a"),
+                "kept.o",
+                Vec::new(),
+            ),
+        ];
+        let cfg = GraphConfig {
+            exclude_archives: vec!["libdrop.a".to_string()],
+            collapse_archives: Vec::new(),
+            ..GraphConfig::default()
+        };
+        let g = BackrefGraph::build(&map(symbols), "target", &cfg);
+        let archives: BTreeSet<Option<String>> = g
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::TranslationUnit { .. }))
+            .map(|n| n.archive.clone())
+            .collect();
+        assert!(archives.contains(&Some("libkeep.a".to_string())));
+        assert!(!archives.contains(&Some("libdrop.a".to_string())));
+    }
+
+    #[test]
+    fn dot_serialization_includes_all_nodes_and_edges() {
+        let symbols = vec![
+            sym(
+                "a",
+                "a",
+                10,
+                Some("libA.a"),
+                "a.o",
+                vec![refr(Some("libB.a"), "b.o")],
+            ),
+            sym("b", "b", 20, Some("libB.a"), "b.o", Vec::new()),
+        ];
+        let cfg = GraphConfig {
+            collapse_archives: Vec::new(),
+            ..GraphConfig::default()
+        };
+        let g = BackrefGraph::build(&map(symbols), "a", &cfg);
+        let dot = g.to_dot();
+        assert!(dot.starts_with("digraph"));
+        assert!(dot.contains("rankdir=LR"));
+        for n in &g.nodes {
+            assert!(dot.contains(&n.id), "node {} missing from .dot", n.id);
+        }
+        for e in &g.edges {
+            assert!(
+                dot.contains(&format!("\"{}\" -> \"{}\"", e.from, e.to)),
+                "edge {}->{} missing",
+                e.from,
+                e.to
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_id_replaces_unsafe_chars() {
+        assert_eq!(sanitize_id("foo bar"), "foo_bar");
+        assert_eq!(sanitize_id("a:b/c\\d"), "a_b_c_d");
+        assert_eq!(sanitize_id("_ok_123"), "_ok_123");
+        assert_eq!(sanitize_id(""), "anon");
+    }
+
+    #[test]
+    fn sanitize_filename_truncates_and_strips() {
+        let long = "a".repeat(200);
+        assert_eq!(sanitize_filename(&long).len(), 80);
+        assert_eq!(sanitize_filename("op<<(int)"), "op___int_");
+        assert_eq!(sanitize_filename(""), "sym");
+    }
+}

--- a/crates/fbuild-core/src/symbol_analysis/mod.rs
+++ b/crates/fbuild-core/src/symbol_analysis/mod.rs
@@ -20,12 +20,17 @@
 //! cross toolchain. Subprocess drivers live in `fbuild_build`.
 
 pub mod cref;
+pub mod graph;
 
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
 pub use cref::{parse_cref_table, SymbolReference};
+pub use graph::{
+    sanitize_filename, sanitize_id, BackrefGraph, GraphConfig, GraphDepth, GraphEdge, GraphNode,
+    NodeKind, TuIndex,
+};
 
 use crate::MemoryRegion;
 


### PR DESCRIPTION
Closes #463. Part 2 follow-up to #459 / #460.

## Summary

Takes the `referenced_by` data shipped by #460 and renders it as Graphviz `.dot` back-reference graphs. Three new surfaces:

1. **`fbuild bloat graph <input> --symbol <S>`** — CLI subcommand emitting a `.dot` graph for one symbol. Reuses `fbuild symbols`' toolchain resolution (#428).
2. **Embedded `dot` blocks in `report.md`** — when `--output-dir` is given, each of the top-10 symbols carries an inline fenced ` ```dot ` block under a `<details>` summary. AI-friendly: a fresh agent can answer "what pulls in `_vfprintf_r`?" from `report.md` alone, no second tool call. `--no-graph` disables.
3. **Sidecar `<output-dir>/graphs/<rank>_<symbol>.dot`** — every symbol > `--graph-min-bytes` (default 256) gets a standalone file for ad-hoc `dot -Tsvg` rendering.

## Walker design

Pure module `fbuild_core::symbol_analysis::graph` (zero I/O, fully unit-testable). BFS outward from the root symbol's `referenced_by` list; for each referencing TU we find every symbol defined there and merge their back-references. Three termination predicates compose:

| Predicate | Default | Purpose |
|---|---|---|
| Adaptive cross-archive termination | on | Stop expanding the first time a branch leaves the root's archive. Surfaces the boundary where a symbol \"escapes\" its own library. |
| Per-node fan-out cap `K` | 5 | Rank referencers by attributed flash bytes desc; keep top-K; collapse the rest into a `(… and N more)` super-node. Stops hubs like `printf` (~25 mbedTLS referencers on ESP32-P4) from blowing the graph up. |
| Hard depth cap `N` | 4 | Safety belt for adaptive. |

Plus archive-level filters:
- `--collapse-archive libc.a,libgcc.a` (default) merges libc-internal hops into per-archive super-nodes.
- `--exclude-archive ...` drops entire archives' branches.

Motivating case from FastLED#2886: `_vfprintf_r` (11.3 KB) is now actionable. The walker traces it through the libc super-node directly to `liblog.a(log_write.c.obj)` (ESP-IDF logging), `libmbedcrypto.a(sha512.c.obj)`, `libheap.a(tlsf.c.obj)` — no manual flag tuning.

## CLI flags

On `fbuild symbols` (controls report.md embedding + sidecars):

| Flag | Default | Effect |
|---|---|---|
| `--no-graph` | off | Skip embedded blocks and sidecar files. |
| `--graph-top N` | 10 | Top-N symbols get embedded graphs (capped by `--top`). |
| `--graph-min-bytes B` | 256 | Sidecar threshold. |
| `--graph-depth adaptive\|N` | adaptive | Override cross-archive termination. |
| `--graph-fan-out K` | 5 | Per-node fan-out cap. |
| `--graph-collapse-archive A,B` | `libc.a,libgcc.a` | Per-archive collapse list. |
| `--graph-exclude-archive A,B` | (empty) | Per-archive drop list. |

On `fbuild bloat graph`: `--symbol/-s`, `--depth`, `--fan-out`, `--max-depth`, `--collapse-archive`, `--exclude-archive`, plus shared toolchain flags and `-o/--output`.

## CLI structure note

Introduces a top-level `Bloat` subcommand parent with one child (`Graph`). #434 can later add `Bloat::Report` as a sibling to land the long-discussed `symbols` -> `bloat` rename without disturbing this PR.

## Acceptance — from #463

- [x] `fbuild bloat graph <input> --symbol <S>` writes a readable `.dot` for both libc and FastLED-ctor target shapes (unit-tested at `vfprintf_r_collapses_libc_chain` and `fastled_ctor_adaptive_terminates_at_app`).
- [x] `fbuild bloat <input> --output-dir <dir>` produces `report.json` (unchanged), `report.md` with inline ` ```dot ` blocks for top-10, and `graphs/*.dot` sidecar files > 256 B.
- [x] `--no-graph` disables both embedding and sidecars; `referenced_by` data still ships in JSON.
- [x] AI-friendliness check: report.md contains the back-reference graph inline as parseable text.
- [x] Zero-referencers case renders a single isolated node.
- [x] No-cref-block case → graphs degrade gracefully, never an error.

## Test plan

- [x] `soldr cargo test -p fbuild-core --lib symbol_analysis::graph` — 9 passed (walker + .dot + sanitization)
- [x] `soldr cargo test -p fbuild-build --lib symbol_analyzer` — 16 passed (4 new: markdown embedding, legacy-path purity, sidecar emission, sidecar disabled)
- [x] `soldr cargo test -p fbuild-cli cli::graph_cmd` — 5 passed (config parsing)
- [x] `uv run --script ci/test.py` — full sweep passes, zero failures
- [x] `soldr cargo clippy -p fbuild-core -p fbuild-build -p fbuild-cli --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all` — clean

## Related

- #463 — this PR's tracking issue
- #459 / #460 — Part 1 (cref → `referenced_by`)
- #434 — `symbols` → `bloat` rename (this PR introduces the `Bloat` enum that it would extend)
- #428 — `build_info.json` toolchain paths (reused as-is)
- FastLED#2886 — original motivating bloat audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)