### PR TITLE
chore(release): 2.2.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "async-trait",
  "blake3",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "blake3",
  "clap",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "libc",
  "running-process",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "criterion",
  "rayon",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "bincode",
  "blake3",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "axum",
  "bzip2",
@@ -1081,14 +1081,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "async-trait",
  "base64",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.21"
+version = "2.2.22"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.21"
+version = "2.2.22"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.21"
+version = "2.2.22"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release picking up #489 — `zccache 1.11.15 -> 1.11.20`.

The headline upstream fix is **zackees/zccache#681** (depgraph contexts pointing at disk-evicted artifacts no longer surface as wasted `Hit`-then-`artifact_not_found` cycles); the soldr-cli dogfood reproducer's real hit rate jumped from **15.7 % back to ~99 %**, which directly affects fbuild's 600+ TU warm-build workloads.

Also bundled:

- #678 — CLI lost-connection message cleanup
- #679 + #684 — docs around cached-stderr cross-worktree leak (zackees/zccache#672) and the new zccache vs sccache feature matrix
- #686 — `ZCCACHE_DIAG_CWD` diagnostic (useful for fbuild's Windows CWD audit work)
- #670 — back-pressure groundwork

No code changes — workspace version (`Cargo.toml` + `Cargo.lock` × 14 member crates) and `pyproject.toml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)