### PR TITLE
feat(bloat): per-symbol back-references + single-symbol lookup (#478)

### DIFF
--- a/crates/fbuild-build/src/symbol_analyzer/markdown.rs
+++ b/crates/fbuild-build/src/symbol_analyzer/markdown.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use fbuild_core::symbol_analysis::graph::{rank_callees_dual, Direction};
+use fbuild_core::symbol_analysis::graph::{rank_callees_dual, rank_callers_dual, Direction};
 use fbuild_core::symbol_analysis::{
     sanitize_filename, BackrefGraph, FineGrainedSymbolMap, GraphConfig, TuIndex,
 };
@@ -233,6 +233,7 @@ fn emit_backref_graph_section(
         );
         let _ = writeln!(out);
 
+        emit_dual_callers_subtable(out, map, s);
         emit_dual_callees_subtable(out, map, s);
 
         let graph = BackrefGraph::build_with_index(map, &index, &s.mangled, &bidir_cfg);
@@ -249,6 +250,80 @@ fn emit_backref_graph_section(
         let _ = writeln!(out, "</details>");
         let _ = writeln!(out);
     }
+}
+
+/// Emit the "Top callers" sub-table for one symbol: per-symbol
+/// inverse of [`emit_dual_callees_subtable`]. Two side-by-side
+/// rankings (by caller flash bytes, by how many other symbols the
+/// caller also calls — proxy for "downstream leverage if this caller
+/// were eliminated") plus an `(… and N more)` overflow row.
+///
+/// Populated from `FineGrainedSymbol::called_by` (objdump-derived,
+/// #478). Skipped when the analyzer ran without an objdump (the
+/// per-symbol back-reference data isn't available; the existing
+/// TU-level `Referenced by` column in the main table still carries
+/// the cref-derived view).
+fn emit_dual_callers_subtable(
+    out: &mut String,
+    map: &FineGrainedSymbolMap,
+    callee: &fbuild_core::symbol_analysis::FineGrainedSymbol,
+) {
+    use std::fmt::Write as _;
+    if callee.called_by.is_empty() {
+        // Don't emit the sub-table header when there's nothing to
+        // show — the parent template already prints the TU-level
+        // `Referenced by` count, so a blank caller table would just
+        // be noise.
+        return;
+    }
+    let (by_size, by_breadth, other) = rank_callers_dual(map, callee, 3);
+    let _ = writeln!(out, "#### Top callers (dual ranking)");
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "| # | by caller size (B) | calls × | by caller breadth (callees ×) | size (B) |"
+    );
+    let _ = writeln!(out, "|---:|---|---:|---|---:|");
+    for i in 0..3 {
+        let size_cell = by_size
+            .get(i)
+            .map(|c| format!("`{}` — {} B", c.demangled.replace('|', "\\|"), c.size))
+            .unwrap_or_else(|| "—".into());
+        let size_breadth = by_size
+            .get(i)
+            .map(|c| c.callees_count.to_string())
+            .unwrap_or_else(|| "—".into());
+        let breadth_cell = by_breadth
+            .get(i)
+            .map(|c| {
+                format!(
+                    "`{}` — calls ×{}",
+                    c.demangled.replace('|', "\\|"),
+                    c.callees_count
+                )
+            })
+            .unwrap_or_else(|| "—".into());
+        let breadth_size = by_breadth
+            .get(i)
+            .map(|c| c.size.to_string())
+            .unwrap_or_else(|| "—".into());
+        let _ = writeln!(
+            out,
+            "| {} | {} | {} | {} | {} |",
+            i + 1,
+            size_cell,
+            size_breadth,
+            breadth_cell,
+            breadth_size
+        );
+    }
+    if other > 0 {
+        let _ = writeln!(
+            out,
+            "| — | _(… and {other} more callers, see graph below)_ | | | |"
+        );
+    }
+    let _ = writeln!(out);
 }
 
 /// Emit the "Top callees" sub-table for one symbol: two side-by-side

--- a/crates/fbuild-build/src/symbol_analyzer/mod.rs
+++ b/crates/fbuild-build/src/symbol_analyzer/mod.rs
@@ -357,7 +357,7 @@ fn run_objdump_and_attribute(
     map: &mut FineGrainedSymbolMap,
 ) -> Result<usize> {
     use fbuild_core::subprocess::run_command;
-    use fbuild_core::symbol_analysis::callgraph::parse_disasm;
+    use fbuild_core::symbol_analysis::callgraph::{invert, parse_disasm};
 
     let objdump_s = objdump_path.to_string_lossy().to_string();
     let elf_s = elf_path.to_string_lossy().to_string();
@@ -376,6 +376,11 @@ fn run_objdump_and_attribute(
     }
 
     let edges = parse_disasm(&result.stdout);
+    // #478: invert once so both per-symbol directions come from the
+    // same disassembly pass. `called_by[X]` = every symbol whose
+    // forward edge list contains X — the per-symbol-precision view
+    // that complements the TU-level `referenced_by` (cref-derived).
+    let backward = invert(&edges);
     let mut total = 0usize;
     for sym in &mut map.symbols {
         if let Some(callees) = edges.get(&sym.mangled) {
@@ -387,6 +392,11 @@ fn run_objdump_and_attribute(
             // name. Match against either.
             sym.references_to = callees.clone();
             total += callees.len();
+        }
+        if let Some(callers) = backward.get(&sym.mangled) {
+            sym.called_by = callers.clone();
+        } else if let Some(callers) = backward.get(&sym.demangled) {
+            sym.called_by = callers.clone();
         }
     }
     Ok(total)

--- a/crates/fbuild-build/src/symbol_analyzer/tests.rs
+++ b/crates/fbuild-build/src/symbol_analyzer/tests.rs
@@ -117,6 +117,7 @@ fn format_markdown_report_emits_tables() {
                 source: "nm".into(),
                 referenced_by: Vec::new(),
                 references_to: Vec::new(),
+                called_by: Vec::new(),
             },
             FineGrainedSymbol {
                 mangled: "_Z3barv".into(),
@@ -131,6 +132,7 @@ fn format_markdown_report_emits_tables() {
                 source: "nm".into(),
                 referenced_by: Vec::new(),
                 references_to: Vec::new(),
+                called_by: Vec::new(),
             },
         ],
         sections: Vec::<SectionBytes>::new(),
@@ -170,6 +172,7 @@ fn format_markdown_report_escapes_pipes_in_symbol_names() {
             source: "nm".into(),
             referenced_by: Vec::new(),
             references_to: Vec::new(),
+            called_by: Vec::new(),
         }],
         sections: Vec::<SectionBytes>::new(),
     };
@@ -224,6 +227,7 @@ fn format_markdown_report_renders_referenced_by_column() {
                 },
             ],
             references_to: Vec::new(),
+            called_by: Vec::new(),
         }],
         sections: Vec::<SectionBytes>::new(),
     };
