### PR TITLE
nxplpc: own Arduino/device assets and lib ingestion

### DIFF
--- a/crates/fbuild-build/src/nxplpc/assets/README.md
+++ b/crates/fbuild-build/src/nxplpc/assets/README.md
@@ -6,6 +6,8 @@
 | `lpc845.ld`       | GNU ld memory map for LPC845 (64 KB Flash / 16 KB RAM).    |
 | `startup_lpc804.S`| Reset_Handler + minimal vector table for LPC804.           |
 | `startup_lpc845.S`| Reset_Handler + minimal vector table for LPC845.           |
+| `arduino_stub/`   | Minimal Arduino.h / Serial / SPI / timing surface.         |
+| `device_headers/` | Minimal LPC804/LPC845 CMSIS device headers.                |
 
 All four files are embedded into the `fbuild-build` crate via `include_str!`
 in `mod.rs` so the Stage-2 orchestrator (FastLED/FastLED#2836) can emit them

--- a/crates/fbuild-build/src/nxplpc/assets/arduino_stub/Arduino.h
+++ b/crates/fbuild-build/src/nxplpc/assets/arduino_stub/Arduino.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Minimal Arduino-compatible surface for fbuild's NXP LPC8xx target.
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HIGH 0x1
+#define LOW 0x0
+
+#define INPUT 0x0
+#define OUTPUT 0x1
+#define INPUT_PULLUP 0x2
+
+typedef uint8_t byte;
+typedef bool boolean;
+typedef uint8_t pin_size_t;
+typedef uint8_t PinStatus;
+typedef uint8_t PinMode;
+
+void pinMode(pin_size_t pin, PinMode mode);
+void digitalWrite(pin_size_t pin, PinStatus value);
+PinStatus digitalRead(pin_size_t pin);
+
+void delay(uint32_t ms);
+void delayMicroseconds(uint32_t us);
+uint32_t millis(void);
+uint32_t micros(void);
+void yield(void);
+
+#ifdef __cplusplus
+}
+
+#define F(str) (str)
+
+#include "HardwareSerial.h"
+#include "SPI.h"
+
+#endif

--- a/crates/fbuild-build/src/nxplpc/assets/arduino_stub/HardwareSerial.cpp
+++ b/crates/fbuild-build/src/nxplpc/assets/arduino_stub/HardwareSerial.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#include "HardwareSerial.h"
+
+HardwareSerial Serial;
+
+void HardwareSerial::begin(uint32_t baud) {
+    (void)baud;
+}
+
+void HardwareSerial::end() {}
+
+int HardwareSerial::available() {
+    return 0;
+}
+
+int HardwareSerial::read() {
+    return -1;
+}
+
+int HardwareSerial::peek() {
+    return -1;
+}
+
+void HardwareSerial::flush() {}
+
+size_t HardwareSerial::write(uint8_t value) {
+    (void)value;
+    return 1;
+}
+
+size_t HardwareSerial::write(const uint8_t* buffer, size_t size) {
+    (void)buffer;
+    return size;
+}
+
+size_t HardwareSerial::print(const char* str) {
+    size_t len = 0;
+    while (str && str[len]) {
+        ++len;
+    }
+    return write(reinterpret_cast<const uint8_t*>(str), len);
+}
+
+size_t HardwareSerial::print(int value) {
+    (void)value;
+    return 0;
+}
+
+size_t HardwareSerial::print(unsigned int value) {
+    (void)value;
+    return 0;
+}
+
+size_t HardwareSerial::print(long value) {
+    (void)value;
+    return 0;
+}
+
+size_t HardwareSerial::print(unsigned long value) {
+    (void)value;
+    return 0;
+}
+
+size_t HardwareSerial::println() {
+    static const uint8_t newline[] = {'\r', '\n'};
+    return write(newline, sizeof(newline));
+}
+
+size_t HardwareSerial::println(const char* str) {
+    return print(str) + println();
+}
+
+size_t HardwareSerial::println(int value) {
+    return print(value) + println();
+}
+
+size_t HardwareSerial::println(unsigned int value) {
+    return print(value) + println();
+}
+
+size_t HardwareSerial::println(long value) {
+    return print(value) + println();
+}
+
+size_t HardwareSerial::println(unsigned long value) {
+    return print(value) + println();
+}

--- a/crates/fbuild-build/src/nxplpc/assets/arduino_stub/HardwareSerial.h
+++ b/crates/fbuild-build/src/nxplpc/assets/arduino_stub/HardwareSerial.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+class HardwareSerial {
+public:
+    void begin(uint32_t baud);
+    void end();
+    int available();
+    int read();
+    int peek();
+    void flush();
+    size_t write(uint8_t value);
+    size_t write(const uint8_t* buffer, size_t size);
+    size_t print(const char* str);
+    size_t print(int value);
+    size_t print(unsigned int value);
+    size_t print(long value);
+    size_t print(unsigned long value);
+    size_t println();
+    size_t println(const char* str);
+    size_t println(int value);
+    size_t println(unsigned int value);
+    size_t println(long value);
+    size_t println(unsigned long value);
+};
+
+extern HardwareSerial Serial;

