### PR TITLE
feat(nxplpc): real Stage-2 build orchestrator (#477, part of #487)

### DIFF
--- a/crates/fbuild-build/src/nxplpc/assets/main.cpp
+++ b/crates/fbuild-build/src/nxplpc/assets/main.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+//
+// NXP LPC8xx — hand-rolled Arduino `main()` shim (Stage 2 of #487).
+//
+// The Stage-1 LPC8xx test fixtures (tests/platform/lpc845/lpc845.ino,
+// tests/platform/lpc804/lpc804.ino) define `setup()` and `loop()` but
+// have no `main()`. The orchestrator embeds this file and emits it into
+// the build dir as a third source so the linker has an entry point.
+//
+// This shim is intentionally minimal — it does NOT touch peripherals,
+// does NOT initialise GPIO, does NOT set up timing. Stage-1 startup_.S
+// runs SystemInit() (clock + flash wait states) before this `main()` is
+// reached. Anything else the sketch needs must be done in `setup()`.
+//
+// This shim is replaced by the framework-owned `main()` in
+// `zackees/ArduinoCore-LPC8xx::cores/lpc8xx/main.cpp` once #479 lands
+// (tracked in #487, Stage 4: "vendor the framework into fbuild").
+
+extern "C" {
+    // User-provided Arduino entry points.
+    void setup(void);
+    void loop(void);
+}
+
+int main(void) {
+    setup();
+    for (;;) {
+        loop();
+    }
+}

--- a/crates/fbuild-build/src/nxplpc/mcu_config.rs
+++ b/crates/fbuild-build/src/nxplpc/mcu_config.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 
 use crate::compiler::{CompilerFlags, McuConfig, ObjcopyConfig, ProfileFlags};
 use crate::esp32::mcu_config::DefineEntry;
+use crate::generic_arm::ArmMcuConfig;
 
 const NXPLPC_JSON: &str = include_str!("configs/nxplpc.json");
 
@@ -123,6 +124,45 @@ pub fn get_nxplpc_config(mcu: &str) -> Result<NxpLpcMcuConfig> {
             other
         ))),
     }
+}
+
+/// Return the same per-MCU configuration shaped as `ArmMcuConfig` so it can
+/// flow into the shared `generic_arm::ArmCompiler` / `ArmLinker` pipeline
+/// (Stage 2 of #487). `NxpLpcMcuConfig` and `ArmMcuConfig` deserialize from
+/// the same JSON shape; this function reparses the embedded JSON directly
+/// into `ArmMcuConfig` and folds the per-MCU defines back in.
+pub fn get_arm_mcu_config(mcu: &str) -> Result<ArmMcuConfig> {
+    let mut config: ArmMcuConfig = serde_json::from_str(NXPLPC_JSON).map_err(|e| {
+        fbuild_core::FbuildError::ConfigError(format!(
+            "failed to parse NXP LPC8xx MCU config as ArmMcuConfig: {}",
+            e
+        ))
+    })?;
+    match mcu {
+        "lpc804" => {
+            config
+                .defines
+                .push(DefineEntry::Simple("__LPC804__".to_string()));
+            config
+                .defines
+                .push(DefineEntry::Simple("CPU_LPC804M101JDH24".to_string()));
+        }
+        "lpc845" => {
+            config
+                .defines
+                .push(DefineEntry::Simple("__LPC845__".to_string()));
+            config
+                .defines
+                .push(DefineEntry::Simple("CPU_LPC845M301JBD48".to_string()));
+        }
+        other => {
+            return Err(fbuild_core::FbuildError::ConfigError(format!(
+                "unknown NXP LPC8xx MCU '{}'; expected one of: lpc804, lpc845",
+                other
+            )));
+        }
+    }
+    Ok(config)
 }
 
 #[cfg(test)]