@@ -268,6 +272,7 @@ fn markdown_report_with_graphs_embeds_dot_blocks_for_top_symbols() {
                 object: "log_write.c.obj".into(),
             }],
             references_to: Vec::new(),
+            called_by: Vec::new(),
         }],
         sections: Vec::<SectionBytes>::new(),
     };
@@ -330,6 +335,7 @@ fn markdown_report_emits_dual_ranked_callees_subtable() {
             "small_helper_4".into(),
             "small_helper_5".into(),
         ],
+        called_by: Vec::new(),
     };
     let callees = vec![
         FineGrainedSymbol {
@@ -350,6 +356,7 @@ fn markdown_report_emits_dual_ranked_callees_subtable() {
                 })
                 .collect(),
             references_to: Vec::new(),
+            called_by: Vec::new(),
         },
         FineGrainedSymbol {
             mangled: "rmt_tx_start".into(),
@@ -367,6 +374,7 @@ fn markdown_report_emits_dual_ranked_callees_subtable() {
                 object: "main.cpp.o".into(),
             }],
             references_to: Vec::new(),
+            called_by: Vec::new(),
         },
         FineGrainedSymbol {
             mangled: "fl_lerp8".into(),
@@ -381,6 +389,7 @@ fn markdown_report_emits_dual_ranked_callees_subtable() {
             source: "nm".into(),
             referenced_by: Vec::new(),
             references_to: Vec::new(),
+            called_by: Vec::new(),
         },
     ];
     let mut all = vec![root];
@@ -445,6 +454,7 @@ fn markdown_report_legacy_path_skips_graph_blocks() {
             source: "nm".into(),
             referenced_by: Vec::new(),
             references_to: Vec::new(),
+            called_by: Vec::new(),
         }],
         sections: Vec::<SectionBytes>::new(),
     };
@@ -478,6 +488,7 @@ fn sidecar_dot_files_written_for_symbols_above_min_bytes() {
                 source: "nm".into(),
                 referenced_by: Vec::new(),
                 references_to: Vec::new(),
+                called_by: Vec::new(),
             },
             FineGrainedSymbol {
                 mangled: "tiny".into(),
@@ -492,6 +503,7 @@ fn sidecar_dot_files_written_for_symbols_above_min_bytes() {
                 source: "nm".into(),
                 referenced_by: Vec::new(),
                 references_to: Vec::new(),
+                called_by: Vec::new(),
             },
         ],
         sections: Vec::<SectionBytes>::new(),
@@ -546,6 +558,7 @@ fn sidecar_disabled_writes_nothing() {
             source: "nm".into(),
             referenced_by: Vec::new(),
             references_to: Vec::new(),
+            called_by: Vec::new(),
         }],
         sections: Vec::<SectionBytes>::new(),
     };
@@ -585,6 +598,7 @@ fn format_markdown_report_referenced_by_empty_renders_dash() {
             source: "nm".into(),
             referenced_by: Vec::new(),
             references_to: Vec::new(),
+            called_by: Vec::new(),
         }],
         sections: Vec::<SectionBytes>::new(),
     };

--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -651,6 +651,45 @@ pub enum BloatCmd {
         #[arg(long = "exclude-archive", default_value = "")]
         exclude_archive: String,
     },
+    /// Print the bloat metric for a single demangled (or mangled)
+    /// symbol — size, archive, object, region, per-symbol callers,
+    /// callees, TU-level referencers. Designed for AI optimisation
+    /// passes that know the symbol they want to query without
+    /// re-rendering the whole top-N report.
+    ///
+    /// Resolution: exact demangled match wins; falls back to a
+    /// substring search; `--symbol-mangled` is always exact (mangled
+    /// names are unambiguous).
+    Lookup {
+        /// ELF file OR project directory (same resolution as
+        /// `fbuild symbols`).
+        input: String,
+        /// Demangled symbol name. Exact match wins; falls back to
+        /// substring search when no exact match. Ambiguous substring
+        /// matches list all candidates.
+        #[arg(long, short = 's', group = "lookup_key")]
+        symbol: Option<String>,
+        /// Mangled symbol name. Exact match only — mangled names
+        /// are unambiguous by construction.
+        #[arg(long = "symbol-mangled", group = "lookup_key")]
+        symbol_mangled: Option<String>,
+        /// Emit the result as JSON instead of the human text block.
+        #[arg(long)]
+        json: bool,
+        /// Path to the linker map (auto-detected if omitted).
+        #[arg(long)]
+        map: Option<String>,
+        /// Cross-toolchain `nm` (auto-resolved when omitted).
+        #[arg(long)]
+        nm: Option<String>,
+        /// Cross-toolchain `c++filt` (derived from `nm` stem when
+        /// omitted).
+        #[arg(long = "cppfilt")]
+        cppfilt: Option<String>,
+        /// Path to a `build_info.json` that carries toolchain paths.
+        #[arg(long = "build-info")]
+        build_info: Option<String>,
+    },
 }
 
 /// Resolve project_dir: prefer the subcommand's value, fall back to the top-level positional arg,