--- a/crates/fbuild-build/src/nxplpc/assets/arduino_stub/SPI.cpp
+++ b/crates/fbuild-build/src/nxplpc/assets/arduino_stub/SPI.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#include "SPI.h"
+
+SPIClass SPI;
+
+void SPIClass::begin() {}
+
+void SPIClass::end() {}
+
+uint8_t SPIClass::transfer(uint8_t value) {
+    return value;
+}
+
+void SPIClass::transfer(void* buffer, size_t size) {
+    (void)buffer;
+    (void)size;
+}
+
+void SPIClass::setClockDivider(uint8_t divider) {
+    (void)divider;
+}
+
+void SPIClass::setBitOrder(uint8_t order) {
+    (void)order;
+}
+
+void SPIClass::setDataMode(uint8_t mode) {
+    (void)mode;
+}

--- a/crates/fbuild-build/src/nxplpc/assets/arduino_stub/SPI.h
+++ b/crates/fbuild-build/src/nxplpc/assets/arduino_stub/SPI.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SPI_CLOCK_DIV2 2
+#define SPI_CLOCK_DIV4 4
+#define SPI_CLOCK_DIV8 8
+#define SPI_CLOCK_DIV16 16
+
+#define MSBFIRST 1
+#define LSBFIRST 0
+
+#define SPI_MODE0 0
+#define SPI_MODE1 1
+#define SPI_MODE2 2
+#define SPI_MODE3 3
+
+class SPIClass {
+public:
+    void begin();
+    void end();
+    uint8_t transfer(uint8_t value);
+    void transfer(void* buffer, size_t size);
+    void setClockDivider(uint8_t divider);
+    void setBitOrder(uint8_t order);
+    void setDataMode(uint8_t mode);
+};
+
+extern SPIClass SPI;

--- a/crates/fbuild-build/src/nxplpc/assets/arduino_stub/wiring_digital.c
+++ b/crates/fbuild-build/src/nxplpc/assets/arduino_stub/wiring_digital.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#include "Arduino.h"
+
+void pinMode(pin_size_t pin, PinMode mode) {
+    (void)pin;
+    (void)mode;
+}
+
+void digitalWrite(pin_size_t pin, PinStatus value) {
+    (void)pin;
+    (void)value;
+}
+
+PinStatus digitalRead(pin_size_t pin) {
+    (void)pin;
+    return LOW;
+}

--- a/crates/fbuild-build/src/nxplpc/assets/arduino_stub/wiring_time.c
+++ b/crates/fbuild-build/src/nxplpc/assets/arduino_stub/wiring_time.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#include "Arduino.h"
+
+#if defined(CPU_LPC845M301JBD48)
+#include "LPC845.h"
+#elif defined(CPU_LPC804M101JDH24)
+#include "LPC804.h"
+#else
+#error "Unsupported NXP LPC8xx CPU"
+#endif
+
+__attribute__((weak)) uint32_t SystemCoreClock = F_CPU;
+
+__attribute__((weak)) void SystemCoreClockUpdate(void) {
+    SystemCoreClock = F_CPU;
+}
+
+static volatile uint32_t g_systick_millis = 0;
+static uint8_t g_systick_started = 0;
+
+static uint32_t ticks_per_ms(void) {
+    return F_CPU / 1000UL;
+}
+
+static uint32_t ticks_per_us(void) {
+    return F_CPU / 1000000UL;
+}
+
+static void init_systick(void) {
+    if (g_systick_started) {
+        return;
+    }
+
+    const uint32_t ticks = ticks_per_ms();
+    if (ticks == 0 || ticks > 0x1000000UL) {
+        return;
+    }
+
+    SysTick->LOAD = ticks - 1;
+    SysTick->VAL = 0;
+    SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
+                    SysTick_CTRL_TICKINT_Msk |
+                    SysTick_CTRL_ENABLE_Msk;
+    g_systick_started = 1;
+}
+
+void SysTick_Handler(void) {
+    ++g_systick_millis;
+}
+
+uint32_t millis(void) {
+    init_systick();
+    return g_systick_millis;
+}
+
+uint32_t micros(void) {
+    init_systick();
+
+    const uint32_t per_us = ticks_per_us();
+    if (!g_systick_started || per_us == 0) {
+        return g_systick_millis * 1000UL;
+    }
+
+    uint32_t before;
+    uint32_t fraction;
+    uint32_t after;
+    do {
+        before = g_systick_millis;
+        const uint32_t period_ticks = SysTick->LOAD + 1;
+        const uint32_t current_ticks = SysTick->VAL;
+        const uint32_t elapsed_ticks = period_ticks - current_ticks;
+        fraction = elapsed_ticks / per_us;
+        if (fraction > 999UL) {
+            fraction = 999UL;
+        }
+        after = g_systick_millis;
+    } while (before != after);
+
+    return before * 1000UL + fraction;
+}
+
+void delay(uint32_t ms) {
+    const uint32_t start = millis();
+    while ((millis() - start) < ms) {
+    }
+}
+
+void delayMicroseconds(uint32_t us) {
+    const uint32_t start = micros();
+    while ((micros() - start) < us) {
+    }
+}
+
+void yield(void) {}