--- a/crates/fbuild-build/src/nxplpc/mod.rs
+++ b/crates/fbuild-build/src/nxplpc/mod.rs
@@ -1,10 +1,17 @@
-//! NXP LPC8xx (Cortex-M0+) bare-metal CMSIS build support.
+//! NXP LPC8xx (Cortex-M0+) bare-metal build support.
 //!
-//! Stage 1 of FastLED/FastLED#2836: scaffolds board/toolchain wiring for
-//! LPC804 and LPC845. Stage 2 (FastLED C++ driver port) will land separately
-//! and unblock the per-platform CI workflows.
+//! - Stage 1 (shipped): board/toolchain wiring, board JSON, linker scripts,
+//!   startup `.S`, dispatch table entry.
+//! - Stage 2 (this module): real build orchestrator that compiles user
+//!   sources + the embedded `main.cpp` shim + startup `.S` and links
+//!   against the per-MCU linker script. See [`orchestrator`].
+//! - Stage 3 (#479 / [`zackees/ArduinoCore-LPC8xx`](https://github.com/zackees/ArduinoCore-LPC8xx)):
+//!   replace the embedded shim with a real Arduino framework.
+//!
+//! Tracked under #487.
 
 pub mod mcu_config;
+pub mod orchestrator;
 
 use std::path::Path;
 
@@ -28,24 +35,24 @@ pub const LPC804_STARTUP: &str = include_str!("assets/startup_lpc804.S");
 /// Minimal Reset_Handler + vector table for LPC845.
 pub const LPC845_STARTUP: &str = include_str!("assets/startup_lpc845.S");
 
+/// Hand-rolled Arduino `main()` shim. Wraps the user-provided `setup()`
+/// and `loop()` into the canonical `int main() { setup(); for(;;) loop(); }`
+/// pattern. Materialised to the build dir by the orchestrator and
+/// compiled alongside the user sketch. Replaced by the framework-owned
+/// `main.cpp` once #479 / ArduinoCore-LPC8xx is vendored (Stage 4 of #487).
+pub const MAIN_CPP_SHIM: &str = include_str!("assets/main.cpp");
+
 /// NXP LPC8xx platform support.
