### PR TITLE
chore(shrink): scaffold module + owo-colors dep (#494, part of #493)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ dependencies = [
  "fbuild-packages",
  "fbuild-paths",
  "futures",
+ "owo-colors",
  "reqwest",
  "serde",
  "serde_json",
@@ -2171,6 +2172,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ bincode = "1"
 zccache-artifact = "1.9"
 rayon = "1"
 tracing-test = "0.2"
+# Terminal coloring for `fbuild build --shrink` reporting (FastLED/fbuild#493).
+# Auto-disables on non-tty and respects `NO_COLOR`, so the same code is safe
+# to call from anywhere — no `--color` flag plumbing needed.
+owo-colors = "4"
 
 # Process containment: all subprocess spawns the daemon performs (compilers,
 # esptool, qemu, simavr, node, npm, …) and any grandchildren they fork must

--- a/crates/fbuild-build/src/lib.rs
+++ b/crates/fbuild-build/src/lib.rs
@@ -31,6 +31,7 @@ pub mod renesas;
 pub mod rp2040;
 pub mod sam;
 pub mod script_runtime;
+pub mod shrink;
 pub mod silabs;
 pub mod source_scanner;
 pub mod stm32;

--- a/crates/fbuild-build/src/shrink/README.md
+++ b/crates/fbuild-build/src/shrink/README.md
@@ -1,0 +1,24 @@
+# shrink
+
+Flash-size reduction subsystem behind `fbuild build --shrink[=MODE]` and `--no-shrink`. Tracked in [FastLED/fbuild#493](https://github.com/FastLED/fbuild/issues/493).
+
+## Status
+
+Phase 0a scaffold: this directory exists but exports nothing. Subsequent phases land the real plumbing:
+
+| Phase | Adds |
+|---|---|
+| Phase 1 | `ShrinkMode` enum, `ShrinkPlan`, fail-closed libc probe, per-platform `AutoShrinkEntry` registry (all entries empty), green reporting one-liner, build-info JSON record |
+| Phase 2 | Vendored picolibc tinystdio sources (`printf_thin/`), `shadow_archive.rs` shim TUs, `libprintf_thin.a` build pipeline |
+| Phase 3 | Per-newlib-version symbol manifest + CI drift-detection test |
+| Phase 4 | `spec_emitter.rs` (`printf-thin.specs`), ESP32 link-orchestrator wiring, build-fingerprint augmentation, compile-many stage-1 amortization. First measurable shrink (ESP32-S3 default build drops ≥ 18 KB flash). |
+| Phase 5 | `wrap_fallback.rs` — `-Wl,--wrap=` path for `--shrink=printf` single-knob debug mode |
+| Phase 6 | Per-platform rollout: STM32, NRF52, RP2040/RP2350, ESP8266, ESP32-C3, AVR (one PR per platform) |
+| Phase 7 | Aggressive mode appliers: `-Oz` (GCC ≥ 12), ESP32 sdkconfig stack knobs, `esp_err_msg_table` strip, coredump strip, personality drop |
+| Phase 8 | `BREAKING_CHANGES.md`, `docs/SHRINK.md`, release notes |
+
+## Design references
+
+- [#493](https://github.com/FastLED/fbuild/issues/493) — final design and implementation phases
+- [#492](https://github.com/FastLED/fbuild/issues/492) — design exploration (superseded by #493)
+- [#491](https://github.com/FastLED/fbuild/issues/491) — `fbuild bloat`: emit and preserve `firmware.map` automatically (hard prerequisite for accurate shrink reporting)

--- a/crates/fbuild-build/src/shrink/mod.rs
+++ b/crates/fbuild-build/src/shrink/mod.rs
@@ -1,0 +1,10 @@
+//! Flash-size reduction for embedded firmware (FastLED/fbuild#493).
+//!
+//! This module is a scaffold for the `fbuild build --shrink[=MODE]` flag and
+//! its per-platform applier registry. Real CLI plumbing, the libc probe, the
+//! auto-resolver, the per-platform shrinker registry, and the spec-file /
+//! shadow-archive / wrap-fallback link strategies all land in later phases
+//! (#493 phases 1+).
+//!
+//! Until then this module exposes nothing and is wired into the crate only so
+//! that subsequent phases can land without touching `lib.rs` again.

--- a/crates/fbuild-cli/Cargo.toml
+++ b/crates/fbuild-cli/Cargo.toml
@@ -31,3 +31,4 @@ blake3 = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
 walkdir = { workspace = true }
+owo-colors = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.21"
+version = "2.2.22"
 source = { editable = "." }
 dependencies = [
     { name = "zccache" },


### PR DESCRIPTION
## Summary

Phase 0a of the `--shrink` design (#493). Zero behavior change; sets up the infrastructure so subsequent phases can land without touching `lib.rs` again.

Closes #494.

## Changes

- Add `owo-colors = "4"` workspace dep (terminal coloring for the forthcoming `--shrink` reporting one-liner; auto-disables on non-tty + respects `NO_COLOR`).
- Wire `owo-colors` into `fbuild-cli`.
- Create `crates/fbuild-build/src/shrink/` with stub `mod.rs` + `README.md` documenting the phase plan.

Drive-by: bump `uv.lock` fbuild entry from `2.2.21` -> `2.2.22` to match the version cut in #490.

## Excluded (separate sub-tasks)

- #491 — `firmware.map` auto-emit. Substantive linker-flag work across all platform orchestrators; tracked in its own issue.
- The real CLI surface, libc probe, auto-resolver, shadow archive, and spec-file emission — Phases 1–4 in #493.

## Test plan

- [x] `soldr cargo check --workspace --all-targets` clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` exits 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundation for `--shrink` flag supporting flash-size reduction capabilities
  * Enabled colored terminal output for build reporting (automatically disables on non-TTY environments and respects NO_COLOR variable)

* **Documentation**
  * Added comprehensive roadmap for the shrink subsystem detailing planned implementation phases and design approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->