### PR TITLE
fix(hooks): truncate subprocess output fed back to Claude

### DIFF
--- a/ci/hooks/README.md
+++ b/ci/hooks/README.md
@@ -10,3 +10,4 @@ Python scripts invoked by Claude Code lifecycle hooks, configured in `.claude/se
 - **`readme_guard.py`** -- PostToolUse: ensures every directory containing edited files has a `README.md`
 - **`check-on-start.py`** -- SessionStart: captures a git fingerprint so the stop hook can detect changes
 - **`check-on-stop.py`** -- Stop: runs full workspace lint + tests if files changed during the session
+- **`_output.py`** -- shared `truncate_output(text, max_lines)` helper used by `lint.py` and `check-on-stop.py` to bound subprocess stderr/stdout fed back to Claude (prevents cc-rs build-script PATH dumps and Windows MAX_PATH C1081 errors from overflowing the context window)

--- a/ci/hooks/_output.py
+++ b/ci/hooks/_output.py
@@ -1,0 +1,35 @@
+"""Shared output-truncation helper for hooks.
+
+Hooks pipe subprocess output back to Claude via stderr. When the underlying
+tool (cargo clippy, cargo test, cc-rs build scripts, etc.) fails and dumps
+megabytes of output — for example, cc-rs printing the full `PATH` env var
+once per compiled C file, or Windows MAX_PATH C1081 errors from
+deeply-nested worktree target dirs — the unbounded stream blows past
+Claude's context window.
+
+`truncate_output()` keeps the last `max_lines` of each stream and prefixes
+a one-line "[... N earlier lines truncated ...]" header so the model can
+see the tail (which is where the actionable error usually lives) without
+ingesting the build-script preamble.
+"""
+
+from __future__ import annotations
+
+DEFAULT_MAX_LINES = 200
+
+
+def truncate_output(text: str, max_lines: int = DEFAULT_MAX_LINES) -> str:
+    """Return `text` with at most `max_lines` trailing lines.
+
+    If truncation occurs, a header line indicates how many earlier lines
+    were dropped so the reader knows context is missing. Trailing/leading
+    whitespace on the original text is preserved on the kept tail.
+    """
+    if max_lines <= 0:
+        return text
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return text
+    skipped = len(lines) - max_lines
+    kept = "\n".join(lines[-max_lines:])
+    return f"[... {skipped} earlier line(s) truncated to fit context ...]\n{kept}"

--- a/ci/hooks/check-on-stop.py
+++ b/ci/hooks/check-on-stop.py
@@ -30,6 +30,9 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 PROJECT_ROOT = SCRIPT_DIR.parent.parent
 SESSION_FINGERPRINT_FILE = PROJECT_ROOT / ".cache" / "session_fingerprint.json"
 
+sys.path.insert(0, str(SCRIPT_DIR))
+from _output import truncate_output  # noqa: E402
+
 # Repo-root files whose change forces a workspace-wide lint+test —
 # they affect every crate (cross-crate deps, toolchain pin, lint config).
 WORKSPACE_TRIGGER_FILES = frozenset({
@@ -61,9 +64,9 @@ def run_cmd(cmd):
 def report_failure(label, result):
     print(f"{label}:", file=sys.stderr)
     if result.stdout.strip():
-        print(result.stdout.strip(), file=sys.stderr)
+        print(truncate_output(result.stdout.strip()), file=sys.stderr)
     if result.stderr.strip():
-        print(result.stderr.strip(), file=sys.stderr)
+        print(truncate_output(result.stderr.strip()), file=sys.stderr)
 
 
 def get_current_fingerprint():

--- a/ci/hooks/lint.py
+++ b/ci/hooks/lint.py
@@ -21,6 +21,9 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 PROJECT_ROOT = SCRIPT_DIR.parent.parent
 
+sys.path.insert(0, str(SCRIPT_DIR))
+from _output import truncate_output  # noqa: E402
+
 
 def main():
     try:
@@ -62,9 +65,9 @@ def main():
         rel_path = os.path.relpath(file_path, str(PROJECT_ROOT))
         print(f"Lint violations in {rel_path}:", file=sys.stderr)
         if result.stdout.strip():
-            print(result.stdout.strip(), file=sys.stderr)
+            print(truncate_output(result.stdout.strip()), file=sys.stderr)
         if result.stderr.strip():
-            print(result.stderr.strip(), file=sys.stderr)
+            print(truncate_output(result.stderr.strip()), file=sys.stderr)
         return 2
 
     return 0

--- a/ci/hooks/test_output.py
+++ b/ci/hooks/test_output.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Unit tests for ci/hooks/_output.py — bounded stderr fed back to Claude
+(issue #481).
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent / "_output.py"
+_spec = importlib.util.spec_from_file_location("_hook_output", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+truncate_output = _module.truncate_output
+DEFAULT_MAX_LINES = _module.DEFAULT_MAX_LINES
+
+
+class TruncateOutputTests(unittest.TestCase):
+    def test_short_input_passes_through(self):
+        self.assertEqual(truncate_output("a\nb\nc", max_lines=10), "a\nb\nc")
+
+    def test_exactly_max_lines_passes_through(self):
+        text = "\n".join(str(i) for i in range(5))
+        self.assertEqual(truncate_output(text, max_lines=5), text)
+
+    def test_long_input_keeps_tail(self):
+        text = "\n".join(str(i) for i in range(500))
+        out = truncate_output(text, max_lines=5)
+        lines = out.splitlines()
+        self.assertEqual(len(lines), 6)
+        self.assertEqual(
+            lines[0],
+            "[... 495 earlier line(s) truncated to fit context ...]",
+        )
+        self.assertEqual(lines[-1], "499")
+        self.assertEqual(lines[-5], "495")
+
+    def test_zero_max_lines_disables_truncation(self):
+        text = "\n".join(str(i) for i in range(50))
+        self.assertEqual(truncate_output(text, max_lines=0), text)
+
+    def test_negative_max_lines_disables_truncation(self):
+        text = "\n".join(str(i) for i in range(50))
+        self.assertEqual(truncate_output(text, max_lines=-1), text)
+
+    def test_empty_input(self):
+        self.assertEqual(truncate_output("", max_lines=5), "")
+
+    def test_default_max_lines_is_positive(self):
+        self.assertGreater(DEFAULT_MAX_LINES, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `ci/hooks/_output.py::truncate_output(text, max_lines=200)` and routes the failure-print paths in `ci/hooks/check-on-stop.py::report_failure()` and `ci/hooks/lint.py` through it.
- Bounds unbounded stderr that the Stop and PostToolUse hooks feed back to Claude on subprocess failure.
- Adds `ci/hooks/test_output.py` (7 unit tests) covering pass-through, tail-keeping, header text, the 0/negative disable knob, and empty input.

## Why

The Stop hook (`check-on-stop.py`) and the per-file lint hook (`lint.py`) both `capture_output=True` their `soldr cargo` / `./lint` subprocess and dump the full stdout+stderr to stderr on non-zero exit. That stderr is fed back to Claude. A single noisy build-script failure can overwhelm the 1M context window — cc-rs prints the kilobyte-sized `PATH` env var once per compiled C source file, and a deeply-nested worktree target dir triggers Windows MAX_PATH `fatal error C1081: 'file name too long'` on every dependency, multiplying the spam.

When that happens, `/compact` itself can fail (`conversation could not be reduced below the context limit`) and the user loses in-progress work to `/clear`. The Stop hook is supposed to help by surfacing failures; without bounding, it does the opposite.

Closes #481

## Out of scope (separate follow-ups)

- The recursive `.claude/worktrees/.claude/worktrees/...` nesting that triggered the MAX_PATH overrun is itself a defect (Agent worktree isolation should not stack inside an existing worktree sandbox). Tracked in #481's "Out of scope" section.
- Tightening cargo output at the source (`CARGO_TERM_VERBOSE=false`, `--message-format short`) on top of truncation.

## Test plan

- [x] `python -m unittest discover -s ci/hooks -p 'test_*.py'` — all 25 hook tests pass (18 prior + 7 new).
- [x] End-to-end smoke: 10,000-line fake `CompletedProcess` through `report_failure()` collapses to ~403 lines with the `[... N earlier line(s) truncated to fit context ...]` header preserved.
- [x] End-to-end smoke: 6,000-line fake clippy failure through `lint.py::main()` collapses to ~403 lines and exits 2.
- [x] No-op verified: `truncate_output("a\nb\nc", max_lines=10) == "a\nb\nc"`.