### PR TITLE
feat(shrink): add ShrinkMode + --shrink / --no-shrink CLI flags (#496, part of #493)

### DIFF
--- a/crates/fbuild-build/src/shrink/mod.rs
+++ b/crates/fbuild-build/src/shrink/mod.rs
@@ -1,10 +1,102 @@
 //! Flash-size reduction for embedded firmware (FastLED/fbuild#493).
 //!
-//! This module is a scaffold for the `fbuild build --shrink[=MODE]` flag and
-//! its per-platform applier registry. Real CLI plumbing, the libc probe, the
-//! auto-resolver, the per-platform shrinker registry, and the spec-file /
-//! shadow-archive / wrap-fallback link strategies all land in later phases
-//! (#493 phases 1+).
+//! This module hosts the `--shrink[=MODE]` flag, the per-platform applier
+//! registry, the libc probe, the auto-resolver, and the spec-file /
+//! shadow-archive / wrap-fallback link strategies.
 //!
-//! Until then this module exposes nothing and is wired into the crate only so
-//! that subsequent phases can land without touching `lib.rs` again.
+//! Phase 1a (FastLED/fbuild#496) lands only the [`ShrinkMode`] enum and the
+//! [`resolve_explicit`] helper that combines the global `--shrink` flag, the
+//! per-subcommand `--shrink` flag, and `--no-shrink` into a single value. Real
+//! per-platform resolution (newlib vs picolibc detection, framework
+//! interrogation) lands in subsequent phases.
+//!
+//! `ShrinkMode` is deliberately clap-free so `fbuild-build` does not pick up a
+//! clap dependency. The CLI layer in `fbuild-cli` defines a tiny mirror enum
+//! with `#[derive(clap::ValueEnum)]` and converts via `From`.
+
+/// User-facing shrink level for `fbuild build --shrink[=MODE]`.
+///
+/// See FastLED/fbuild#493 for the full per-mode contract. Phase 1a treats
+/// every variant as a no-op at the link level — only [`Off`](Self::Off) is
+/// observably distinct from "no flag", because the auto-resolver returns
+/// `Off` for every platform in this phase.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum ShrinkMode {
+    /// Decide per framework + IDF version + libc probe. Default when the user
+    /// passes `--shrink` with no value or omits the flag entirely.
+    #[default]
+    Auto,
+    /// Disable all shrinking; use stock libc, full symbol set. Same as
+    /// `--no-shrink`.
+    Off,
+    /// No-behavior-change wins only: printf-thin wrap, scanf-thin wrap,
+    /// stdio FILE strip.
+    Safe,
+    /// `Safe` plus behavior-altering wins: `esp_err_msg_table` strip, coredump
+    /// disable, `-Oz`. Requires sdkconfig rebuild on ESP32.
+    Aggressive,
+    /// Single-knob debugging: only the printf-family wrap via the
+    /// `-Wl,--wrap=` fallback path. Useful for A/B-comparing the printf swap
+    /// against `Safe` (which uses the spec-file strategy).
+    Printf,
+}
+
+/// Combine the CLI inputs into a single resolved [`ShrinkMode`].
+///
+/// Precedence (highest wins):
+/// 1. `--no-shrink` always wins and resolves to [`ShrinkMode::Off`].
+/// 2. Subcommand-level `--shrink=<MODE>` overrides global `--shrink`.
+/// 3. Global `--shrink=<MODE>` from the top-level `Cli`.
+/// 4. Nothing → [`ShrinkMode::Auto`].
+///
+/// Per-platform resolution of `Auto` → `Safe` / `Off` lands in subsequent
+/// phases; this helper only deals with explicit user intent.
+pub fn resolve_explicit(
+    global: Option<ShrinkMode>,
+    subcommand: Option<ShrinkMode>,
+    no_shrink: bool,
+) -> ShrinkMode {
+    if no_shrink {
+        return ShrinkMode::Off;
+    }
+    subcommand.or(global).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_flag_resolves_to_auto() {
+        assert_eq!(resolve_explicit(None, None, false), ShrinkMode::Auto);
+    }
+
+    #[test]
+    fn no_shrink_always_wins() {
+        assert_eq!(
+            resolve_explicit(Some(ShrinkMode::Aggressive), Some(ShrinkMode::Safe), true),
+            ShrinkMode::Off,
+        );
+    }
+
+    #[test]
+    fn subcommand_overrides_global() {
+        assert_eq!(
+            resolve_explicit(Some(ShrinkMode::Safe), Some(ShrinkMode::Aggressive), false),
+            ShrinkMode::Aggressive,
+        );
+    }
+
+    #[test]
+    fn global_used_when_subcommand_absent() {
+        assert_eq!(
+            resolve_explicit(Some(ShrinkMode::Aggressive), None, false),
+            ShrinkMode::Aggressive,
+        );
+    }
+
+    #[test]
+    fn default_is_auto() {
+        assert_eq!(ShrinkMode::default(), ShrinkMode::Auto);
+    }
+}