--- a/crates/fbuild-cli/src/cli/bloat_lookup.rs
+++ b/crates/fbuild-cli/src/cli/bloat_lookup.rs
@@ -1,0 +1,227 @@
+//! `fbuild bloat lookup` — single-symbol bloat-metric query.
+//!
+//! Resolves one demangled or mangled symbol against the full
+//! fine-grained symbol map, and prints a focused per-symbol block
+//! (size, archive, object, region, per-symbol callers, per-symbol
+//! callees, TU-level referencers). Designed for AI optimisation
+//! passes that have a specific symbol in mind and want its row
+//! without rendering the entire top-N report.
+
+use std::path::PathBuf;
+
+use fbuild_build::symbol_analyzer::{
+    analyze_elf, default_map_path, discover_elf_in_project, AnalyzeConfig,
+};
+use fbuild_core::symbol_analysis::{
+    FineGrainedSymbol, FineGrainedSymbolMap, SymbolLookup, SymbolQuery,
+};
+use fbuild_core::{FbuildError, Result};
+
+use super::symbols_cmd::resolve_tool_paths_public;
+
+#[allow(clippy::too_many_arguments)]
+pub fn run_bloat_lookup(
+    input: String,
+    symbol: Option<String>,
+    symbol_mangled: Option<String>,
+    json: bool,
+    map: Option<String>,
+    nm: Option<String>,
+    cppfilt: Option<String>,
+    build_info: Option<String>,
+) -> Result<()> {
+    if symbol.is_none() && symbol_mangled.is_none() {
+        return Err(FbuildError::BuildFailed(
+            "lookup requires one of --symbol or --symbol-mangled".into(),
+        ));
+    }
+
+    let input_path = PathBuf::from(&input);
+    if !input_path.exists() {
+        return Err(FbuildError::BuildFailed(format!(
+            "input not found: {}",
+            input_path.display()
+        )));
+    }
+    let elf_path = if input_path.is_dir() {
+        discover_elf_in_project(&input_path).ok_or_else(|| {
+            FbuildError::BuildFailed(format!("no ELF found under {}", input_path.display()))
+        })?
+    } else {
+        input_path
+    };
+
+    let (nm_path, cppfilt_path, objdump_path) = resolve_tool_paths_public(
+        &elf_path,
+        nm.as_deref(),
+        cppfilt.as_deref(),
+        build_info.as_deref(),
+    )?;
+
+    let map_path_owned = map
+        .map(PathBuf::from)
+        .or_else(|| default_map_path(&elf_path));
+
+    let cfg = AnalyzeConfig {
+        elf_path: &elf_path,
+        map_path: map_path_owned.as_deref(),
+        nm_path: &nm_path,
+        cppfilt_path: cppfilt_path.as_deref(),
+        objdump_path: objdump_path.as_deref(),
+    };
+    let report = analyze_elf(cfg)?;
+
+    let query_str = symbol.clone().or_else(|| symbol_mangled.clone()).unwrap();
+    let query = match (&symbol, &symbol_mangled) {
+        (Some(s), _) => SymbolQuery::SubstringDemangled(s),
+        (None, Some(m)) => SymbolQuery::ExactMangled(m),
+        (None, None) => unreachable!("guarded above"),
+    };
+
+    match report.find_symbol(&query) {
+        SymbolLookup::Hit(sym) => {
+            if json {
+                let out = serde_json::to_string_pretty(sym)
+                    .map_err(|e| FbuildError::Other(format!("json serialize: {e}")))?;
+                println!("{out}");
+            } else {
+                print!("{}", format_symbol_block(sym, &report));
+            }
+            Ok(())
+        }
+        SymbolLookup::Ambiguous(candidates) => {
+            if json {
+                let payload: Vec<&FineGrainedSymbol> = candidates;
+                let out = serde_json::to_string_pretty(&payload)
+                    .map_err(|e| FbuildError::Other(format!("json serialize: {e}")))?;
+                println!("{out}");
+            } else {
+                eprintln!(
+                    "ambiguous: {} symbols match `{}`:",
+                    candidates.len(),
+                    query_str
+                );
+                for c in &candidates {
+                    eprintln!("  {} B  {}", c.size, c.demangled);
+                }
+                eprintln!("re-run with a more specific --symbol value (or use --symbol-mangled).");
+            }
+            Err(FbuildError::BuildFailed(format!(
+                "ambiguous symbol query `{query_str}`"
+            )))
+        }
+        SymbolLookup::Miss => Err(FbuildError::BuildFailed(format!(
+            "no symbol matched `{query_str}` (try a substring of the demangled name)"
+        ))),
+    }
+}
+
+/// Render the human-readable per-symbol block for `fbuild bloat lookup`.
+/// Shows the row's facts, then per-symbol callers (called_by, objdump),
+/// per-symbol callees (references_to, objdump), and TU-level referencers
+/// (referenced_by, cref).
+fn format_symbol_block(sym: &FineGrainedSymbol, map: &FineGrainedSymbolMap) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "{}", sym.demangled);
+    let _ = writeln!(out, "  size:        {} B  {:?}", sym.size, sym.region);
+    if !sym.mangled.is_empty() && sym.mangled != sym.demangled {
+        let _ = writeln!(out, "  mangled:     {}", sym.mangled);
+    }
+    if let Some(a) = &sym.archive {
+        let _ = writeln!(out, "  archive:     {a}");
+    }
+    if let Some(o) = &sym.object {
+        let _ = writeln!(out, "  object:      {o}");
+    }
+    if let Some(s) = &sym.output_section {
+        let _ = writeln!(out, "  section:     {s}");
+    }
+    let _ = writeln!(out, "  address:     {:#x}", sym.address);
+    let _ = writeln!(out, "  source:      {}", sym.source);
+    let _ = writeln!(out);
+
+    // Per-symbol callers (called_by) — the #478 use case.
+    if !sym.called_by.is_empty() {
+        let _ = writeln!(
+            out,
+            "  Callers (per-symbol, {} direct):",
+            sym.called_by.len()
+        );
+        let mut rows: Vec<(u64, &str, &str)> = sym
+            .called_by
+            .iter()
+            .map(|m| {
+                let resolved = map
+                    .symbols
+                    .iter()
+                    .find(|r| r.mangled == *m || r.demangled == *m);
+                let size = resolved.map(|r| r.size).unwrap_or(0);
+                let demangled = resolved.map(|r| r.demangled.as_str()).unwrap_or(m.as_str());
+                (size, demangled, m.as_str())
+            })
+            .collect();
+        rows.sort_by(|a, b| b.0.cmp(&a.0));
+        for (size, demangled, _) in rows.iter().take(10) {
+            let _ = writeln!(out, "    {size:>8} B  {demangled}");
+        }
+        if rows.len() > 10 {
+            let _ = writeln!(out, "    … and {} more callers", rows.len() - 10);
+        }
+        let _ = writeln!(out);
+    }
+
+    // Per-symbol callees (references_to).
+    if !sym.references_to.is_empty() {
+        let _ = writeln!(
+            out,
+            "  Callees (per-symbol, {} direct):",
+            sym.references_to.len()
+        );
+        let mut rows: Vec<(u64, &str)> = sym
+            .references_to
+            .iter()
+            .map(|m| {
+                let resolved = map
+                    .symbols
+                    .iter()
+                    .find(|r| r.mangled == *m || r.demangled == *m);
+                let size = resolved.map(|r| r.size).unwrap_or(0);
+                let demangled = resolved.map(|r| r.demangled.as_str()).unwrap_or(m.as_str());
+                (size, demangled)
+            })
+            .collect();
+        rows.sort_by(|a, b| b.0.cmp(&a.0));
+        for (size, demangled) in rows.iter().take(10) {
+            let _ = writeln!(out, "    {size:>8} B  {demangled}");
+        }
+        if rows.len() > 10 {
+            let _ = writeln!(out, "    … and {} more callees", rows.len() - 10);
+        }
+        let _ = writeln!(out);
+    }
+
+    // TU-level referencers (referenced_by, cref).
+    if !sym.referenced_by.is_empty() {
+        let _ = writeln!(
+            out,
+            "  Referenced by ({} TUs, cref-derived):",
+            sym.referenced_by.len()
+        );
+        for r in sym.referenced_by.iter().take(10) {
+            let label = match &r.archive {
+                Some(a) => format!("{a}({})", r.object),
+                None => r.object.clone(),
+            };
+            let _ = writeln!(out, "    {label}");
+        }
+        if sym.referenced_by.len() > 10 {
+            let _ = writeln!(
+                out,
+                "    … and {} more referencers",
+                sym.referenced_by.len() - 10
+            );
+        }
+    }
+    out
+}

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use crate::{daemon_client, lib_select, mcp};
 
 use super::args::{resolve_project_dir, rewrite_args, BloatCmd, Cli, Commands};