--- a/crates/fbuild-build/src/nxplpc/assets/device_headers/LPC804.h
+++ b/crates/fbuild-build/src/nxplpc/assets/device_headers/LPC804.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Minimal CMSIS device header for fbuild's LPC804 target.
+#pragma once
+
+#include <stdint.h>
+
+#define NUMBER_OF_INT_VECTORS 48
+
+typedef enum IRQn {
+    NonMaskableInt_IRQn = -14,
+    HardFault_IRQn = -13,
+    SVCall_IRQn = -5,
+    PendSV_IRQn = -2,
+    SysTick_IRQn = -1,
+    SPI0_IRQn = 0,
+    USART0_IRQn = 3,
+    USART1_IRQn = 4,
+    I2C1_IRQn = 7,
+    I2C0_IRQn = 8,
+    SCT_IRQn = 9,
+    MRT_IRQn = 10,
+    WDT_IRQn = 12,
+    BOD_IRQn = 13,
+    WKT_IRQn = 15,
+    ADC_SEQA_IRQn = 16,
+    ADC_SEQB_IRQn = 17,
+    ADC_THCMP_IRQn = 18,
+    ADC_OVR_IRQn = 19,
+    DMA_IRQn = 20,
+    I2C2_IRQn = 21,
+    I2C3_IRQn = 22,
+    CTIMER0_IRQn = 23,
+    PIN_INT0_IRQn = 24,
+    PIN_INT1_IRQn = 25,
+    PIN_INT2_IRQn = 26,
+    PIN_INT3_IRQn = 27,
+    PIN_INT4_IRQn = 28,
+    PIN_INT5_IRQn = 29,
+    PIN_INT6_IRQn = 30,
+    PIN_INT7_IRQn = 31
+} IRQn_Type;
+
+#define __CM0PLUS_REV 0x0000U
+#define __MPU_PRESENT 0
+#define __VTOR_PRESENT 1
+#define __NVIC_PRIO_BITS 2
+#define __Vendor_SysTickConfig 0
+
+#include "core_cm0plus.h"
+#include "system_LPC804.h"

--- a/crates/fbuild-build/src/nxplpc/assets/device_headers/LPC845.h
+++ b/crates/fbuild-build/src/nxplpc/assets/device_headers/LPC845.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Minimal CMSIS device header for fbuild's LPC845 target.
+#pragma once
+
+#include <stdint.h>
+
+#define NUMBER_OF_INT_VECTORS 48
+
+typedef enum IRQn {
+    NonMaskableInt_IRQn = -14,
+    HardFault_IRQn = -13,
+    SVCall_IRQn = -5,
+    PendSV_IRQn = -2,
+    SysTick_IRQn = -1,
+    SPI0_IRQn = 0,
+    SPI1_IRQn = 1,
+    DAC0_IRQn = 2,
+    USART0_IRQn = 3,
+    USART1_IRQn = 4,
+    USART2_IRQn = 5,
+    I2C1_IRQn = 7,
+    I2C0_IRQn = 8,
+    SCT_IRQn = 9,
+    MRT_IRQn = 10,
+    CMP_IRQn = 11,
+    WDT_IRQn = 12,
+    BOD_IRQn = 13,
+    FLASH_IRQn = 14,
+    WKT_IRQn = 15,
+    ADC_SEQA_IRQn = 16,
+    ADC_SEQB_IRQn = 17,
+    ADC_THCMP_IRQn = 18,
+    ADC_OVR_IRQn = 19,
+    DMA_IRQn = 20,
+    I2C2_IRQn = 21,
+    I2C3_IRQn = 22,
+    CTIMER0_IRQn = 23,
+    PIN_INT0_IRQn = 24,
+    PIN_INT1_IRQn = 25,
+    PIN_INT2_IRQn = 26,
+    PIN_INT3_IRQn = 27,
+    PIN_INT4_IRQn = 28,
+    PIN_INT5_IRQn = 29,
+    PIN_INT6_IRQn = 30,
+    PIN_INT7_IRQn = 31
+} IRQn_Type;
+
+#define __CM0PLUS_REV 0x0000U
+#define __MPU_PRESENT 0
+#define __VTOR_PRESENT 1
+#define __NVIC_PRIO_BITS 2
+#define __Vendor_SysTickConfig 0
+
+#include "core_cm0plus.h"
+#include "system_LPC845.h"

--- a/crates/fbuild-build/src/nxplpc/assets/device_headers/fsl_device_registers.h
+++ b/crates/fbuild-build/src/nxplpc/assets/device_headers/fsl_device_registers.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#if defined(CPU_LPC845M301JBD48)
+#define LPC845_SERIES
+#include "LPC845.h"
+#elif defined(CPU_LPC804M101JDH24)
+#define LPC804_SERIES
+#include "LPC804.h"
+#else
+#error "No valid NXP LPC8xx CPU defined"
+#endif

--- a/crates/fbuild-build/src/nxplpc/assets/device_headers/system_LPC804.h
+++ b/crates/fbuild-build/src/nxplpc/assets/device_headers/system_LPC804.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DEFAULT_SYSTEM_CLOCK 15000000u
+
+extern uint32_t SystemCoreClock;
+void SystemInit(void);
+void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/fbuild-build/src/nxplpc/assets/device_headers/system_LPC845.h
+++ b/crates/fbuild-build/src/nxplpc/assets/device_headers/system_LPC845.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DEFAULT_SYSTEM_CLOCK 30000000u
+
+extern uint32_t SystemCoreClock;
+void SystemInit(void);
+void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/fbuild-build/src/nxplpc/assets/main.cpp
+++ b/crates/fbuild-build/src/nxplpc/assets/main.cpp
@@ -16,11 +16,10 @@
 // `zackees/ArduinoCore-LPC8xx::cores/lpc8xx/main.cpp` once #479 lands
 // (tracked in #487, Stage 4: "vendor the framework into fbuild").
 