--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -4,9 +4,37 @@
 //! `KNOWN_SUBCOMMANDS` / `rewrite_args` / `resolve_project_dir` without
 //! pulling in the handler bodies.
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+use fbuild_build::shrink::ShrinkMode;
 
 use super::monitor_parse::parse_jobs;
+
+/// CLI mirror of [`ShrinkMode`] (FastLED/fbuild#493 / #496).
+///
+/// Carries the `#[derive(ValueEnum)]` so `clap` can parse `--shrink=<mode>`
+/// without pulling clap into `fbuild-build`. The two enums are kept in
+/// 1:1 correspondence via the `From` impl below.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+#[clap(rename_all = "kebab-case")]
+pub enum CliShrinkMode {
+    Auto,
+    Off,
+    Safe,
+    Aggressive,
+    Printf,
+}
+
+impl From<CliShrinkMode> for ShrinkMode {
+    fn from(value: CliShrinkMode) -> Self {
+        match value {
+            CliShrinkMode::Auto => ShrinkMode::Auto,
+            CliShrinkMode::Off => ShrinkMode::Off,
+            CliShrinkMode::Safe => ShrinkMode::Safe,
+            CliShrinkMode::Aggressive => ShrinkMode::Aggressive,
+            CliShrinkMode::Printf => ShrinkMode::Printf,
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -60,6 +88,16 @@ pub struct Cli {
     /// Expected output pattern for monitor
     #[arg(long)]
     pub expect: Option<String>,
+
+    /// Flash-size reduction mode (FastLED/fbuild#493). MODE: auto (default
+    /// when omitted), off, safe, aggressive, printf. Subcommand-level
+    /// `--shrink` overrides this; `--no-shrink` always wins.
+    #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "auto", require_equals = true)]
+    pub shrink: Option<CliShrinkMode>,
+
+    /// Disable all shrink optimizations. Equivalent to `--shrink=off`.
+    #[arg(long = "no-shrink", conflicts_with = "shrink")]
+    pub no_shrink: bool,
 }
 
 #[derive(Subcommand)]
@@ -192,6 +230,13 @@ pub enum Commands {
         /// Export build artifacts to a tooling-friendly directory
         #[arg(long)]
         output_dir: Option<String>,
+        /// Flash-size reduction mode. MODE: auto, off, safe, aggressive,
+        /// printf. Overrides the global `--shrink`. See FastLED/fbuild#493.
+        #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "auto", require_equals = true)]
+        shrink: Option<CliShrinkMode>,
+        /// Disable all shrink optimizations. Equivalent to `--shrink=off`.
+        #[arg(long = "no-shrink", conflicts_with = "shrink")]
+        no_shrink: bool,
     },
     /// Deploy firmware to device
     Deploy {
@@ -245,6 +290,13 @@ pub enum Commands {
         /// Export build artifacts to a tooling-friendly directory
         #[arg(long)]
         output_dir: Option<String>,
+        /// Flash-size reduction mode. MODE: auto, off, safe, aggressive,
+        /// printf. Overrides the global `--shrink`. See FastLED/fbuild#493.
+        #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "auto", require_equals = true)]
+        shrink: Option<CliShrinkMode>,
+        /// Disable all shrink optimizations. Equivalent to `--shrink=off`.
+        #[arg(long = "no-shrink", conflicts_with = "shrink")]
+        no_shrink: bool,
     },
     /// Monitor serial output
     Monitor {
@@ -361,6 +413,13 @@ pub enum Commands {
         /// Emulator backend: "qemu", "avr8js", or "simavr" (auto-detected if omitted)
         #[arg(long, value_parser = ["avr8js", "qemu", "simavr"])]
         emulator: Option<String>,
+        /// Flash-size reduction mode. MODE: auto, off, safe, aggressive,
+        /// printf. Overrides the global `--shrink`. See FastLED/fbuild#493.
+        #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "auto", require_equals = true)]
+        shrink: Option<CliShrinkMode>,
+        /// Disable all shrink optimizations. Equivalent to `--shrink=off`.
+        #[arg(long = "no-shrink", conflicts_with = "shrink")]
+        no_shrink: bool,
     },
     /// Run clang-query on project sources
     ClangQuery {
@@ -481,6 +540,13 @@ pub enum Commands {
         /// directory is the project. Matches `pio ci` positional args.
         #[arg(required = true)]
         sketches: Vec<String>,
+        /// Flash-size reduction mode. MODE: auto, off, safe, aggressive,
+        /// printf. Overrides the global `--shrink`. See FastLED/fbuild#493.
+        #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "auto", require_equals = true)]
+        shrink: Option<CliShrinkMode>,
+        /// Disable all shrink optimizations. Equivalent to `--shrink=off`.
+        #[arg(long = "no-shrink", conflicts_with = "shrink")]
+        no_shrink: bool,
     },
 }
 

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -153,6 +153,8 @@ pub async fn async_main() {
             symbol_analysis,
             no_timestamp,
             output_dir,
+            shrink: _,
+            no_shrink: _,
         }) => {
             let project_dir = resolve_project_dir(project_dir, &top_level_project_dir);
             if platformio {
@@ -196,6 +198,8 @@ pub async fn async_main() {
             emulator,
             target,
             output_dir,
+            shrink: _,
+            no_shrink: _,
         }) => {
             let project_dir = resolve_project_dir(project_dir, &top_level_project_dir);
             if platformio {
@@ -336,6 +340,8 @@ pub async fn async_main() {
             project_dir,
             environment,
             verbose,
+            shrink: _,
+            no_shrink: _,
             timeout,
             halt_on_error,
             halt_on_success,
@@ -421,6 +427,8 @@ pub async fn async_main() {
             board,
             libs,
             project_conf,
+            shrink: _,
+            no_shrink: _,
             keep_build_dir: _keep_build_dir,
             build_dir,
             framework_jobs,

--- a/crates/fbuild-cli/src/cli/tests.rs
+++ b/crates/fbuild-cli/src/cli/tests.rs
@@ -157,3 +157,85 @@ fn compile_many_diag_stage2_flag_is_accepted() {
         _ => panic!("expected CompileMany subcommand"),
     }
 }
+
+// `--shrink` / `--no-shrink` parsing (FastLED/fbuild#496, part of #493).
+// The flag is plumbed onto the global Cli and every build-adjacent subcommand
+// but is otherwise unused in Phase 1a — these tests just exercise clap's
+// surface so a future refactor doesn't silently break parsing.
+
+#[test]
+fn build_accepts_shrink_safe() {
+    let argv = ["fbuild", "build", "--shrink=safe", "tests/platform/uno"];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Build { shrink, .. }) => {
+            assert_eq!(
+                shrink,
+                Some(super::args::CliShrinkMode::Safe),
+                "build --shrink=safe should parse to Safe",
+            );
+        }
+        _ => panic!("expected Build subcommand"),
+    }
+}
+
+#[test]
+fn build_bare_shrink_defaults_to_auto() {
+    let argv = ["fbuild", "build", "--shrink", "tests/platform/uno"];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Build { shrink, .. }) => {
+            assert_eq!(shrink, Some(super::args::CliShrinkMode::Auto));
+        }
+        _ => panic!("expected Build subcommand"),
+    }
+}
+
+#[test]
+fn build_no_shrink_flag_is_accepted() {
+    let argv = ["fbuild", "build", "--no-shrink", "tests/platform/uno"];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Build {
+            shrink, no_shrink, ..
+        }) => {
+            assert_eq!(shrink, None);
+            assert!(no_shrink);
+        }
+        _ => panic!("expected Build subcommand"),
+    }
+}
+
+#[test]
+fn shrink_and_no_shrink_together_is_rejected() {
+    // clap's `conflicts_with` should turn this into a parse error.
+    let argv = [
+        "fbuild",
+        "build",
+        "--shrink=safe",
+        "--no-shrink",
+        "tests/platform/uno",
+    ];
+    assert!(
+        Cli::try_parse_from(argv).is_err(),
+        "--shrink and --no-shrink must conflict",
+    );
+}
+
+#[test]
+fn build_accepts_all_shrink_modes() {
+    for mode in ["auto", "off", "safe", "aggressive", "printf"] {
+        let arg = format!("--shrink={mode}");
+        let argv = ["fbuild", "build", &arg, "tests/platform/uno"];
+        let cli = Cli::try_parse_from(argv)
+            .unwrap_or_else(|e| panic!("--shrink={mode} should parse but got: {e}"));
+        assert!(matches!(cli.command, Some(Commands::Build { .. })));
+    }
+}
+
+#[test]
+fn global_shrink_flag_is_accepted() {
+    let argv = ["fbuild", "--shrink=safe", "build", "tests/platform/uno"];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    assert_eq!(cli.shrink, Some(super::args::CliShrinkMode::Safe));
+}


### PR DESCRIPTION
## Summary

Phase 1a of the `--shrink` design (#493). Adds the user-facing CLI surface without wiring any link-flag emission. Every invocation is a no-op at the link level; subsequent phases land the libc probe, per-platform auto-resolver, reporting, shadow archive, and spec-file emission.

Closes #496.

## Public API

- `fbuild_build::shrink::ShrinkMode { Auto, Off, Safe, Aggressive, Printf }` with `Default = Auto`. Deliberately clap-free so `fbuild-build` doesn't pick up a clap dep; the CLI layer in `fbuild-cli` defines a mirror `CliShrinkMode` with `#[derive(ValueEnum)]` and `From<CliShrinkMode> for ShrinkMode`.
- `fbuild_build::shrink::resolve_explicit(global, subcommand, no_shrink)` combines the global `--shrink` flag, the per-subcommand `--shrink` flag, and `--no-shrink` into a single `ShrinkMode`. `--no-shrink` always wins; subcommand overrides global; absence resolves to `Auto`.

## CLI surface

- `--shrink[=MODE]` and `--no-shrink` on the global `Cli` and on `Build`, `Deploy`, `TestEmu`, `Ci` subcommands.
- `require_equals = true` so `--shrink` (bare) falls back to `default_missing_value = "auto"` instead of greedily consuming the next positional arg as a mode.
- `--shrink` and `--no-shrink` conflict (clap error at parse time).
- Dispatch sites destructure the new fields as `shrink: _, no_shrink: _` pending real plumbing in subsequent phases.

## Tests added

- 5 unit tests for `resolve_explicit` in `fbuild-build::shrink`.
- 6 clap parsing tests in `fbuild-cli::cli::tests`:
  - `build_accepts_shrink_safe`
  - `build_bare_shrink_defaults_to_auto`
  - `build_no_shrink_flag_is_accepted`
  - `shrink_and_no_shrink_together_is_rejected`
  - `build_accepts_all_shrink_modes` (auto/off/safe/aggressive/printf)
  - `global_shrink_flag_is_accepted`

## Test plan

- [x] `soldr cargo check --workspace --all-targets` clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` exits 0
- [x] `soldr cargo test -p fbuild-build --lib shrink::` — 5/5 pass
- [x] `soldr cargo test -p fbuild-cli --bin fbuild cli::tests::` — 19/19 pass (6 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