+use super::bloat_lookup::run_bloat_lookup;
 use super::build::run_build;
 use super::clang_tools::{run_clang_tool, run_iwyu};
 use super::compile_many::{
@@ -117,6 +118,25 @@ pub async fn async_main() {
                 max_depth,
                 collapse_archive,
                 exclude_archive,
+            ),
+            BloatCmd::Lookup {
+                input,
+                symbol,
+                symbol_mangled,
+                json,
+                map,
+                nm,
+                cppfilt,
+                build_info,
+            } => run_bloat_lookup(
+                input,
+                symbol,
+                symbol_mangled,
+                json,
+                map,
+                nm,
+                cppfilt,
+                build_info,
             ),
         },
         Some(Commands::Build {

--- a/crates/fbuild-cli/src/cli/mod.rs
+++ b/crates/fbuild-cli/src/cli/mod.rs
@@ -10,6 +10,7 @@
 //! byte-for-byte. Items remain reachable at `crate::cli::<submod>::<Item>`.
 
 pub mod args;
+pub mod bloat_lookup;
 pub mod build;
 pub mod clang_tools;
 pub mod compile_many;

--- a/crates/fbuild-core/src/symbol_analysis/graph/mod.rs
+++ b/crates/fbuild-core/src/symbol_analysis/graph/mod.rs
@@ -38,8 +38,11 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use super::{FineGrainedSymbolMap, SymbolReference};
 
 mod walker;
-use walker::{push_edge_dedup, rank_and_cap_referencers, walk_forward, CappedReferencer};
-pub use walker::{rank_callees_dual, CalleeRanked};
+use walker::{
+    push_edge_dedup, rank_and_cap_referencers, walk_backward_per_symbol, walk_forward,
+    CappedReferencer,
+};
+pub use walker::{rank_callees_dual, rank_callers_dual, CalleeRanked, CallerRanked};
 
 #[cfg(test)]
 mod tests;
@@ -156,6 +159,21 @@ pub enum NodeKind {
         demangled: String,
         size: u64,
         callers_count: usize,
+    },
+    /// A caller — a specific symbol that calls the root (or one of
+    /// its callers). The per-symbol-precision inverse of `Callee`,
+    /// populated from `FineGrainedSymbol::called_by` (objdump-derived,
+    /// #478). Distinct from `TranslationUnit` because the call-in
+    /// edge is per-symbol, not per-TU — answers "*which function* in
+    /// `main.cpp.o` calls this?" instead of just "`main.cpp.o`
+    /// references this." `size` is the caller's own flash footprint
+    /// (drives ranking + node sizing); `callees_count` is the number
+    /// of distinct symbols the caller itself calls (proxy for "how
+    /// many other things did pulling this caller in drag along?").
+    Caller {
+        demangled: String,
+        size: u64,
+        callees_count: usize,
     },
     /// A super-node bundling multiple TUs from the same archive
     /// because of `collapse_archives` OR fan-out overflow.
@@ -338,11 +356,23 @@ impl BackrefGraph {
         // only — the BFS expansion below short-circuits naturally on an
         // empty queue, so we get a clean forward-only graph without
         // editing the rest of this method.
+        //
+        // Skipped *also* when per-symbol back-reference data
+        // (`called_by`) is available: the per-symbol walker below
+        // produces a strictly more informative picture (caller *symbol*,
+        // not just caller *TU*), so running both would only stack two
+        // versions of the same edge in the rendered graph. The TU
+        // walker remains the fallback when `called_by` is empty —
+        // typical of pre-#478 reports, missing-objdump pipelines, and
+        // any symbol whose calls are all indirect (vtable / fn ptr)
+        // and therefore invisible to objdump.
         let want_backward = matches!(
             config.direction,
             Direction::Backward | Direction::Bidirectional
         );
-        let level1: Vec<CappedReferencer> = if want_backward {
+        let use_per_symbol_backward = want_backward && !root.called_by.is_empty();
+        let want_tu_backward = want_backward && !use_per_symbol_backward;
+        let level1: Vec<CappedReferencer> = if want_tu_backward {
             rank_and_cap_referencers(
                 &root.referenced_by,
                 index,
@@ -514,6 +544,27 @@ impl BackrefGraph {
             }
         }
 
+        // ---- Per-symbol backward direction (#478): walk
+        // ---- root.called_by outward when objdump-derived per-symbol
+        // ---- call-in data is available. Strictly more precise than
+        // ---- the TU walker above (caller *symbol*, not just caller
+        // ---- *TU*); gated on `use_per_symbol_backward` so we don't
+        // ---- double-render edges.
+        if use_per_symbol_backward {
+            let mut visited_syms: BTreeSet<String> = BTreeSet::new();
+            visited_syms.insert(root.mangled.clone());
+            walk_backward_per_symbol(
+                map,
+                config,
+                root,
+                &root_id,
+                /*depth=*/ 1,
+                &mut nodes,
+                &mut edges,
+                &mut visited_syms,
+            );
+        }
+
         // ---- Forward direction: walk root.references_to outward.
         //
         // Forward edges are per-symbol (not TU-level), so the node
@@ -624,6 +675,7 @@ fn node_width(n: &GraphNode) -> Option<f64> {
             size_hint: Some(b), ..
         } => *b,
         NodeKind::Callee { size, .. } => *size,
+        NodeKind::Caller { size, .. } => *size,
         _ => return None,
     };
     if bytes == 0 {

--- a/crates/fbuild-core/src/symbol_analysis/graph/tests.rs
+++ b/crates/fbuild-core/src/symbol_analysis/graph/tests.rs
@@ -27,6 +27,7 @@ fn sym(
         source: "nm".to_string(),
         referenced_by: refs,
         references_to: Vec::new(),
+        called_by: Vec::new(),
     }
 }
 
@@ -712,4 +713,122 @@ fn default_direction_is_backward_only() {
         .edges
         .iter()
         .all(|e| e.direction == EdgeDirection::Backward));
+}
+
+// ---- #478: per-symbol backward walker ----
+
+/// Helper: build a symbol with explicit `called_by`. Per-symbol
+/// inverse of [`sym_calls`] above.
+fn sym_called_by(
+    mangled: &str,
+    size: u64,
+    archive: Option<&str>,
+    object: &str,
+    callers: Vec<&str>,
+) -> FineGrainedSymbol {
+    let mut s = sym(mangled, mangled, size, archive, object, Vec::new());
+    s.called_by = callers.into_iter().map(|c| c.to_string()).collect();
+    s
+}
+
+/// When `called_by` is non-empty, the backward walker must emit
+/// per-symbol Caller nodes instead of TU-level TranslationUnit
+/// nodes. The picture answers "*which symbol* calls me?" with
+/// precision, which is the AI-optimisation use-case from #478.
+#[test]
+fn backward_uses_per_symbol_when_called_by_populated() {
+    let symbols = vec![
+        sym_called_by("root_sym", 5_000, None, "main.cpp.o", vec!["caller_big"]),
+        sym(
+            "caller_big",
+            "caller_big",
+            8_000,
+            None,
+            "main.cpp.o",
+            Vec::new(),
+        ),
+    ];
+    let g = BackrefGraph::build(&map(symbols), "root_sym", &GraphConfig::default());
+    let caller_nodes: Vec<&str> = g
+        .nodes
+        .iter()
+        .filter_map(|n| match &n.kind {
+            NodeKind::Caller { demangled, .. } => Some(demangled.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(caller_nodes, vec!["caller_big"]);
+    let tu_nodes: Vec<_> = g
+        .nodes
+        .iter()
+        .filter(|n| matches!(n.kind, NodeKind::TranslationUnit { .. }))
+        .collect();
+    assert!(
+        tu_nodes.is_empty(),
+        "per-symbol back-edges must not emit TU nodes"
+    );
+}
+
+/// Fallback path: when `called_by` is empty (no objdump in the
+/// chain, or all calls are indirect), the historical TU-level
+/// walker still runs from `referenced_by`. This preserves the
+/// pre-#478 picture for older reports and call sites that aren't
+/// reachable via direct disassembly edges (vtable / fn ptr).
+#[test]
+fn backward_falls_back_to_tu_when_called_by_empty() {
+    let referencer = refr(None, "main.cpp.o");
+    let symbols = vec![
+        sym(
+            "root_sym",
+            "root_sym",
+            5_000,
+            None,
+            "fl.cpp.o",
+            vec![referencer],
+        ),
+        sym(
+            "caller_sym",
+            "caller_sym",
+            8_000,
+            None,
+            "main.cpp.o",
+            Vec::new(),
+        ),
+    ];
+    let g = BackrefGraph::build(&map(symbols), "root_sym", &GraphConfig::default());
+    let tu_nodes: Vec<_> = g
+        .nodes
+        .iter()
+        .filter(|n| matches!(n.kind, NodeKind::TranslationUnit { .. }))
+        .collect();
+    assert_eq!(tu_nodes.len(), 1, "TU fallback should kick in");
+    assert!(g
+        .nodes
+        .iter()
+        .all(|n| !matches!(n.kind, NodeKind::Caller { .. })));
+}
+
+/// `rank_callers_dual` exposes both rankings the markdown sub-table
+/// renders side-by-side. The "by size" axis picks the heaviest caller;
+/// the "by breadth" axis picks the caller that calls the most other
+/// symbols (proxy for downstream-leverage if eliminated).
+#[test]
+fn rank_callers_dual_sorts_each_axis_independently() {
+    use super::rank_callers_dual;
+    let mut huge_narrow = sym("huge_narrow", "huge_narrow", 9_000, None, "a.o", Vec::new());
+    huge_narrow.references_to = vec!["x".into()];
+    let mut small_broad = sym("small_broad", "small_broad", 200, None, "b.o", Vec::new());
+    small_broad.references_to = vec!["x".into(), "y".into(), "z".into(), "w".into()];
+    let mut tiny = sym("tiny", "tiny", 50, None, "c.o", Vec::new());
+    tiny.references_to = vec!["x".into()];
+    let mut root = sym("root", "root", 5_000, None, "main.o", Vec::new());
+    root.called_by = vec!["huge_narrow".into(), "small_broad".into(), "tiny".into()];
+    let m = map(vec![root.clone(), huge_narrow, small_broad, tiny]);
+    let (by_size, by_breadth, other) = rank_callers_dual(&m, &root, 1);
+    assert_eq!(by_size.len(), 1);
+    assert_eq!(by_size[0].demangled, "huge_narrow");
+    assert_eq!(by_breadth.len(), 1);
+    assert_eq!(by_breadth[0].demangled, "small_broad");
+    // `tiny` was in neither bucket, so it counts as "other".
+    assert_eq!(other, 1);
 }

--- a/crates/fbuild-core/src/symbol_analysis/graph/walker.rs
+++ b/crates/fbuild-core/src/symbol_analysis/graph/walker.rs
@@ -273,6 +273,174 @@ fn format_callee_label(demangled: &str, size: u64, callers_count: usize) -> Stri
     }
 }
 
+/// Per-caller node label: `<demangled>\n<size> B\ncalls ×N`.
+/// Distinct from `format_callee_label` so users reading the rendered
+/// graph can tell at a glance whether a node is a back-edge (a thing
+/// calling the root) or a forward-edge (a thing the root calls).
+fn format_caller_label(demangled: &str, size: u64, callees_count: usize) -> String {
+    let truncated = if demangled.len() > 64 {
+        format!("{}…", &demangled[..63])
+    } else {
+        demangled.to_string()
+    };
+    if callees_count > 1 {
+        format!("{truncated}\n{size} B\ncalls ×{callees_count}")
+    } else {
+        format!("{truncated}\n{size} B")
+    }
+}
+
+/// BFS the per-symbol backward edges (`called_by`) outward from a
+/// starting symbol. Mirror of [`walk_forward`] but for the inverse
+/// direction: surfaces "*which symbols call into this?*" with
+/// per-symbol precision instead of the TU-level granularity the
+/// `referenced_by` (cref-based) walker provides.
+///
+/// Ranking is by caller flash size descending. Same fan-out cap and
+/// `max_depth` policy as `walk_forward`; same overflow super-node
+/// rendering.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn walk_backward_per_symbol(
+    map: &FineGrainedSymbolMap,
+    config: &GraphConfig,
+    callee_sym: &super::super::FineGrainedSymbol,
+    callee_node_id: &str,
+    depth: u32,
+    nodes: &mut Vec<GraphNode>,
+    edges: &mut Vec<GraphEdge>,
+    visited_syms: &mut BTreeSet<String>,
+) {
+    if depth > config.max_depth {
+        return;
+    }
+    let mut callers: Vec<CallerCandidate<'_>> = Vec::new();
+    for caller_mangled in &callee_sym.called_by {
+        if visited_syms.contains(caller_mangled) {
+            continue;
+        }
+        let resolved = map
+            .symbols
+            .iter()
+            .find(|s| s.mangled == *caller_mangled || s.demangled == *caller_mangled);
+        callers.push(CallerCandidate {
+            mangled: caller_mangled.clone(),
+            sym: resolved,
+        });
+    }
+    if callers.is_empty() {
+        return;
+    }
+    callers.retain(|c| match c.sym.and_then(|s| s.archive.as_ref()) {
+        Some(a) => !config.exclude_archives.iter().any(|x| x == a),
+        None => true,
+    });
+    if callers.is_empty() {
+        return;
+    }
+    callers.sort_by(|a, b| {
+        b.size()
+            .cmp(&a.size())
+            .then_with(|| b.callees_count().cmp(&a.callees_count()))
+            .then_with(|| a.mangled.cmp(&b.mangled))
+    });
+
+    let total = callers.len();
+    let take_n = config.fan_out.min(total);
+    let overflow = total.saturating_sub(take_n);
+
+    for c in callers.iter().take(take_n) {
+        let caller_id = format!("sym__{}", sanitize_id(&c.mangled));
+        if visited_syms.insert(c.mangled.clone()) {
+            let (demangled, size) = match c.sym {
+                Some(s) => (s.demangled.clone(), s.size),
+                None => (c.mangled.clone(), 0),
+            };
+            let callees_count = c.callees_count();
+            let archive = c.sym.and_then(|s| s.archive.clone());
+            let object = c.sym.and_then(|s| s.object.clone());
+            nodes.push(GraphNode {
+                id: caller_id.clone(),
+                label: format_caller_label(&demangled, size, callees_count),
+                archive,
+                object,
+                kind: NodeKind::Caller {
+                    demangled,
+                    size,
+                    callees_count,
+                },
+                depth,
+            });
+            if let Some(resolved) = c.sym {
+                if depth < config.max_depth && !resolved.called_by.is_empty() {
+                    walk_backward_per_symbol(
+                        map,
+                        config,
+                        resolved,
+                        &caller_id,
+                        depth + 1,
+                        nodes,
+                        edges,
+                        visited_syms,
+                    );
+                }
+            }
+        }
+        // Backward edge: caller → callee (root). Solid arrow matches
+        // the historical pre-#478 backref-edge style so existing `.dot`
+        // consumers see the same visual.
+        push_edge_dedup(
+            edges,
+            GraphEdge {
+                from: caller_id,
+                to: callee_node_id.to_string(),
+                direction: EdgeDirection::Backward,
+            },
+        );
+    }
+
+    if overflow > 0 {
+        let overflow_id = format!(
+            "bwd_ovf__{}__d{}__{}",
+            sanitize_id(callee_node_id),
+            depth,
+            overflow
+        );
+        nodes.push(GraphNode {
+            id: overflow_id.clone(),
+            label: format!("(… and {overflow} more callers)"),
+            archive: None,
+            object: None,
+            kind: NodeKind::Collapsed {
+                archive: "(overflow)".to_string(),
+                count: overflow,
+            },
+            depth,
+        });
+        edges.push(GraphEdge {
+            from: overflow_id,
+            to: callee_node_id.to_string(),
+            direction: EdgeDirection::Backward,
+        });
+    }
+}
+
+/// Working struct for ranking per-symbol callers (mirror of
+/// [`CalleeCandidate`]).
+pub(super) struct CallerCandidate<'a> {
+    mangled: String,
+    sym: Option<&'a super::super::FineGrainedSymbol>,
+}
+
+impl<'a> CallerCandidate<'a> {
+    fn size(&self) -> u64 {
+        self.sym.map(|s| s.size).unwrap_or(0)
+    }
+
+    fn callees_count(&self) -> usize {
+        self.sym.map(|s| s.references_to.len()).unwrap_or(0)
+    }
+}
+
 /// Rank a symbol's direct callees by two axes simultaneously and
 /// return the top-`top_n` from each — the data the markdown
 /// "Top N callees" sub-table renders side by side.
@@ -357,5 +525,84 @@ pub struct CalleeRanked<'a> {
     pub demangled: String,
     pub size: u64,
     pub callers_count: usize,
+    pub sym: Option<&'a super::super::FineGrainedSymbol>,
+}
+
+/// Dual-axis ranking of a symbol's per-symbol callers (mirror of
+/// [`rank_callees_dual`]). Returns `(by_size, by_breadth, other_count)`:
+///   - `by_size`: heaviest callers (flash bytes) — answers "which big
+///     thing dragged this in?" so an AI pass that wants to shrink the
+///     binary knows which caller, if eliminated, would let the
+///     dead-code pass also strip the callee.
+///   - `by_breadth`: callers with the most callees of their own —
+///     proxy for "how much else did pulling this caller in cost?" so
+///     the AI can see whether eliminating a caller has high downstream
+///     leverage.
+///   - `other_count`: number of unique callers that fell out of both
+///     top-N buckets.
+///
+/// Callers that don't resolve to a row in `map` get `size=0`/`callees_count=0`
+/// and contribute to neither axis.
+#[must_use]
+pub fn rank_callers_dual<'a>(
+    map: &'a FineGrainedSymbolMap,
+    callee: &super::super::FineGrainedSymbol,
+    top_n: usize,
+) -> (Vec<CallerRanked<'a>>, Vec<CallerRanked<'a>>, usize) {
+    let mut resolved: Vec<CallerRanked<'a>> = callee
+        .called_by
+        .iter()
+        .map(|m| {
+            let s = map
+                .symbols
+                .iter()
+                .find(|s| s.mangled == *m || s.demangled == *m);
+            CallerRanked {
+                mangled: m.clone(),
+                demangled: s.map(|s| s.demangled.clone()).unwrap_or_else(|| m.clone()),
+                size: s.map(|s| s.size).unwrap_or(0),
+                callees_count: s.map(|s| s.references_to.len()).unwrap_or(0),
+                sym: s,
+            }
+        })
+        .collect();
+
+    let mut by_size = resolved.clone();
+    by_size.sort_by(|a, b| {
+        b.size
+            .cmp(&a.size)
+            .then_with(|| a.demangled.cmp(&b.demangled))
+    });
+    let mut by_breadth = resolved.clone();
+    by_breadth.sort_by(|a, b| {
+        b.callees_count
+            .cmp(&a.callees_count)
+            .then_with(|| b.size.cmp(&a.size))
+            .then_with(|| a.demangled.cmp(&b.demangled))
+    });
+
+    let size_top = by_size.iter().take(top_n).cloned().collect::<Vec<_>>();
+    let breadth_top = by_breadth.iter().take(top_n).cloned().collect::<Vec<_>>();
+
+    let top_mangled: BTreeSet<&str> = size_top
+        .iter()
+        .chain(breadth_top.iter())
+        .map(|c| c.mangled.as_str())
+        .collect();
+    let other_count = resolved
+        .drain(..)
+        .filter(|c| !top_mangled.contains(c.mangled.as_str()))
+        .count();
+
+    (size_top, breadth_top, other_count)
+}
+
+/// Row in the dual-ranked caller table.
+#[derive(Debug, Clone)]
+pub struct CallerRanked<'a> {
+    pub mangled: String,
+    pub demangled: String,
+    pub size: u64,
+    pub callees_count: usize,
     pub sym: Option<&'a super::super::FineGrainedSymbol>,
 }

