### PR TITLE
docs(bloat): pin map-file tombstone trap with regression test + doc note

### DIFF
--- a/crates/fbuild-core/src/symbol_analysis/tests.rs
+++ b/crates/fbuild-core/src/symbol_analysis/tests.rs
@@ -89,6 +89,59 @@ Linker script and memory map
     assert_eq!(ranges[0].input_section, ".text.live");
 }
 
+/// fbuild#417 regression: the exact rodata rows from the FastLED #2473
+/// symbol audit that led to a ~95 KB phantom-bloat report. Three of
+/// the four heaviest "rodata candidates" the audit picked were
+/// `--gc-sections`-tombstoned (address `0x00000000`); only the fourth
+/// — `esp_err_to_name` — was actually live. The parser MUST drop the
+/// three tombstones so downstream analysis can't sum phantom bytes.
+///
+/// The snippet below mirrors the map-file shape from the issue
+/// verbatim (output section header in the link view + four rodata
+/// input rows, three at `0x00000000` and one at a real flash
+/// address). See:
+///   - https://github.com/FastLED/fbuild/issues/417
+///   - https://github.com/FastLED/FastLED/issues/2473#issuecomment-4628287075
+#[test]
+fn parse_linker_map_drops_fastled_2473_tombstones() {
+    let text = "\
+Linker script and memory map
+
+.flash.rodata   0x3c000020    0x10000
+ .rodata.embedded
+                0x00000000    0x110f8 path/libmbedtls.a(x509_crt_bundle.S.obj)
+ .rodata.str1.1 0x00000000     0x2b64 path/libmesh.a(mesh_parent.o)
+ .rodata.huffTable
+                0x00000000     0x2124 path/libFastLED.a(third_party+.cpp.o)
+ .rodata.str1.1 0x3c000020     0x1776 path/libesp_common.a(esp_err_to_name.c.obj)
+";
+    let ranges = parse_linker_map(text);
+    // Exactly one live row survives — `esp_err_to_name`. The three
+    // tombstones (x509_crt_bundle, mesh_parent, huffTable) are
+    // dropped because their address is `0x00000000`.
+    assert_eq!(
+        ranges.len(),
+        1,
+        "expected exactly 1 live row, got {}: {:?}",
+        ranges.len(),
+        ranges.iter().map(|r| &r.input_section).collect::<Vec<_>>()
+    );
+    let live = &ranges[0];
+    assert_eq!(live.archive.as_deref(), Some("libesp_common.a"));
+    assert_eq!(live.object, "esp_err_to_name.c.obj");
+    assert_eq!(live.addr, 0x3c000020);
+    assert_eq!(live.size, 0x1776);
+    // Phantom row attribution must NOT appear under any archive name
+    // — guard against a future refactor that forgets the addr filter.
+    let mbedtls_phantom = ranges
+        .iter()
+        .any(|r| r.archive.as_deref() == Some("libmbedtls.a"));
+    assert!(
+        !mbedtls_phantom,
+        "fbuild#417: x509_crt_bundle tombstone must not be reported as a live mbedtls.a row"
+    );
+}
+
 #[test]
 fn input_section_index_lookup_inside_range() {
     let ranges = vec![

--- a/crates/fbuild-core/src/symbol_analysis/tests.rs
+++ b/crates/fbuild-core/src/symbol_analysis/tests.rs
@@ -90,15 +90,15 @@ Linker script and memory map
 }
 
 /// fbuild#417 regression: the exact rodata rows from the FastLED #2473
-/// symbol audit that led to a ~95 KB phantom-bloat report. Three of
-/// the four heaviest "rodata candidates" the audit picked were
-/// `--gc-sections`-tombstoned (address `0x00000000`); only the fourth
+/// symbol audit that led to a ~95 KB phantom-bloat report. Four of
+/// the five heaviest "rodata candidates" the audit picked were
+/// `--gc-sections`-tombstoned (address `0x00000000`); only the fifth
 /// — `esp_err_to_name` — was actually live. The parser MUST drop the
-/// three tombstones so downstream analysis can't sum phantom bytes.
+/// four tombstones so downstream analysis can't sum phantom bytes.
 ///
 /// The snippet below mirrors the map-file shape from the issue
-/// verbatim (output section header in the link view + four rodata
-/// input rows, three at `0x00000000` and one at a real flash
+/// verbatim (output section header in the link view + five rodata
+/// input rows, four at `0x00000000` and one at a real flash
 /// address). See:
 ///   - https://github.com/FastLED/fbuild/issues/417
 ///   - https://github.com/FastLED/FastLED/issues/2473#issuecomment-4628287075
@@ -113,12 +113,15 @@ Linker script and memory map
  .rodata.str1.1 0x00000000     0x2b64 path/libmesh.a(mesh_parent.o)
  .rodata.huffTable
                 0x00000000     0x2124 path/libFastLED.a(third_party+.cpp.o)
+ .rodata.PLM_AUDIO_SYNTHESIS_WINDOW
+                0x00000000      0x800 path/libFastLED.a(third_party+.cpp.o)
  .rodata.str1.1 0x3c000020     0x1776 path/libesp_common.a(esp_err_to_name.c.obj)
 ";
     let ranges = parse_linker_map(text);
-    // Exactly one live row survives — `esp_err_to_name`. The three
-    // tombstones (x509_crt_bundle, mesh_parent, huffTable) are
-    // dropped because their address is `0x00000000`.
+    // Exactly one live row survives — `esp_err_to_name`. The four
+    // tombstones (x509_crt_bundle, mesh_parent, huffTable,
+    // PLM_AUDIO_SYNTHESIS_WINDOW) are dropped because their address
+    // is `0x00000000`.
     assert_eq!(
         ranges.len(),
         1,

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -155,8 +155,36 @@ back-references; ask `nm`/`objdump`/`addr2line` for that.
 See [#459](https://github.com/FastLED/fbuild/issues/459) for the
 motivating bloat audit.
 
+## Gotcha: tree-shaken sections live in the map at address `0x00000000`
+
+This is the trap that bit FastLED `#2473`'s symbol audit: GNU `ld`
+keeps dropped sections in the `.map` for debugging, but assigns them
+placement address `0x00000000`. A naive map-file parser that sums
+sizes without filtering produces **phantom bloat** for sections that
+`--gc-sections` already harvested.
+
+`fbuild bloat` and `fbuild symbols` handle this for you — the
+`parse_linker_map` step in `fbuild_core::symbol_analysis` drops every
+input-section range whose `addr == 0` before attribution runs, and a
+`parse_linker_map_drops_fastled_2473_tombstones` regression test
+pins the exact rows from the original audit
+(`x509_crt_bundle.S.obj`, `mesh_parent.o`, `huffTable`,
+`PLM_AUDIO_SYNTHESIS_WINDOW`). PT_LOAD filtering on the nm side
+catches the sibling case (linker-script boundary symbols like
+`__StackTop` whose nm-reported "size" is just the gap to the next
+symbol). Together: anything `fbuild bloat`'s `report.json` lists as
+live is actually placed in the firmware image.
+
+If you're rolling your own analyzer outside fbuild, **always filter
+`address != 0x00000000`** before summing per-archive contributions.
+The exact `awk` invocation that catches the trap is captured in
+[fbuild#417](https://github.com/FastLED/fbuild/issues/417); the
+sanctioned answer is "use `fbuild bloat .` and skip the awk".
+
 ## Related
 
+- Issue [#417](https://github.com/FastLED/fbuild/issues/417) — the
+  tree-shaken-sections trap that motivated documenting this gotcha.
 - Issue [#428](https://github.com/FastLED/fbuild/issues/428) —
   toolchain-path schema and CLI auto-discovery (this doc).
 - Issue [#434](https://github.com/FastLED/fbuild/issues/434) — the


### PR DESCRIPTION
## Summary

Closes #417.

#417 was filed before `fbuild bloat` / `fbuild symbols` shipped and asked for one of: (A) a sanctioned analyzer that filters tree-shaken sections, (B) docs on the gotcha, or (C) a sanctioned helper library.

**Option (A) is already in `main`** — `parse_linker_map` in `fbuild-core::symbol_analysis::mod` drops every input-section range whose `addr == 0` (lines 349 and 378), and PT_LOAD filtering on the nm side catches the sibling case (linker-script boundary symbols whose nm \"size\" is just the gap to the next symbol).

This PR adds (B): an explicit \"tree-shaken sections\" gotcha section in `docs/symbols.md`, plus a regression test that pins the filter behaviour with the audit's own data.

## What changed

- **New regression test** `parse_linker_map_drops_fastled_2473_tombstones` uses the exact mbedTLS / mesh / FastLED-huff / esp_err_to_name rows from the FastLED #2473 audit transcript referenced by #417. Three of the four rows are tombstoned at `0x00000000` and must be dropped; the one surviving row (`esp_err_to_name.c.obj` at `0x3c000020`) is the only one actually placed in flash. The test also asserts no phantom mbedtls row leaks through, in case a future refactor forgets the address filter.
- **Docs section** `## Gotcha: tree-shaken sections live in the map at address \`0x00000000\`` in `docs/symbols.md` explains the trap and the answer (\"use `fbuild bloat .` and skip the awk\"), with a pointer back at this issue for anyone who needs the manual-awk recipe.

## Test plan

- [x] `soldr cargo clippy -p fbuild-core --all-targets -- -D warnings` ✅
- [x] `soldr cargo test -p fbuild-core --lib symbol_analysis` — **67 passed** (was 66 + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed linker map parser to properly filter out dropped code sections appearing at address 0x00000000, preventing false bloat reports.

* **Documentation**
  * Added guidance on handling tree-shaken sections in linker maps that can cause phantom bloat, with filtering recommendations for external analyzers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->