-extern "C" {
-    // User-provided Arduino entry points.
-    void setup(void);
-    void loop(void);
-}
+// User-provided Arduino entry points. The .ino preprocessor emits normal
+// C++ prototypes, so keep these declarations in C++ linkage.
+void setup(void);
+void loop(void);
 
 int main(void) {
     setup();

--- a/crates/fbuild-build/src/nxplpc/mod.rs
+++ b/crates/fbuild-build/src/nxplpc/mod.rs
@@ -42,6 +42,65 @@ pub const LPC845_STARTUP: &str = include_str!("assets/startup_lpc845.S");
 /// `main.cpp` once #479 / ArduinoCore-LPC8xx is vendored (Stage 4 of #487).
 pub const MAIN_CPP_SHIM: &str = include_str!("assets/main.cpp");
 
+/// Minimal Arduino compatibility layer used until #479's external
+/// ArduinoCore-LPC8xx package is production-ready.
+pub const ARDUINO_STUB_ASSETS: &[(&str, &str)] = &[
+    (
+        "arduino_stub/Arduino.h",
+        include_str!("assets/arduino_stub/Arduino.h"),
+    ),
+    (
+        "arduino_stub/HardwareSerial.h",
+        include_str!("assets/arduino_stub/HardwareSerial.h"),
+    ),
+    (
+        "arduino_stub/HardwareSerial.cpp",
+        include_str!("assets/arduino_stub/HardwareSerial.cpp"),
+    ),
+    (
+        "arduino_stub/SPI.h",
+        include_str!("assets/arduino_stub/SPI.h"),
+    ),
+    (
+        "arduino_stub/SPI.cpp",
+        include_str!("assets/arduino_stub/SPI.cpp"),
+    ),
+    (
+        "arduino_stub/wiring_digital.c",
+        include_str!("assets/arduino_stub/wiring_digital.c"),
+    ),
+    (
+        "arduino_stub/wiring_time.c",
+        include_str!("assets/arduino_stub/wiring_time.c"),
+    ),
+];
+
+/// NXP device headers that bridge the generic CMSIS Core package to the
+/// LPC804/LPC845-specific symbols FastLED includes (`LPC804.h`, `LPC845.h`,
+/// and `fsl_device_registers.h`).
+pub const DEVICE_HEADER_ASSETS: &[(&str, &str)] = &[
+    (
+        "device_headers/LPC804.h",
+        include_str!("assets/device_headers/LPC804.h"),
+    ),
+    (
+        "device_headers/LPC845.h",
+        include_str!("assets/device_headers/LPC845.h"),
+    ),
+    (
+        "device_headers/fsl_device_registers.h",
+        include_str!("assets/device_headers/fsl_device_registers.h"),
+    ),
+    (
+        "device_headers/system_LPC804.h",
+        include_str!("assets/device_headers/system_LPC804.h"),
+    ),
+    (
+        "device_headers/system_LPC845.h",
+        include_str!("assets/device_headers/system_LPC845.h"),
+    ),
+];
+
 /// NXP LPC8xx platform support.
 pub struct NxpLpcPlatformSupport;
 
@@ -56,6 +115,8 @@ impl crate::PlatformSupport for NxpLpcPlatformSupport {
         use fbuild_packages::Package;
         let tc = fbuild_packages::toolchain::ArmToolchain::new(project_dir);
         Package::ensure_installed(&tc)?;
+        let cmsis = fbuild_packages::library::CmsisFramework::new(project_dir);
+        Package::ensure_installed(&cmsis)?;
         tracing::info!("ARM GCC toolchain installed for NXP LPC8xx");
         Ok(())
     }

--- a/crates/fbuild-build/src/nxplpc/orchestrator.rs
+++ b/crates/fbuild-build/src/nxplpc/orchestrator.rs
@@ -26,7 +26,10 @@ use crate::generic_arm::{ArmCompiler, ArmLinker};
 use crate::pipeline;
 use crate::{BuildOrchestrator, BuildParams, BuildResult, SourceScanner};
 
-use super::{mcu_config, LPC804_LD, LPC804_STARTUP, LPC845_LD, LPC845_STARTUP, MAIN_CPP_SHIM};
+use super::{
+    mcu_config, ARDUINO_STUB_ASSETS, DEVICE_HEADER_ASSETS, LPC804_LD, LPC804_STARTUP, LPC845_LD,
+    LPC845_STARTUP, MAIN_CPP_SHIM,
+};
 
 /// Per-MCU asset bundle: linker script + startup `.S`. Selected from
 /// the embedded `include_str!` constants based on the board's `mcu`
@@ -60,8 +63,21 @@ fn mcu_assets(mcu: &str) -> Result<McuAssets> {
 /// can consume them.
 fn write_asset(dir: &std::path::Path, filename: &str, content: &str) -> Result<PathBuf> {
     let path = dir.join(filename);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     std::fs::write(&path, content)?;
     Ok(path)
+}
+
+fn write_asset_group(
+    dir: &std::path::Path,
+    assets: &[(&'static str, &'static str)],
+) -> Result<Vec<PathBuf>> {
+    assets
+        .iter()
+        .map(|(filename, content)| write_asset(dir, filename, content))
+        .collect()
 }
 
 /// NXP LPC8xx (Cortex-M0+) build orchestrator.
@@ -90,6 +106,10 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
         let toolchain_dir = fbuild_packages::Package::ensure_installed(&toolchain)?;
         tracing::info!("arm-none-eabi-gcc toolchain at {}", toolchain_dir.display());
 
+        let cmsis = fbuild_packages::library::CmsisFramework::new(&params.project_dir);
+        let cmsis_dir = fbuild_packages::Package::ensure_installed(&cmsis)?;
+        tracing::info!("CMSIS framework at {}", cmsis_dir.display());
+
         use fbuild_packages::Toolchain;
         pipeline::log_toolchain_version(
             &toolchain.get_gcc_path(),
@@ -111,6 +131,8 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
             assets.startup_asm,
         )?;
         let main_shim_path = write_asset(&ctx.build_dir, "lpc8xx_main.cpp", MAIN_CPP_SHIM)?;
+        let stub_paths = write_asset_group(&ctx.build_dir, ARDUINO_STUB_ASSETS)?;
+        write_asset_group(&ctx.build_dir, DEVICE_HEADER_ASSETS)?;
 
         // 6. Scan user sources. No external framework yet (Stage 3 / #479).
         let scanner = SourceScanner::new(&ctx.src_dir, &ctx.src_build_dir);
@@ -123,6 +145,14 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
         // real implementations.
         sources.core_sources.push(startup_path);
         sources.core_sources.push(main_shim_path);
+        for path in stub_paths {
+            if matches!(
+                path.extension().and_then(|ext| ext.to_str()),
+                Some("c" | "cc" | "cpp" | "S" | "s")
+            ) {
+                sources.core_sources.push(path);
+            }
+        }
 
         tracing::info!(
             "sources: {} sketch, {} core (framework shim), {} variant",
@@ -136,12 +166,23 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
         let mut defines = ctx.board.get_defines();
         defines.extend(mcu_config.defines_map());
 
-        // 8. Include dirs: sketch + project discovery (libs under lib/, etc.).
-        //    No framework include path yet — the bare CMSIS path will gain
-        //    the MCUXpresso SDK include dirs when Stage 4 vendors the
-        //    framework library.
-        let mut include_dirs = vec![ctx.src_dir.clone()];
+        // 8. Include dirs: framework stub + device headers + CMSIS core +
+        //    sketch/project discovery (libs under lib/, etc.). These fbuild-
+        //    owned roots replace the misplaced example-local include tree from
+        //    FastLED/FastLED#2988 and flow into build_info.json.
+        let build_dir = crate::compiler::absolute_from_cwd(&ctx.build_dir);
+        let src_dir = crate::compiler::absolute_from_cwd(&ctx.src_dir);
+        let mut include_dirs = vec![
+            build_dir.join("arduino_stub"),
+            build_dir.join("device_headers"),
+            cmsis.get_core_include_dir(),
+            src_dir,
+        ];
         pipeline::discover_project_includes(&params.project_dir, &mut include_dirs);
+        let lib_extra_dirs = ctx.config.get_lib_extra_dirs(&params.env_name)?;
+        let extra_library_roots =
+            pipeline::discover_extra_library_roots(&params.project_dir, &lib_extra_dirs);
+        pipeline::add_extra_library_include_dirs(&extra_library_roots, &mut include_dirs);
 
         let compiler = ArmCompiler::new(
             toolchain.get_gcc_path(),
@@ -149,7 +190,7 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
             &ctx.board.mcu,
             &ctx.board.f_cpu,
             defines,
-            include_dirs,
+            include_dirs.clone(),
             mcu_config.clone(),
             params.profile,
             params.verbose,
@@ -171,20 +212,37 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
             params.verbose,
         );
 
-        // 10. Run the shared sequential build pipeline.
-        //
-        // `lib_env = None` because there is no project-as-library path
-        // here — the bare LPC8xx target doesn't pre-build dependencies
-        // into archives (yet). Stage 4 may add this once an Arduino
-        // library ecosystem is in scope.
+        // 10. Compile extra library roots before the shared pipeline links them.
+        let gcc_path = toolchain.get_gcc_path();
+        let gxx_path = toolchain.get_gxx_path();
+        let ar_path = toolchain.get_ar_path();
+        let gcc_ar_path = toolchain.get_gcc_ar_path();
+        let c_flags = crate::compiler::Compiler::c_flags(&compiler);
+        let cpp_flags = crate::compiler::Compiler::cpp_flags(&compiler);
+        let lib_ar_path = pipeline::pick_archiver(&ar_path, &gcc_ar_path, &c_flags, &cpp_flags);
+        let lib_env = pipeline::LibraryBuildEnv {
+            gcc_path: &gcc_path,
+            gxx_path: &gxx_path,
+            ar_path: lib_ar_path,
+            c_flags: &c_flags,
+            cpp_flags: &cpp_flags,
+            include_dirs: &include_dirs,
+            verbose: params.verbose,
+            jobs: crate::parallel::effective_jobs(params.jobs),
+            compiler_cache: None,
+        };
+        let extra_link_inputs =
+            pipeline::compile_extra_libraries(&extra_library_roots, &ctx.build_dir, &lib_env)?;
+
+        // 11. Run the shared sequential build pipeline.
         pipeline::run_sequential_build_with_libs(
             &compiler,
             &linker,
             ctx,
             params,
             &sources,
-            &[],
-            None,
+            &extra_link_inputs,
+            Some(&lib_env),
             TargetArchitecture::Arm,
             "NXPLPC",
             start,

--- a/crates/fbuild-build/src/pipeline/library.rs
+++ b/crates/fbuild-build/src/pipeline/library.rs
@@ -1,5 +1,5 @@
 //! Library compilation helpers: `LibraryBuildEnv`, archiver selection,
-//! and the "project-as-library" compile path.
+//! extra library roots, and the "project-as-library" compile path.
 
 use std::path::{Path, PathBuf};
 
@@ -50,6 +50,154 @@ pub fn pick_archiver<'a>(
     } else {
         ar_path
     }
+}
+
+fn resolve_extra_library_path(project_dir: &Path, entry: &str) -> PathBuf {
+    let path = PathBuf::from(entry);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        project_dir.join(path)
+    };
+    crate::compiler::absolute_from_cwd(&path)
+}
+
+fn looks_like_library_root(path: &Path) -> bool {
+    path.join("library.json").is_file()
+        || path.join("library.properties").is_file()
+        || path.join("src").is_dir()
+}
+
+fn library_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("library")
+        .to_lowercase()
+}
+
+fn strip_windows_extended_prefix(path: PathBuf) -> PathBuf {
+    if !cfg!(windows) {
+        return path;
+    }
+    let s = path.to_string_lossy();
+    if let Some(rest) = s.strip_prefix(r"\\?\").or_else(|| s.strip_prefix("//?/")) {
+        return PathBuf::from(rest);
+    }
+    path
+}
+
+/// Resolve `lib_extra_dirs`/`PLATFORMIO_LIB_EXTRA_DIRS` entries to library roots.
+///
+/// `pio ci --lib <path>` commonly points directly at a library root (FastLED
+/// uses `--lib .`), while `lib_extra_dirs` can point at a directory containing
+/// multiple libraries. Support both forms.
+pub fn discover_extra_library_roots(project_dir: &Path, entries: &[String]) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for entry in entries {
+        let path = resolve_extra_library_path(project_dir, entry);
+        if !path.is_dir() {
+            tracing::warn!(
+                "lib_extra_dirs entry is not a directory: {}",
+                path.display()
+            );
+            continue;
+        }
+
+        let mut candidates = Vec::new();
+        if looks_like_library_root(&path) {
+            candidates.push(path);
+        } else if let Ok(children) = std::fs::read_dir(&path) {
+            for child in children.flatten() {
+                let child_path = child.path();
+                if child_path.is_dir() && looks_like_library_root(&child_path) {
+                    candidates.push(child_path);
+                }
+            }
+        }
+
+        for candidate in candidates {
+            let key = std::fs::canonicalize(&candidate)
+                .map(strip_windows_extended_prefix)
+                .unwrap_or(candidate.clone());
+            if seen.insert(key.clone()) {
+                roots.push(key);
+            }
+        }
+    }
+
+    roots
+}
+
+/// Add include dirs for extra library roots to an orchestrator include list.
+pub fn add_extra_library_include_dirs(library_roots: &[PathBuf], include_dirs: &mut Vec<PathBuf>) {
+    for root in library_roots {
+        let lib_name = library_name(root);
+        let lib = fbuild_packages::library::library_info::InstalledLibrary::new(root, &lib_name);
+        let mut dirs = lib.get_include_dirs();
+        if !include_dirs.contains(root) {
+            dirs.push(root.clone());
+        }
+        for dir in dirs {
+            if !include_dirs.contains(&dir) {
+                include_dirs.push(dir);
+            }
+        }
+    }
+}
+
+/// Compile extra library roots from `lib_extra_dirs` into archives.
+pub fn compile_extra_libraries(
+    library_roots: &[PathBuf],
+    build_dir: &Path,
+    env: &LibraryBuildEnv<'_>,
+) -> Result<Vec<PathBuf>> {
+    let mut archives = Vec::new();
+    for root in library_roots {
+        let lib_name = library_name(root);
+        let lib_info =
+            fbuild_packages::library::library_info::InstalledLibrary::new(root, &lib_name);
+        let sources = lib_info.get_source_files();
+        if sources.is_empty() {
+            tracing::info!("extra library '{}' is header-only", lib_name);
+            continue;
+        }
+
+        tracing::info!(
+            "compiling extra library '{}': {} source files from {}",
+            lib_name,
+            sources.len(),
+            root.display()
+        );
+
+        let output_dir = build_dir.join("extra_lib").join(&lib_name);
+        std::fs::create_dir_all(&output_dir)?;
+        match fbuild_packages::library::library_compiler::compile_library_with_jobs(
+            &lib_name,
+            &sources,
+            env.include_dirs,
+            env.gcc_path,
+            env.gxx_path,
+            env.ar_path,
+            env.c_flags,
+            env.cpp_flags,
+            &output_dir,
+            env.verbose,
+            env.jobs,
+            env.compiler_cache,
+        ) {
+            Ok(Some(archive)) => archives.push(archive),
+            Ok(None) => {}
+            Err(e) => {
+                return Err(fbuild_core::FbuildError::BuildFailed(format!(
+                    "extra library '{}' compilation failed: {}",
+                    lib_name, e
+                )));
+            }
+        }
+    }
+    Ok(archives)
 }
 
 /// Compile the project's own `src/` as a library archive, when the project