--- a/crates/fbuild-core/src/symbol_analysis/mod.rs
+++ b/crates/fbuild-core/src/symbol_analysis/mod.rs
@@ -92,6 +92,20 @@ pub struct FineGrainedSymbol {
     /// See `symbol_analysis::callgraph`.
     #[serde(default)]
     pub references_to: Vec<String>,
+    /// Symbols that **call into** this symbol — the per-symbol inverse
+    /// of `references_to`. Populated by inverting the objdump-derived
+    /// forward map (`callgraph::invert`) so a single objdump pass
+    /// produces both directions. Strings match another row's `mangled`
+    /// in the same report. Empty for the same reasons `references_to`
+    /// would be empty (no objdump in the chain, indirect-only call
+    /// sites, etc.). Complementary to `referenced_by`, which is
+    /// TU-level — `called_by` answers "which specific *symbols* call
+    /// me?" where `referenced_by` answers "which *TUs* reference me?".
+    /// Per-symbol granularity is the AI-optimisation use-case (#478)
+    /// that wants to distinguish `f()` calling `g()` from `f()`'s
+    /// sibling-in-the-same-TU calling `g()`.
+    #[serde(default)]
+    pub called_by: Vec<String>,
 }
 
 fn default_source_nm() -> String {
@@ -167,7 +181,92 @@ impl LoadedRegion {
     }
 }
 