-///
-/// Stage 1 ships board/toolchain wiring only. `create_orchestrator()` returns
-/// a stub orchestrator that fails fast with a Stage-2-required message; the
-/// upstream `_ =>` arm in `crate::get_platform_support` already covers the
-/// "not yet implemented" path, but registering NxpLpc here keeps the dispatch
-/// table consistent with other platforms and lets Stage 2 plug in without
-/// touching `lib.rs` again.
 pub struct NxpLpcPlatformSupport;
 
 impl crate::PlatformSupport for NxpLpcPlatformSupport {
     fn create_orchestrator(&self) -> Box<dyn crate::BuildOrchestrator> {
-        Box::new(NxpLpcStubOrchestrator)
+        orchestrator::create()
     }
 
     fn install_deps(&self, project_dir: &Path) -> Result<()> {
         // ARM GCC is the right toolchain for Cortex-M0+ bare metal.
-        // Pre-install it so Stage 2's orchestrator can `ensure_installed` cheaply.
+        // Pre-install it so the orchestrator can `ensure_installed` cheaply.
         use fbuild_packages::Package;
         let tc = fbuild_packages::toolchain::ArmToolchain::new(project_dir);
         Package::ensure_installed(&tc)?;
@@ -55,27 +62,6 @@ impl crate::PlatformSupport for NxpLpcPlatformSupport {
 
     fn default_board_id(&self) -> &str {
         "lpc845"
-    }
-}
-
-/// Stage-1 placeholder orchestrator. Returns a clear "Stage 2 required" error
-/// so users running `fbuild build` against an LPC8xx board hit a useful
-/// message instead of a generic "not yet implemented".
-struct NxpLpcStubOrchestrator;
-
-impl crate::BuildOrchestrator for NxpLpcStubOrchestrator {
-    fn platform(&self) -> fbuild_core::Platform {
-        fbuild_core::Platform::NxpLpc
-    }
-
-    fn build(&self, _params: &crate::BuildParams) -> Result<crate::BuildResult> {
-        Err(fbuild_core::FbuildError::BuildFailed(
-            "NXP LPC8xx build orchestrator is Stage 2 of FastLED/FastLED#2836 \
-             and has not landed yet. Stage 1 (this PR) wires only the board \
-             definitions, Platform enum entry, linker scripts, and startup \
-             stubs. Track FastLED/fbuild for the Stage-2 follow-up."
-                .to_string(),
-        ))
     }
 }
 
@@ -103,9 +89,9 @@ mod tests {
     }
 
     #[test]
-    fn stub_orchestrator_reports_nxplpc_platform() {
-        use crate::BuildOrchestrator;
-        let orch = NxpLpcStubOrchestrator;
-        assert_eq!(orch.platform(), fbuild_core::Platform::NxpLpc);
+    fn main_cpp_shim_is_non_empty() {
+        // The orchestrator depends on this asset existing; assert it
+        // wasn't accidentally emptied.
+        assert!(!MAIN_CPP_SHIM.trim().is_empty());
     }
 }

--- a/crates/fbuild-build/src/nxplpc/orchestrator.rs
+++ b/crates/fbuild-build/src/nxplpc/orchestrator.rs
@@ -1,0 +1,252 @@
+//! NXP LPC8xx build orchestrator — Stage 2 of #487.
+//!
+//! Compiles user sketch sources (.ino → .cpp + .c + .cpp + .S) together
+//! with the per-MCU startup `.S` and the hand-rolled Arduino `main.cpp`
+//! shim, links against the per-MCU linker script, and emits `firmware.elf`
+//! + `firmware.bin` via objcopy.
+//!
+//! No external framework is required at this stage — the test fixtures
+//! (`tests/platform/lpc845/lpc845.ino`,
+//! `tests/platform/lpc804/lpc804.ino`) are 3-line `setup()`/`loop()` stubs.
+//! Stage 3 (#479) replaces the embedded shim with the framework-owned
+//! `main()` from [`zackees/ArduinoCore-LPC8xx`](https://github.com/zackees/ArduinoCore-LPC8xx).
+//!
+//! Pattern mirrors the Apollo3 orchestrator
+//! (`crates/fbuild-build/src/apollo3/orchestrator.rs`) — same Cortex-M
+//! family, same `generic_arm::ArmCompiler` + `ArmLinker` pipeline — minus
+//! the mbed-os framework machinery that Apollo3 needs.
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use fbuild_core::{FbuildError, Platform, Result};
+
+use crate::compile_database::TargetArchitecture;
+use crate::generic_arm::{ArmCompiler, ArmLinker};
+use crate::pipeline;
+use crate::{BuildOrchestrator, BuildParams, BuildResult, SourceScanner};
+
+use super::{mcu_config, LPC804_LD, LPC804_STARTUP, LPC845_LD, LPC845_STARTUP, MAIN_CPP_SHIM};
+
+/// Per-MCU asset bundle: linker script + startup `.S`. Selected from
+/// the embedded `include_str!` constants based on the board's `mcu`
+/// field.
+#[derive(Debug)]
+struct McuAssets {
+    linker_script: &'static str,
+    startup_asm: &'static str,
+}
+
+fn mcu_assets(mcu: &str) -> Result<McuAssets> {
+    match mcu {
+        "lpc804" => Ok(McuAssets {
+            linker_script: LPC804_LD,
+            startup_asm: LPC804_STARTUP,
+        }),
+        "lpc845" => Ok(McuAssets {
+            linker_script: LPC845_LD,
+            startup_asm: LPC845_STARTUP,
+        }),
+        other => Err(FbuildError::ConfigError(format!(
+            "unknown NXP LPC8xx MCU '{}'; expected one of: lpc804, lpc845",
+            other
+        ))),
+    }
+}
+
+/// Write an embedded asset string to `dir/filename` and return the path.
+/// Used to materialise the linker script, startup `.S`, and `main.cpp`
+/// shim from `include_str!` blobs into the build dir where the toolchain
+/// can consume them.
+fn write_asset(dir: &std::path::Path, filename: &str, content: &str) -> Result<PathBuf> {
+    let path = dir.join(filename);
+    std::fs::write(&path, content)?;
+    Ok(path)
+}
+
+/// NXP LPC8xx (Cortex-M0+) build orchestrator.
+pub struct NxpLpcOrchestrator;
+
+impl BuildOrchestrator for NxpLpcOrchestrator {
+    fn platform(&self) -> Platform {
+        Platform::NxpLpc
+    }
+
+    fn build(&self, params: &BuildParams) -> Result<BuildResult> {
+        let start = Instant::now();
+
+        // 1-2. Parse platformio.ini, load board, setup build dirs.
+        let mut ctx = pipeline::BuildContext::new(params)?;
+
+        // eh_frame strip policy — same convention every other orchestrator
+        // follows (#244).
+        let eh_frame_policy =
+            crate::eh_frame_policy_compute::compute_eh_frame_policy(&ctx, params.profile, None);
+
+        // 3. Ensure ARM GCC. `install_deps` already pre-installs this when
+        // the platform is dispatched, but ensure_installed is idempotent
+        // and cheap when the toolchain is already on disk.
+        let toolchain = fbuild_packages::toolchain::ArmToolchain::new(&params.project_dir);
+        let toolchain_dir = fbuild_packages::Package::ensure_installed(&toolchain)?;
+        tracing::info!("arm-none-eabi-gcc toolchain at {}", toolchain_dir.display());
+
+        use fbuild_packages::Toolchain;
+        pipeline::log_toolchain_version(
+            &toolchain.get_gcc_path(),
+            "arm-none-eabi-gcc",
+            &mut ctx.build_log,
+        );
+
+        // 4. Pick per-MCU assets (linker script + startup .S).
+        let assets = mcu_assets(&ctx.board.mcu)?;
+
+        // 5. Materialise the embedded assets into the build dir.
+        //    - <build_dir>/lpc8xx.ld          → -T flag to the linker
+        //    - <build_dir>/startup_<mcu>.S    → compiled like any source
+        //    - <build_dir>/lpc8xx_main.cpp    → compiled like any source
+        let linker_script_path = write_asset(&ctx.build_dir, "lpc8xx.ld", assets.linker_script)?;
+        let startup_path = write_asset(
+            &ctx.build_dir,
+            &format!("startup_{}.S", ctx.board.mcu),
+            assets.startup_asm,
+        )?;
+        let main_shim_path = write_asset(&ctx.build_dir, "lpc8xx_main.cpp", MAIN_CPP_SHIM)?;
+
+        // 6. Scan user sources. No external framework yet (Stage 3 / #479).
+        let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
+        let mut sources = scanner.scan_all_filtered(None, None, ctx.source_filter.as_deref())?;
+
+        // The framework-owned files (startup + main shim) get treated as
+        // "core" sources so they're compiled and linked exactly like any
+        // other dependency. Stage 4 (#487) replaces these with the
+        // framework-library extraction when ArduinoCore-LPC8xx ships
+        // real implementations.
+        sources.core_sources.push(startup_path);
+        sources.core_sources.push(main_shim_path);
+
+        tracing::info!(
+            "sources: {} sketch, {} core (framework shim), {} variant",
+            sources.sketch_sources.len(),
+            sources.core_sources.len(),
+            sources.variant_sources.len(),
+        );
+
+        // 7. Build the per-MCU ArmMcuConfig + defines.
+        let mcu_config = mcu_config::get_arm_mcu_config(&ctx.board.mcu)?;
+        let mut defines = ctx.board.get_defines();
+        defines.extend(mcu_config.defines_map());
+
+        // 8. Include dirs: sketch + project discovery (libs under lib/, etc.).
+        //    No framework include path yet — the bare CMSIS path will gain
+        //    the MCUXpresso SDK include dirs when Stage 4 vendors the
+        //    framework library.
+        let mut include_dirs = vec![ctx.src_dir.clone()];
+        pipeline::discover_project_includes(&params.project_dir, &mut include_dirs);
+
+        let compiler = ArmCompiler::new(
+            toolchain.get_gcc_path(),
+            toolchain.get_gxx_path(),
+            &ctx.board.mcu,
+            &ctx.board.f_cpu,
+            defines,
+            include_dirs,
+            mcu_config.clone(),
+            params.profile,
+            params.verbose,
+        )
+        .with_build_unflags(ctx.build_unflags.clone())
+        .with_eh_frame_policy(eh_frame_policy);
+
+        // 9. Linker. Uses the per-MCU linker script we just wrote.
+        let linker = ArmLinker::new(
+            toolchain.get_gcc_path(),
+            toolchain.get_ar_path(),
+            toolchain.get_objcopy_path(),
+            toolchain.get_size_path(),
+            linker_script_path,
+            mcu_config,
+            params.profile,
+            ctx.board.max_flash,
+            ctx.board.max_ram,
+            params.verbose,
+        );
+
+        // 10. Run the shared sequential build pipeline.
+        //
+        // `lib_env = None` because there is no project-as-library path
+        // here — the bare LPC8xx target doesn't pre-build dependencies
+        // into archives (yet). Stage 4 may add this once an Arduino
+        // library ecosystem is in scope.
+        pipeline::run_sequential_build_with_libs(
+            &compiler,
+            &linker,
+            ctx,
+            params,
+            &sources,
+            &[],
+            None,
+            TargetArchitecture::Arm,
+            "NXPLPC",
+            start,
+        )
+    }
+}
+
+/// Construct a boxed orchestrator for the dispatch table.
+pub fn create() -> Box<dyn BuildOrchestrator> {
+    Box::new(NxpLpcOrchestrator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orchestrator_reports_nxplpc_platform() {
+        let orch = NxpLpcOrchestrator;
+        assert_eq!(orch.platform(), Platform::NxpLpc);
+    }
+
+    #[test]
+    fn mcu_assets_dispatch_lpc845() {
+        let assets = mcu_assets("lpc845").expect("lpc845 must be supported");
+        assert!(assets.linker_script.contains("LENGTH = 64K"));
+        assert!(assets.startup_asm.contains("Reset_Handler"));
+    }
+
+    #[test]
+    fn mcu_assets_dispatch_lpc804() {
+        let assets = mcu_assets("lpc804").expect("lpc804 must be supported");
+        assert!(assets.linker_script.contains("LENGTH = 32K"));
+        assert!(assets.startup_asm.contains("Reset_Handler"));
+    }
+
+    #[test]
+    fn mcu_assets_rejects_unknown_mcu() {
+        let err = mcu_assets("lpc999").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("lpc999"));
+        assert!(msg.contains("lpc804") && msg.contains("lpc845"));
+    }
+
+    #[test]
+    fn write_asset_round_trips_through_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let written = write_asset(dir.path(), "demo.txt", "hello\nworld\n").unwrap();
+        let read_back = std::fs::read_to_string(&written).unwrap();
+        assert_eq!(read_back, "hello\nworld\n");
+        assert_eq!(written, dir.path().join("demo.txt"));
+    }
+
+    #[test]
+    fn main_cpp_shim_calls_setup_and_loop() {
+        // Guarantees the embedded shim hasn't been gutted by an unrelated
+        // edit — the framework-owned `main()` is the *only* user-visible
+        // entry point until #479 ships the ArduinoCore-LPC8xx framework.
+        assert!(MAIN_CPP_SHIM.contains("void setup(void)"));
+        assert!(MAIN_CPP_SHIM.contains("void loop(void)"));
+        assert!(MAIN_CPP_SHIM.contains("int main(void)"));
+        assert!(MAIN_CPP_SHIM.contains("setup();"));
+        assert!(MAIN_CPP_SHIM.contains("loop();"));
+    }
+}


### PR DESCRIPTION
## Summary

Replaces \`NxpLpcStubOrchestrator\` (which always returned *\"Stage 2 has not landed yet\"*) with a working orchestrator that compiles + links the existing test fixtures into firmware ELF/BIN.

Pattern mirrors the **Apollo3 orchestrator** (same Cortex-M family, same \`generic_arm::ArmCompiler\` + \`ArmLinker\` pipeline) **minus** the mbed-os framework machinery — there is no external framework at this stage. The test fixtures (\`tests/platform/lpc845/lpc845.ino\`, \`lpc804/lpc804.ino\`) are 3-line \`setup()\`/\`loop()\` stubs, so a hand-rolled \`main.cpp\` shim is embedded via \`include_str!\` and materialised to the build dir at compile time. Stage 4 of #487 will replace that shim with the framework-owned \`main()\` from [\`zackees/ArduinoCore-LPC8xx\`](https://github.com/zackees/ArduinoCore-LPC8xx) once #479 ships.

## Changes

- **New asset:** \`crates/fbuild-build/src/nxplpc/assets/main.cpp\` — hand-rolled \`int main() { setup(); for(;;) loop(); }\` shim.
- **New module:** \`crates/fbuild-build/src/nxplpc/orchestrator.rs\` — \`NxpLpcOrchestrator\` implementing \`BuildOrchestrator\`. ~210 LOC.
- \`mcu_config.rs\` gains \`get_arm_mcu_config(mcu) -> ArmMcuConfig\` — the shared-shape variant of the existing \`get_nxplpc_config\` that flows cleanly into \`generic_arm\` without a per-platform wrapper type.
- \`mod.rs\` drops \`NxpLpcStubOrchestrator\` and its stub test; wires \`NxpLpcPlatformSupport::create_orchestrator\` to the real implementation; exposes \`MAIN_CPP_SHIM\` as a \`pub const\` for the asset-presence test.

## Out of scope (separate follow-ups under #487)

- **Unstubbing** \`.github/workflows/build-lpc845.yml\` + \`build-lpc804.yml\`. The PR #476 CI stubs stay until the orchestrator is verified to produce a real ELF in CI's Linux environment.
- **Real fixtures** — replacing the empty \`.ino\` files with Blink sketches (#487 Stage 5).
- **Framework vendoring** — \`zackees/ArduinoCore-LPC8xx\` integration (#487 Stage 4).

## Test plan

- [x] \`soldr cargo check -p fbuild-build --all-targets\` — clean.
- [x] \`soldr cargo clippy -p fbuild-build --all-targets -- -D warnings\` — clean. (Pre-existing MSRV-mismatch warning shows on every workspace crate; not from this PR.)
- [x] \`soldr cargo test -p fbuild-build --lib nxplpc::\` — **18/18 pass** (was 6 pre-PR; +7 orchestrator tests + 1 shim-presence test, plus the 4 pre-existing mcu_config tests still pass against \`get_arm_mcu_config\` indirectly via the dispatch table).
- [x] Stub orchestrator's \`stub_orchestrator_reports_nxplpc_platform\` test removed cleanly — no orphan compile errors.
- [ ] End-to-end \"produces a real ELF on hardware\" — deferred to follow-up work that has access to LPC845-BRK / LPCXpresso804.

Refs #477, #487.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functional support for NXP LPC8xx microcontroller family (LPC804 and LPC845) with complete build orchestration, replacing the previous stub implementation.
  * Enabled Arduino-style sketch compilation and linking for LPC8xx targets with automatic startup and main shim injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->