@@ -186,6 +334,56 @@ mod pick_archiver_tests {
         let c_flags: Vec<String> = vec![];
         let cpp_flags = vec!["-flto=auto".to_string()];
         assert_eq!(pick_archiver(ar, gcc_ar, &c_flags, &cpp_flags), gcc_ar);
+    }
+}
+
+#[cfg(test)]
+mod extra_library_tests {
+    use super::*;
+
+    #[test]
+    fn discovers_direct_library_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("library.properties"), "name=FastLED\n").unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+        let roots = discover_extra_library_roots(tmp.path(), &[".".to_string()]);
+
+        assert_eq!(roots.len(), 1);
+        assert_eq!(
+            roots[0],
+            strip_windows_extended_prefix(std::fs::canonicalize(tmp.path()).unwrap())
+        );
+    }
+
+    #[test]
+    fn discovers_libraries_inside_storage_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = tmp.path().join("libs");
+        let lib_a = storage.join("LibA");
+        let lib_b = storage.join("LibB");
+        std::fs::create_dir_all(lib_a.join("src")).unwrap();
+        std::fs::create_dir_all(lib_b.join("src")).unwrap();
+
+        let roots = discover_extra_library_roots(tmp.path(), &["libs".to_string()]);
+
+        assert_eq!(roots.len(), 2);
+        assert!(roots.iter().any(|root| root.ends_with("LibA")));
+        assert!(roots.iter().any(|root| root.ends_with("LibB")));
+    }
+
+    #[test]
+    fn adds_src_and_root_include_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("FastLED");
+        std::fs::create_dir_all(lib.join("src")).unwrap();
+        std::fs::write(lib.join("src").join("FastLED.h"), "").unwrap();
+
+        let mut include_dirs = Vec::new();
+        add_extra_library_include_dirs(&[lib.clone()], &mut include_dirs);
+
+        assert!(include_dirs.contains(&lib.join("src")));
+        assert!(include_dirs.contains(&lib));
     }
 }
 