+/// A symbol-lookup query passed to [`FineGrainedSymbolMap::find_symbol`].
+///
+/// Three dispatch modes; the variant carries the precedence rules the
+/// `fbuild bloat lookup --symbol` CLI surface relies on:
+///
+/// - `ExactDemangled` — case-sensitive full-string match on `demangled`.
+///   Wins over substring matching because operator-overloads and templated
+///   functions are uniquely identified by their full demangled form.
+/// - `SubstringDemangled` — case-sensitive `contains()` match. Useful for
+///   one-shot queries from a human ("just give me the `ClocklessIdf5`
+///   row"); ambiguous matches return all hits so the caller can refine.
+/// - `ExactMangled` — case-sensitive full-string match on `mangled`.
+///   Never falls back to substring matching: mangled names are
+///   unambiguous by construction, so a substring match would just
+///   surface noise.
+#[derive(Debug, Clone)]
+pub enum SymbolQuery<'a> {
+    ExactDemangled(&'a str),
+    SubstringDemangled(&'a str),
+    ExactMangled(&'a str),
+}
+
+/// Outcome of a single-symbol lookup against [`FineGrainedSymbolMap`].
+///
+/// Distinguishes the three outcomes the AI / human caller actually
+/// wants to fork on:
+///   - `Hit` — exactly one symbol matched; render the focused per-symbol
+///     block straight from the contained row.
+///   - `Ambiguous` — multiple symbols matched (only possible from
+///     `SubstringDemangled`); the caller surfaces the candidates so
+///     the user can re-query with a more specific name.
+///   - `Miss` — no rows matched; the caller emits a "not found" message
+///     and suggests trying a substring search.
+#[derive(Debug)]
+pub enum SymbolLookup<'a> {
+    Hit(&'a FineGrainedSymbol),
+    Ambiguous(Vec<&'a FineGrainedSymbol>),
+    Miss,
+}
+
 impl FineGrainedSymbolMap {
+    /// Resolve a single-symbol query against this map.
+    ///
+    /// Lookup order for `SubstringDemangled` is: exact-demangled match
+    /// first (so `--symbol 'fl::ChannelXYZ::show()'` always picks the
+    /// exact row even if a longer demangled name also contains it as
+    /// a substring); if no exact hit, fall back to all rows whose
+    /// `demangled` contains the query as a substring. Multi-hit
+    /// substring matches return [`SymbolLookup::Ambiguous`] so the
+    /// caller can list candidates rather than guessing.
+    ///
+    /// `ExactDemangled` and `ExactMangled` skip the substring fallback
+    /// — for those modes a miss is a miss.
+    #[must_use]
+    pub fn find_symbol(&self, query: &SymbolQuery<'_>) -> SymbolLookup<'_> {
+        match query {
+            SymbolQuery::ExactDemangled(name) => self
+                .symbols
+                .iter()
+                .find(|s| s.demangled == *name)
+                .map(SymbolLookup::Hit)
+                .unwrap_or(SymbolLookup::Miss),
+            SymbolQuery::ExactMangled(name) => self
+                .symbols
+                .iter()
+                .find(|s| s.mangled == *name)
+                .map(SymbolLookup::Hit)
+                .unwrap_or(SymbolLookup::Miss),
+            SymbolQuery::SubstringDemangled(needle) => {
+                if let Some(exact) = self.symbols.iter().find(|s| s.demangled == *needle) {
+                    return SymbolLookup::Hit(exact);
+                }
+                let mut hits: Vec<&FineGrainedSymbol> = self
+                    .symbols
+                    .iter()
+                    .filter(|s| s.demangled.contains(needle))
+                    .collect();
+                match hits.len() {
+                    0 => SymbolLookup::Miss,
+                    1 => SymbolLookup::Hit(hits.remove(0)),
+                    _ => SymbolLookup::Ambiguous(hits),
+                }
+            }
+        }
+    }
+
     /// Drop symbols that did not land in any loaded region of the final
     /// binary, then recompute `total_flash` / `total_ram` from the
     /// surviving rows.
@@ -680,6 +779,7 @@ pub fn build_fine_grained_map_with_synth(
             source: "nm".to_string(),
             referenced_by,
             references_to: Vec::new(),
+            called_by: Vec::new(),
         });
     }
 
@@ -724,6 +824,7 @@ pub fn build_fine_grained_map_with_synth(
             source: "map-derived".to_string(),
             referenced_by,
             references_to: Vec::new(),
+            called_by: Vec::new(),
         });
     }
     FineGrainedSymbolMap {

--- a/crates/fbuild-core/src/symbol_analysis/tests.rs
+++ b/crates/fbuild-core/src/symbol_analysis/tests.rs
@@ -457,6 +457,7 @@ fn sample_symbol(addr: u64, size: u64, region: MemoryRegion, name: &str) -> Fine
         source: "nm".to_string(),
         referenced_by: Vec::new(),
         references_to: Vec::new(),
+        called_by: Vec::new(),
     }
 }
 
