### PR TITLE
fix(esp32): emit -Wl,-Map=firmware.map at link time (#508, part of #491)

### DIFF
--- a/crates/fbuild-build/src/esp32/esp32_linker.rs
+++ b/crates/fbuild-build/src/esp32/esp32_linker.rs
@@ -229,23 +229,21 @@ impl Esp32Linker {
             tracing::warn!("failed to write firmware size cache: {}", e);
         }
     }
-}
 
-impl Linker for Esp32Linker {
-    fn archive(&self, objects: &[PathBuf], output: &Path) -> Result<()> {
-        crate::linker::LinkerBase::archive(&self.ar_path, objects, output, "ar")
-    }
-
-    fn link(
+    /// Build the linker argv that [`Self::link`] will invoke, without
+    /// touching the filesystem or running the subprocess. Extracted from
+    /// `link()` so unit tests can assert on the argv shape — in particular
+    /// the `-Wl,-Map=<elf-stem>.map` flag required by `fbuild bloat` for
+    /// archive / object / section attribution (see FastLED/fbuild#491,
+    /// #508). Every other platform linker (avr, teensy, generic_arm,
+    /// esp8266, ...) already does this; ESP32 was the outlier.
+    fn build_link_args(
         &self,
         objects: &[PathBuf],
         archives: &[PathBuf],
-        output_dir: &Path,
+        elf_path: &Path,
         extra: &LinkExtraArgs,
-    ) -> Result<PathBuf> {
-        std::fs::create_dir_all(output_dir)?;
-        let elf_path = output_dir.join("firmware.elf");
-
+    ) -> Vec<String> {
         let mut link_args: Vec<String> = Vec::new();
 
         // Compiler/driver
@@ -263,6 +261,12 @@ impl Linker for Esp32Linker {
 
         // Output
         link_args.extend(["-o".to_string(), elf_path.to_string_lossy().to_string()]);
+
+        // Always emit a linker map next to firmware.elf — required by
+        // `fbuild bloat` / `fbuild symbols` for archive / object / section
+        // attribution (#491, #508).
+        let map_path = elf_path.with_extension("map");
+        link_args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
 
         // Sketch objects
         for obj in objects {
@@ -282,6 +286,26 @@ impl Linker for Esp32Linker {
         link_args.extend(extra.libs.iter().cloned());
 
         link_args.push("-Wl,--end-group".to_string());
+
+        link_args
+    }
+}
+
+impl Linker for Esp32Linker {
+    fn archive(&self, objects: &[PathBuf], output: &Path) -> Result<()> {
+        crate::linker::LinkerBase::archive(&self.ar_path, objects, output, "ar")
+    }
+
+    fn link(
+        &self,
+        objects: &[PathBuf],
+        archives: &[PathBuf],
+        output_dir: &Path,
+        extra: &LinkExtraArgs,
+    ) -> Result<PathBuf> {
+        std::fs::create_dir_all(output_dir)?;
+        let elf_path = output_dir.join("firmware.elf");
+        let link_args = self.build_link_args(objects, archives, &elf_path, extra);
 
         if self.verbose {
             tracing::info!("link: {}", link_args.join(" "));
@@ -483,6 +507,26 @@ mod tests {
 
         assert_eq!(flash_size, "4MB");
         assert_eq!(cache.flash_size, "4MB");
+    }
+
+    /// Regression test: `build_link_args` always emits `-Wl,-Map=` next to
+    /// `firmware.elf`. ESP32 was the only platform linker not emitting the
+    /// map before #491 / #508; without it `fbuild bloat` cannot attribute
+    /// symbols to their source archives.
+    #[test]
+    fn test_esp32_link_command_emits_linker_map_next_to_elf() {
+        let linker = test_linker("esp32c6");
+        let args = linker.build_link_args(
+            &[],
+            &[],
+            &PathBuf::from("/build/firmware.elf"),
+            &LinkExtraArgs::default(),
+        );
+        assert!(
+            args.iter().any(|a| a == "-Wl,-Map=/build/firmware.map"),
+            "expected -Wl,-Map=/build/firmware.map next to firmware.elf. Args: {:?}",
+            args,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #508 (narrow ESP32 slice of #491).

Every other platform linker in fbuild (`avr_linker`, `teensy_linker`, `generic_arm/arm_linker` covering STM32/NRF52, `esp8266_linker`, `ch32v_linker`, `renesas_linker`, `sam_linker`, `silabs_linker`, `nrf52_linker`) already passes `-Wl,-Map=<elf>.map` so `fbuild bloat` / `fbuild symbols` can attribute symbols to their source archives / objects / sections.

ESP32 was the outlier. Without `firmware.map` next to `firmware.elf`, the ARCHIVE / OBJECT / SECTION columns of `fbuild bloat` are all `-` and the "flash bytes by archive" rollup collapses to "(unattributed)" — a hard prerequisite for Phase 4 of #493 (the shrink integration needs archive attribution to report "libc.a/lib_a-vfprintf.o" deltas).

## Changes

- Extract `Esp32Linker::build_link_args(objects, archives, elf_path, extra) -> Vec<String>` from the trait impl `link()` method. The extracted helper does no filesystem I/O and no subprocess spawning, matching the pattern used in `avr_linker.rs:86` and `teensy_linker.rs`.
- Inside `build_link_args`, push `-Wl,-Map=<elf-stem>.map` right after the `-o <elf>` flag — same position the other linkers use.
- `link()` becomes a thin wrapper that calls `build_link_args` and then runs the resulting argv via response-file-on-Windows / direct-on-Unix.

## Test

New `test_esp32_link_command_emits_linker_map_next_to_elf` regression test (analogous to the existing teensy/AVR ones) constructs a stub `Esp32Linker` via the existing `test_linker(mcu)` helper, calls `build_link_args`, and asserts the argv contains `-Wl,-Map=/build/firmware.map` when the elf is at `/build/firmware.elf`.

## Out of scope

Apollo3, NXP LPC, and RP2040 are also missing the flag. Those land in follow-up sub-issues.

## Test plan

- [x] `cargo test -p fbuild-build --lib esp32::esp32_linker::tests::test_esp32_link_command_emits_linker_map_next_to_elf` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
