### PR TITLE
fix(hooks): lower Stop timeout + add opt-in pre-push workspace gate (#462)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,7 +62,7 @@
           {
             "type": "command",
             "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/check-on-stop.py",
-            "timeout": 600
+            "timeout": 120
           }
         ]
       }

--- a/ci/git-hooks/README.md
+++ b/ci/git-hooks/README.md
@@ -1,0 +1,40 @@
+# Local git hooks
+
+Tracked git hooks for fbuild. Opt in **once per clone**:
+
+```bash
+git config core.hooksPath ci/git-hooks
+```
+
+After that, every hook in this directory is wired up automatically. The
+directory is on the repo's normal source path so updates flow with
+`git pull`.
+
+## Hooks
+
+- **`pre-push`** — workspace-wide safety net. Runs `cargo fmt --check`,
+  `cargo clippy --workspace --all-targets -- -D warnings`, and
+  `cargo test --workspace` before any branch is pushed. Skipped when
+  the push touches no Rust files. Bypass with `git push --no-verify`
+  or `FBUILD_SKIP_PRE_PUSH=1 git push`.
+
+  Why here and not in the Stop hook: the Claude Code Stop hook
+  (`ci/hooks/check-on-stop.py`) is scoped to changed crates for fast
+  iteration (#465). The workspace-wide gate belongs at the
+  *push* boundary, where it actually prevents an escape, not at the
+  conversation-stop boundary, where it just adds latency. See #462.
+
+## Opting out per-push
+
+```bash
+git push --no-verify        # bypass all hooks
+FBUILD_SKIP_PRE_PUSH=1 git push   # bypass only pre-push, keep others
+```
+
+## Adding a new hook
+
+1. Drop an executable script named exactly the git event
+   (`pre-commit`, `commit-msg`, `pre-push`, `post-merge`, ...).
+2. Make it skip cleanly when there's no work to do — `pre-push` here
+   filters by changed-file extensions so non-Rust pushes are free.
+3. Document the bypass mechanism in the script header.

--- a/ci/git-hooks/pre-push
+++ b/ci/git-hooks/pre-push
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+# Pre-push gate: full workspace lint + tests before code leaves this machine.
+#
+# Stop hook (`ci/hooks/check-on-stop.py`) is scoped to the changed crates
+# for fast iteration feedback — see #465. This hook is the workspace-wide
+# safety net. CI also runs `cargo clippy --workspace` + `cargo test
+# --workspace` on every push; this just catches escapes locally so you
+# don't need to wait on a remote runner to find out.
+#
+# Opt in once per clone:
+#
+#     git config core.hooksPath ci/git-hooks
+#
+# Bypass for a single push (e.g. emergency fix where CI must arbitrate):
+#
+#     git push --no-verify
+#
+# Skipped automatically when:
+#   - the cargo workspace has no `.rs`, `Cargo.toml`, or `Cargo.lock`
+#     differences vs the upstream HEAD being pushed to
+#   - the env var `FBUILD_SKIP_PRE_PUSH=1` is set
+#
+# Exit codes:
+#   0 - all checks passed (or skipped)
+#   1 - lint or test failed; push is rejected
+
+set -e
+
+if [ "${FBUILD_SKIP_PRE_PUSH:-0}" = "1" ]; then
+    echo "pre-push: FBUILD_SKIP_PRE_PUSH=1 — skipping workspace gate"
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Read git's per-ref input from stdin: <local ref> <local sha> <remote ref> <remote sha>
+# When pushing a new branch, remote sha is 40 zeros — fall back to upstream/HEAD.
+ZERO="0000000000000000000000000000000000000000"
+RUST_TOUCHED=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    if [ -z "$local_sha" ] || [ "$local_sha" = "$ZERO" ]; then
+        # Deletion — nothing to lint.
+        continue
+    fi
+    if [ -z "$remote_sha" ] || [ "$remote_sha" = "$ZERO" ]; then
+        # New branch — diff against upstream's default branch.
+        base="$(git merge-base "$local_sha" origin/HEAD 2>/dev/null || echo "")"
+        if [ -z "$base" ]; then
+            # No upstream HEAD known — be conservative and run the gate.
+            RUST_TOUCHED=1
+            break
+        fi
+    else
+        base="$remote_sha"
+    fi
+    if git diff --name-only "$base" "$local_sha" 2>/dev/null \
+        | grep -Eq '(\.rs$|Cargo\.toml$|Cargo\.lock$|rust-toolchain\.toml$|^\.cargo/)'; then
+        RUST_TOUCHED=1
+        break
+    fi
+done
+
+if [ "$RUST_TOUCHED" = "0" ]; then
+    echo "pre-push: no Rust changes in this push — skipping workspace gate"
+    exit 0
+fi
+
+echo "pre-push: running workspace lint + tests"
+echo "  (set FBUILD_SKIP_PRE_PUSH=1 to bypass)"
+
+soldr cargo fmt --all -- --check || {
+    echo "pre-push: rustfmt --check failed; run \`soldr cargo fmt --all\`" >&2
+    exit 1
+}
+
+soldr cargo clippy --workspace --all-targets -- -D warnings || {
+    echo "pre-push: clippy --workspace failed" >&2
+    exit 1
+}
+
+soldr cargo test --workspace || {
+    echo "pre-push: cargo test --workspace failed" >&2
+    exit 1
+}
+
+echo "pre-push: workspace gate passed"


### PR DESCRIPTION
Closes #462.

Final umbrella items from #462 once \`#464\` and \`#465\` have shipped.

## Summary

- **Stop hook timeout: 600s → 120s** in \`.claude/settings.json\`.
  With #465's per-crate scoping a typical edit completes well under
  that; anything past 2 min on Stop is treated as a hang, not silently
  accepted.

- **New \`ci/git-hooks/pre-push\`** — opt-in workspace-wide safety net.
  Runs \`cargo fmt --all -- --check\`,
  \`cargo clippy --workspace --all-targets -- -D warnings\`, and
  \`cargo test --workspace\` before any branch leaves the machine.

  - Install once per clone: \`git config core.hooksPath ci/git-hooks\`
  - Auto-skips when no \`.rs\` / \`Cargo.toml\` / \`Cargo.lock\` /
    \`rust-toolchain.toml\` / \`.cargo/**\` change is in the push range
  - Bypass: \`git push --no-verify\` or \`FBUILD_SKIP_PRE_PUSH=1 git push\`

- **New \`ci/git-hooks/README.md\`** documents the install and bypass
  flows.

## Rationale

Stop hook is per-conversation interactive feedback — should be fast
and scoped (delivered by #465). Push is the boundary where workspace
correctness actually matters. CI still runs the same workspace
verification on every push; pre-push just catches escapes locally so
the round-trip-to-remote feedback loop becomes optional.

## #462 acceptance items — status

- [x] **Skip-gate by file-extension diff** → delivered in #465 (the
      no-Rust-changes path returns early; doc-only edits skip
      entirely).
- [x] **Scope clippy + test to affected crates** → delivered in #465.
- [x] **Move full \`--workspace\` verification to a pre-push hook**
      → this PR.
- [x] **Lower the timeout to ~120s** → this PR.
- [N/A] **Serialize lint then test** — #465 keeps the
      concurrent-with-early-exit pattern; the early-exit on lint
      failure already captures the "don't waste time testing if lint
      is broken" win. Pure-serial micro-saving would not warrant
      churning #465's structure further.

## Test plan

- [x] \`sh -n ci/git-hooks/pre-push\` clean (POSIX shell syntax)
- [x] Hook is marked executable (\`git update-index --chmod=+x\`)
- [ ] Manual: install via \`git config core.hooksPath ci/git-hooks\`,
      attempt a no-Rust-change push → skip message
- [ ] Manual: attempt a Rust-change push that breaks clippy → push
      rejected with clippy output

## Recommended merge order

1. #466 (PEP 723, prerequisite)
2. #467 (per-crate scoping, settles check-on-stop.py shape)
3. This PR (#462) lands on top with no expected conflicts in the
   files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)