@@ -701,4 +702,96 @@ fn retain_loaded_symbols_no_op_when_regions_empty() {
     assert_eq!(map.symbols.len(), 2);
     assert_eq!(map.total_flash, 0x40);
     assert_eq!(map.total_ram, 0x80);
+}
+
+/// #478: single-symbol lookup must distinguish exact, substring,
+/// ambiguous-substring, and miss outcomes.
+#[test]
+fn find_symbol_dispatches_correctly() {
+    let mut foo = sample_symbol(0x1000, 100, MemoryRegion::Flash, "fl::foo()");
+    foo.mangled = "_ZN2fl3fooEv".to_string();
+    let mut foo_bar = sample_symbol(0x2000, 50, MemoryRegion::Flash, "fl::foo_bar()");
+    foo_bar.mangled = "_ZN2fl7foo_barEv".to_string();
+    let mut other = sample_symbol(0x3000, 25, MemoryRegion::Flash, "ns::other()");
+    other.mangled = "_ZN2ns5otherEv".to_string();
+    let map = FineGrainedSymbolMap {
+        elf_path: "x.elf".into(),
+        map_path: None,
+        total_flash: 175,
+        total_ram: 0,
+        symbols: vec![foo, foo_bar, other],
+        sections: Vec::new(),
+    };
+
+    // Exact demangled wins.
+    match map.find_symbol(&SymbolQuery::ExactDemangled("fl::foo()")) {
+        SymbolLookup::Hit(s) => assert_eq!(s.size, 100),
+        other => panic!("expected Hit, got {other:?}"),
+    }
+    // Exact demangled miss is a miss, not a substring fallback.
+    assert!(matches!(
+        map.find_symbol(&SymbolQuery::ExactDemangled("fl::foo")),
+        SymbolLookup::Miss
+    ));
+
+    // Substring: exact-demangled match still wins even when the same
+    // string is a substring of another row's demangled name.
+    match map.find_symbol(&SymbolQuery::SubstringDemangled("fl::foo()")) {
+        SymbolLookup::Hit(s) => assert_eq!(s.demangled, "fl::foo()"),
+        other => panic!("expected exact-wins Hit, got {other:?}"),
+    }
+    // Substring: ambiguous returns all candidates.
+    match map.find_symbol(&SymbolQuery::SubstringDemangled("fl::foo")) {
+        SymbolLookup::Ambiguous(hits) => {
+            assert_eq!(hits.len(), 2);
+            let names: Vec<&str> = hits.iter().map(|s| s.demangled.as_str()).collect();
+            assert!(names.contains(&"fl::foo()"));
+            assert!(names.contains(&"fl::foo_bar()"));
+        }
+        other => panic!("expected Ambiguous, got {other:?}"),
+    }
+    // Substring: unique substring is a Hit.
+    match map.find_symbol(&SymbolQuery::SubstringDemangled("other")) {
+        SymbolLookup::Hit(s) => assert_eq!(s.demangled, "ns::other()"),
+        other => panic!("expected unique-substring Hit, got {other:?}"),
+    }
+    // Substring miss.
+    assert!(matches!(
+        map.find_symbol(&SymbolQuery::SubstringDemangled("not_present")),
+        SymbolLookup::Miss
+    ));
+
+    // Exact mangled.
+    match map.find_symbol(&SymbolQuery::ExactMangled("_ZN2fl3fooEv")) {
+        SymbolLookup::Hit(s) => assert_eq!(s.demangled, "fl::foo()"),
+        other => panic!("expected mangled Hit, got {other:?}"),
+    }
+}
+
+/// #478: called_by survives the FineGrainedSymbol JSON round-trip.
+/// Default empty when missing so older reports still deserialize.
+#[test]
+fn called_by_roundtrips_via_serde_with_default() {
+    let mut s = sample_symbol(0x1000, 50, MemoryRegion::Flash, "f");
+    s.called_by = vec!["caller_a".into(), "caller_b".into()];
+    let json = serde_json::to_string(&s).unwrap();
+    assert!(json.contains("called_by"));
+    let round: FineGrainedSymbol = serde_json::from_str(&json).unwrap();
+    assert_eq!(round.called_by, vec!["caller_a", "caller_b"]);
+
+    // Older reports without the field still parse with default empty.
+    let without = serde_json::json!({
+        "mangled": "x",
+        "demangled": "x",
+        "address": 0u64,
+        "size": 10u64,
+        "sym_type": "T",
+        "region": "flash",
+        "archive": null,
+        "object": null,
+        "output_section": null,
+    });
+    let parsed: FineGrainedSymbol = serde_json::from_value(without).unwrap();
+    assert!(parsed.called_by.is_empty());
+    assert!(parsed.references_to.is_empty());
 }


