### PR TITLE
fix(hooks): refuse Agent worktree-isolation calls from nested worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/worktree_guard.py",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ All hooks are Python scripts in `ci/hooks/`, invoked via `uv run`:
 
 - **UserPromptSubmit**: `ci/hooks/board_context.py` detects board-related prompts and injects skill guidance (board lookup workflow, external source URLs, relevant commands)
 - **PreToolUse**: `ci/hooks/tool_guard.py` blocks bare Rust commands and any `uv run` invocation of `soldr`/`cargo` (must use a globally-installed `soldr` directly) and bare `python`/`pip` (must use `uv`) across supported shell tools, not just Bash
+- **PreToolUse**: `ci/hooks/worktree_guard.py` (matcher: `Agent`) refuses `Agent` calls with `isolation: "worktree"` when cwd is already inside `.claude/worktrees/...`, preventing the recursive worktree nesting that triggered issue #481
 - **PostToolUse**: `ci/hooks/lint.py` auto-formats + runs clippy on edited .rs files
 - **PostToolUse**: `ci/hooks/readme_guard.py` errors if directory lacks README.md
 - **SessionStart**: `ci/hooks/check-on-start.py` captures git fingerprint

--- a/ci/hooks/README.md
+++ b/ci/hooks/README.md
@@ -6,6 +6,7 @@ Python scripts invoked by Claude Code lifecycle hooks, configured in `.claude/se
 
 - **`board_context.py`** -- UserPromptSubmit: detects board-related prompts (board names, MCU keywords, board error patterns) and injects guidance about the `/board-support` skill, relevant commands, and external board registries
 - **`tool_guard.py`** -- PreToolUse: blocks bare `cargo`/`rustc`/`rustfmt`, legacy `uv run cargo`-style shims, `uv run soldr ...` (since soldr is no longer a venv dep — issue #251), and bare `python`/`pip` commands across shell tool variants such as Bash and PowerShell. Requires a globally-installed `soldr ...` for Rust tooling and `uv run` / `uv pip` for Python tooling.
+- **`worktree_guard.py`** -- PreToolUse on the `Agent` tool: refuses `Agent` invocations with `isolation: "worktree"` when the current working directory is already inside a `.claude/worktrees/...` path. Prevents the recursive nesting (`.claude/worktrees/<a>/.claude/worktrees/<b>/...`) that was the root trigger of issue #481 (Windows MAX_PATH C1081 build failures + cc-rs PATH dumps overwhelming the context window).
 - **`lint.py`** -- PostToolUse: runs per-file rustfmt + clippy on edited `.rs` files
 - **`readme_guard.py`** -- PostToolUse: ensures every directory containing edited files has a `README.md`
 - **`check-on-start.py`** -- SessionStart: captures a git fingerprint so the stop hook can detect changes

--- a/ci/hooks/test_worktree_guard.py
+++ b/ci/hooks/test_worktree_guard.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Unit tests for the Agent-worktree nesting guard hook."""
+
+import unittest
+
+from worktree_guard import is_inside_worktree, should_deny
+
+
+class IsInsideWorktreeTests(unittest.TestCase):
+    def test_repo_root_is_not_inside_worktree(self):
+        self.assertFalse(is_inside_worktree("/c/Users/niteris/dev/fbuild"))
+        self.assertFalse(is_inside_worktree("C:\\Users\\niteris\\dev\\fbuild"))
+
+    def test_path_containing_worktree_segment(self):
+        self.assertTrue(
+            is_inside_worktree("/c/Users/niteris/dev/fbuild/.claude/worktrees/foo")
+        )
+        self.assertTrue(
+            is_inside_worktree("C:\\Users\\niteris\\dev\\fbuild\\.claude\\worktrees\\foo")
+        )
+
+    def test_deeply_nested_worktrees(self):
+        nested = (
+            "C:\\Users\\niteris\\dev\\fbuild\\.claude\\worktrees\\a\\"
+            ".claude\\worktrees\\b\\.claude\\worktrees\\c"
+        )
+        self.assertTrue(is_inside_worktree(nested))
+
+    def test_path_that_only_has_dot_claude_but_not_worktrees(self):
+        self.assertFalse(
+            is_inside_worktree("/c/Users/niteris/dev/fbuild/.claude/skills")
+        )
+
+    def test_trailing_worktrees_dir_without_child_is_not_inside(self):
+        # cwd at `.claude/worktrees/` (the parent dir) is not "inside" a
+        # specific worktree — a real worktree has a name segment after
+        # `worktrees/`. The harness wouldn't put an agent there in practice.
+        self.assertFalse(
+            is_inside_worktree("/c/Users/niteris/dev/fbuild/.claude/worktrees")
+        )
+
+
+class ShouldDenyTests(unittest.TestCase):
+    REPO_ROOT = "C:\\Users\\niteris\\dev\\fbuild"
+    INSIDE_WORKTREE = "C:\\Users\\niteris\\dev\\fbuild\\.claude\\worktrees\\agent-aaa"
+
+    def test_denies_agent_worktree_inside_worktree(self):
+        self.assertTrue(
+            should_deny("Agent", {"isolation": "worktree"}, self.INSIDE_WORKTREE)
+        )
+
+    def test_allows_agent_worktree_at_repo_root(self):
+        self.assertFalse(
+            should_deny("Agent", {"isolation": "worktree"}, self.REPO_ROOT)
+        )
+
+    def test_allows_agent_without_worktree_isolation(self):
+        self.assertFalse(
+            should_deny("Agent", {}, self.INSIDE_WORKTREE),
+            "no isolation specified — sub-agent shares cwd, no nesting risk",
+        )
+        self.assertFalse(
+            should_deny("Agent", {"isolation": "none"}, self.INSIDE_WORKTREE),
+        )
+
+    def test_ignores_non_agent_tools(self):
+        self.assertFalse(
+            should_deny("Bash", {"command": "ls"}, self.INSIDE_WORKTREE)
+        )
+        self.assertFalse(
+            should_deny("Edit", {"isolation": "worktree"}, self.INSIDE_WORKTREE),
+            "isolation field is meaningless for non-Agent tools",
+        )
+
+    def test_tolerates_non_dict_tool_input(self):
+        # The JSON event from the harness should always be a dict, but the
+        # guard is defensive in case a future event shape ships something
+        # else (a list of multi-agent tool uses, for example).
+        for bad in (None, "string", 42, ["not", "a", "dict"]):
+            with self.subTest(bad=bad):
+                self.assertFalse(
+                    should_deny("Agent", bad, self.INSIDE_WORKTREE)
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/hooks/worktree_guard.py
+++ b/ci/hooks/worktree_guard.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""PreToolUse hook: refuse Agent calls that would stack a worktree inside an
+existing `.claude/worktrees/` directory.
+
+The Claude Code Agent tool, when invoked with ``isolation: "worktree"``,
+creates the worktree relative to the agent's current working directory. If
+the calling agent is itself running inside ``.claude/worktrees/<parent>/``,
+the new worktree lands at ``.claude/worktrees/<parent>/.claude/worktrees/
+<child>/`` — and so on, recursively. This nesting was the root trigger of
+issue #481 (Windows MAX_PATH C1081 + cc-rs PATH dumps overflowing the
+1M context window).
+
+This hook detects the nested-spawn case and denies it with a message
+pointing at the fix: spawn the agent from the repo root (not from inside
+another worktree), or omit ``isolation: "worktree"`` so it shares the
+parent worktree.
+
+Exit codes:
+  0 - Always (deny is communicated via JSON ``hookSpecificOutput``).
+"""
+
+import json
+import os
+import sys
+from pathlib import PurePosixPath
+
+
+WORKTREE_SEGMENT = (".claude", "worktrees")
+
+
+def _normalize_parts(path: str) -> tuple[str, ...]:
+    """Split a path into segments, normalising backslashes to forward."""
+    posix = PurePosixPath(path.replace("\\", "/"))
+    return tuple(part for part in posix.parts if part not in ("", "/"))
+
+
+def is_inside_worktree(cwd: str) -> bool:
+    """True if ``cwd`` contains ``.claude/worktrees/<something>`` as a path
+    segment pair — i.e. the agent is already running inside a worktree the
+    harness previously created."""
+    parts = _normalize_parts(cwd)
+    for i in range(len(parts) - 2):
+        if parts[i] == WORKTREE_SEGMENT[0] and parts[i + 1] == WORKTREE_SEGMENT[1]:
+            return True
+    return False
+
+
+def should_deny(tool_name: str, tool_input: object, cwd: str) -> bool:
+    """Deny only the case that produces nesting: Agent + worktree isolation
+    spawned from inside an existing worktree."""
+    if tool_name != "Agent":
+        return False
+    if not isinstance(tool_input, dict):
+        return False
+    if tool_input.get("isolation") != "worktree":
+        return False
+    return is_inside_worktree(cwd)
+
+
+DENY_REASON = (
+    "Refusing to spawn an Agent worktree from inside an existing worktree. "
+    "Doing so creates `.claude/worktrees/<parent>/.claude/worktrees/<child>/` "
+    "nesting, which has triggered Windows MAX_PATH C1081 build-script failures "
+    "and overwhelmed Claude's context window (issue #481). "
+    "Either omit `isolation: \"worktree\"` so the sub-agent shares the current "
+    "worktree, or spawn the agent from the repo root instead of from inside "
+    "a worktree."
+)
+
+
+def deny(reason: str) -> None:
+    json.dump({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }, sys.stdout)
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+    cwd = data.get("cwd") or os.getcwd()
+
+    if should_deny(tool_name, tool_input, cwd):
+        deny(DENY_REASON)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `ci/hooks/worktree_guard.py`, a new `PreToolUse` hook (matcher: `Agent`) that **denies** Agent invocations with `isolation: "worktree"` when the calling agent's cwd is already inside a `.claude/worktrees/...` path.
- Wires the hook into `.claude/settings.json` alongside the existing shell `tool_guard.py`.
- Adds `ci/hooks/test_worktree_guard.py` (10 unit tests) and documents the new hook in `ci/hooks/README.md` + `CLAUDE.md`.