--- a/crates/fbuild-build/src/pipeline/library.rs
+++ b/crates/fbuild-build/src/pipeline/library.rs
@@ -380,7 +380,7 @@ mod extra_library_tests {
         std::fs::write(lib.join("src").join("FastLED.h"), "").unwrap();
 
         let mut include_dirs = Vec::new();
-        add_extra_library_include_dirs(&[lib.clone()], &mut include_dirs);
+        add_extra_library_include_dirs(std::slice::from_ref(&lib), &mut include_dirs);
 
         assert!(include_dirs.contains(&lib.join("src")));
         assert!(include_dirs.contains(&lib));

--- a/crates/fbuild-build/src/pipeline/mod.rs
+++ b/crates/fbuild-build/src/pipeline/mod.rs
@@ -20,7 +20,10 @@ pub use compile::{
     compile_local_libraries, compile_sources, generate_compile_db, log_toolchain_version,
 };
 pub use context::BuildContext;
-pub use library::{compile_project_as_library, pick_archiver, LibraryBuildEnv};
+pub use library::{
+    add_extra_library_include_dirs, compile_extra_libraries, compile_project_as_library,
+    discover_extra_library_roots, pick_archiver, LibraryBuildEnv,
+};
 pub use link::{assemble_build_result, handle_link_result};
 pub use project_discovery::{discover_project_includes, is_platform_project, is_project_a_library};
 pub use sequential::run_sequential_build_with_libs;

--- a/crates/fbuild-cli/src/cli/compile_many.rs
+++ b/crates/fbuild-cli/src/cli/compile_many.rs
@@ -54,6 +54,15 @@ pub fn build_ci_pio_env(
 ) -> std::collections::HashMap<String, String> {
     let mut env = std::collections::HashMap::new();
     if !libs.is_empty() {
+        let libs: Vec<String> = libs
+            .iter()
+            .map(|lib| {
+                std::fs::canonicalize(lib)
+                    .ok()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|| lib.clone())
+            })
+            .collect();
         env.insert(
             "PLATFORMIO_LIB_EXTRA_DIRS".to_string(),
             libs.join(ci_lib_extra_dirs_sep()),

--- a/crates/fbuild-config/src/ini_parser/mod.rs
+++ b/crates/fbuild-config/src/ini_parser/mod.rs
@@ -20,7 +20,9 @@ use std::path::{Path, PathBuf};
 use crate::pio_env::PioEnvOverrides;
 
 use self::parser::{parse_ini, resolve_all_envs};
-use self::values::{parse_flags, parse_lib_deps, parse_list_values, strip_inline_comment};
+use self::values::{
+    parse_flags, parse_lib_deps, parse_list_values, parse_path_list, strip_inline_comment,
+};
 
 /// Parsed platformio.ini configuration.
 pub struct PlatformIOConfig {
@@ -248,6 +250,19 @@ impl PlatformIOConfig {
         let config = self.get_env_config(env_name)?;
         match config.get("lib_deps") {
             Some(deps) => Ok(parse_lib_deps(deps)),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Get extra library search directories for an environment.
+    pub fn get_lib_extra_dirs(&self, env_name: &str) -> fbuild_core::Result<Vec<String>> {
+        if let Some(dirs) = self.overrides.get_lib_extra_dirs() {
+            return Ok(parse_path_list(dirs));
+        }
+
+        let config = self.get_env_config(env_name)?;
+        match config.get("lib_extra_dirs") {
+            Some(dirs) => Ok(parse_list_values(dirs)),
             None => Ok(Vec::new()),
         }
     }

--- a/crates/fbuild-config/src/ini_parser/tests.rs
+++ b/crates/fbuild-config/src/ini_parser/tests.rs
@@ -284,6 +284,53 @@ fn test_get_lib_deps_absent() {
 }
 
 #[test]
+fn test_get_lib_extra_dirs_from_ini() {
+    let f = write_ini(
+        "\
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+lib_extra_dirs =
+    ../FastLED
+    vendor/libs
+",
+    );
+    let config = PlatformIOConfig::from_path(f.path()).unwrap();
+    assert_eq!(
+        config.get_lib_extra_dirs("uno").unwrap(),
+        vec!["../FastLED", "vendor/libs"]
+    );
+}
+
+#[test]
+fn test_get_lib_extra_dirs_prefers_env_override() {
+    let f = write_ini(
+        "\
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+lib_extra_dirs = ignored
+",
+    );
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    let overrides = crate::pio_env::PioEnvOverrides::from_map(
+        [(
+            "PLATFORMIO_LIB_EXTRA_DIRS".to_string(),
+            format!("from-env{sep}more-env"),
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let config = PlatformIOConfig::from_path_with_overrides(f.path(), overrides).unwrap();
+    assert_eq!(
+        config.get_lib_extra_dirs("uno").unwrap(),
+        vec!["from-env", "more-env"]
+    );
+}
+
+#[test]
 fn test_has_environment() {
     let f = write_ini("[env:uno]\nplatform = atmelavr\nboard = uno\nframework = arduino\n");
     let config = PlatformIOConfig::from_path(f.path()).unwrap();

--- a/crates/fbuild-config/src/ini_parser/values.rs
+++ b/crates/fbuild-config/src/ini_parser/values.rs
@@ -96,6 +96,23 @@ pub(super) fn parse_lib_deps(deps_str: &str) -> Vec<String> {
     result
 }
 
+/// Parse a `PATH`-style list of paths from `PLATFORMIO_LIB_EXTRA_DIRS`.
+pub(super) fn parse_path_list(paths_str: &str) -> Vec<String> {
+    let separator = if cfg!(windows) { ';' } else { ':' };
+    let mut result = Vec::new();
+
+    for line in paths_str.lines() {
+        for path in line.split(separator) {
+            let cleaned = strip_inline_comment(path);
+            if !cleaned.is_empty() {
+                result.push(cleaned);
+            }
+        }
+    }
+
+    result
+}
+
 /// Parse a generic multi-value option from a multi-line or comma-separated string.
 pub(super) fn parse_list_values(value: &str) -> Vec<String> {
     let mut result = Vec::new();


### PR DESCRIPTION
## Summary
- add fbuild-owned minimal Arduino, Serial, SPI, wiring, and LPC804/LPC845 device-header assets for nxplpc
- install CMSIS and emit those include roots/defines through normal build_info generation
- consume `lib_extra_dirs` / `pio ci --lib` for nxplpc so FastLED can be built as an external library instead of copying headers into an example
- keep Windows canonicalized `--lib` paths usable by stripping extended path prefixes before compiler include flags
- fix the clippy-only regression from the PR branch after rebasing on current `main`

Companion FastLED PR: FastLED/FastLED#2989.

## Validation
- `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings`
- `soldr cargo test -p fbuild-build nxplpc -- --nocapture`
- `soldr cargo test -p fbuild-build extra_library -- --nocapture`
- `soldr cargo test -p fbuild-config lib_extra_dirs -- --nocapture`
- `soldr cargo test -p fbuild-cli build_pio_env_joins_libs_with_platform_separator -- --nocapture`
- `soldr cargo build -p fbuild-cli -p fbuild-daemon`
- `target\x86_64-pc-windows-msvc\debug\fbuild.exe build tests\platform\lpc804 --quick -v --no-timestamp`
- `target\x86_64-pc-windows-msvc\debug\fbuild.exe build tests\platform\lpc845 --quick -v --no-timestamp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arduino API compatibility layer for NXP LPC8xx targets, enabling Serial, SPI, GPIO, and timing operations.
  * Added support for LPC804 and LPC845 device headers with CMSIS integration.
  * Added support for extra library directories via PlatformIO configuration.

* **Documentation**
  * Updated asset documentation with new Arduino stub and device header entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->