### PR DESCRIPTION
Closes #478.

## Summary

Two complementary capabilities so AI optimisation passes can answer
*"who calls this specific symbol?"* and *"what does this specific
symbol cost?"* with per-symbol precision (not TU-level).

- **`FineGrainedSymbol.called_by`** — per-symbol inverse of
  `references_to`, populated by inverting the existing objdump-derived
  forward map (`callgraph::invert`) in `run_objdump_and_attribute`.
  Single objdump pass produces both directions.
- **`NodeKind::Caller` + `walk_backward_per_symbol`** — graph walker
  mirror of `walk_forward`. When `called_by` is non-empty the graph
  uses per-symbol back-edges (more precise); falls back to the
  TU-level walker when empty (older reports, vtable-only calls).
- **`Top callers` markdown sub-table** — sibling of the existing
  `Top callees` table, dual-ranked by caller flash size and by caller
  breadth (callees-count, proxy for downstream-leverage).
- **`fbuild bloat lookup <input> --symbol <demangled>`** — focused
  per-symbol block (size, archive, object, region, per-symbol callers,
  per-symbol callees, TU-level referencers). `--symbol-mangled` for
  exact mangled lookup, `--json` for machine consumption. Substring
  search falls back from exact-demangled-first → ambiguous list.
- **`FineGrainedSymbolMap::find_symbol`** with `SymbolQuery` /
  `SymbolLookup` — programmatic API behind the CLI.

## Test plan

- [x] `find_symbol_dispatches_correctly` — exact/substring/ambiguous/unique/miss/mangled
- [x] `called_by_roundtrips_via_serde_with_default` — JSON round-trip + back-compat for older reports
- [x] `backward_uses_per_symbol_when_called_by_populated` — graph walker takes per-symbol path
- [x] `backward_falls_back_to_tu_when_called_by_empty` — TU walker still runs as fallback
- [x] `rank_callers_dual_sorts_each_axis_independently` — both rankings work
- [x] `soldr cargo check --workspace --all-targets`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `soldr cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings soldr cargo doc --workspace --no-deps`
- [x] `soldr cargo test -p fbuild-core --lib symbol_analysis::` (72 passed)
- [x] `soldr cargo test -p fbuild-build --lib symbol_analyzer` (17 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fbuild bloat lookup` subcommand to search and analyze specific symbols
  * Symbol lookup via exact or substring matching on demangled and mangled names
  * Display direct callers and callees for symbols with optional JSON output
  * Enhanced symbol analysis with backward callgraph relationships showing which symbols call into a target symbol

<!-- end of auto-generated comment: release notes by coderabbit.ai -->