## Why

PR #482 truncated the **symptom** (hook stderr overflowing context). This PR removes the **cause**.

The Claude Code Agent tool, when invoked with `isolation: "worktree"`, creates the new worktree relative to the caller's cwd. A sub-agent already running inside `.claude/worktrees/<parent>/` therefore lands its child worktree at `.claude/worktrees/<parent>/.claude/worktrees/<child>/`, and the next level deepens further. Local `git worktree list` actually shows a 4-deep stack:

```
.claude/worktrees/split-graph/.claude/worktrees/split-analyzer/.claude/worktrees/rebase-472/.claude/worktrees/fix-lpc-stubs
```

That path is past Windows MAX_PATH for many cargo build-script tempfiles. It produced the `fatal error C1081: 'file name too long'` that triggered cc-rs's PATH-dumping retry loop in issue #481, which in turn overwhelmed the 1M context window before truncation could help.

We can't change the harness from inside the harness, but we can short-circuit the bad case at the PreToolUse boundary:

- `tool_name == "Agent"` AND
- `tool_input.isolation == "worktree"` AND
- `os.getcwd()` already contains `.claude/worktrees/<x>/`

→ deny, with a message naming the fix (omit `isolation: "worktree"` so the sub-agent shares the parent worktree, or spawn from the repo root instead of from inside a worktree).

Top-level Agent invocations (from the repo root) are still allowed; non-worktree Agent calls are still allowed; non-Agent tools (`Bash`, `Edit`, …) are never inspected.

## Out of scope (separate follow-up)

This is a **fbuild-local workaround**, not a fix in Claude Code itself. The harness should ideally always anchor new worktrees at the repo root regardless of the calling agent's cwd. Tracked upstream-side in #485 — the hook can be retired once that lands.

## Test plan

- [x] `uv run -m unittest discover -s ci/hooks -p 'test_*.py'` → **35/35** hook tests pass (25 prior + 10 new).
- [x] End-to-end JSON-stdin smoke: `Agent` + `isolation: "worktree"` + nested cwd → emits the `permissionDecision: "deny"` JSON.
- [x] Allow-path smoke: same payload but cwd = repo root → empty stdout, exit 0.
- [x] Allow-path smoke: `Bash` tool with nested cwd → empty stdout, exit 0 (non-Agent tools are never blocked).
- [x] Defensive: malformed `tool_input` (None, str, int, list) → returns False rather than crashing.

Refs #481, follow-up to #482, tracked upstream-side in #485.