### PR TITLE
fix(build): wire project_dir into board resolution on the daemon build path

### DIFF
--- a/crates/fbuild-build/src/pipeline/context.rs
+++ b/crates/fbuild-build/src/pipeline/context.rs
@@ -77,12 +77,23 @@ impl BuildContext {
         }
 
         // 2. Load board config
+        //
+        // Use `from_board_id_in_project` (not the legacy `from_board_id`) so
+        // a `<project_dir>/boards/<board_id>.json` file is picked up when
+        // the bundled DB has no entry. Matches PlatformIO's auto-discovery
+        // of project-local board manifests and is the only knob `fbuild
+        // build` had to honor FastLED/fbuild#515 — without this the daemon
+        // build path silently dropped the project_dir context.
         let t0 = std::time::Instant::now();
         let board_id = env_config.get("board").ok_or_else(|| {
             fbuild_core::FbuildError::ConfigError("missing 'board' in environment config".into())
         })?;
         let overrides = config.get_board_overrides(env_name)?;
-        let board = fbuild_config::BoardConfig::from_board_id(board_id, &overrides)?;
+        let board = fbuild_config::BoardConfig::from_board_id_in_project(
+            board_id,
+            &overrides,
+            Some(project_dir.as_path()),
+        )?;
         if let Some(p) = perf.as_mut() {
             p.record("board-load", t0.elapsed());
         }

--- a/crates/fbuild-build/src/script_runtime.rs
+++ b/crates/fbuild-build/src/script_runtime.rs
@@ -37,7 +37,7 @@ pub fn resolve_extra_script_overlay(
     }
 
     let project_options = config.get_env_config(env_name)?;
-    let board_config = build_script_runtime_board_config(project_options)?;
+    let board_config = build_script_runtime_board_config(project_options, Some(project_dir))?;
     let input = ScriptRuntimeInput {
         project_dir: &project_dir.to_string_lossy(),
         env_name,
@@ -290,13 +290,22 @@ fn find_python() -> Option<Vec<String>> {
 
 fn build_script_runtime_board_config(
     project_options: &HashMap<String, String>,
+    project_dir: Option<&Path>,
 ) -> fbuild_core::Result<HashMap<String, String>> {
     let mut result = HashMap::new();
     let Some(board_id) = project_options.get("board") else {
         return Ok(result);
     };
 
-    let board = fbuild_config::BoardConfig::from_board_id(board_id, &HashMap::new())?;
+    // Shares the same project-local boards/*.json resolution as the
+    // pipeline `BuildContext` and `compile_many::platform_for_board` so a
+    // user's `<project>/boards/<id>.json` is the single source of truth
+    // for every build-side board lookup. See FastLED/fbuild#515.
+    let board = fbuild_config::BoardConfig::from_board_id_in_project(
+        board_id,
+        &HashMap::new(),
+        project_dir,
+    )?;
     result.insert("name".to_string(), board.name.clone());
     result.insert("build.mcu".to_string(), board.mcu.clone());
     result.insert("build.f_cpu".to_string(), board.f_cpu.clone());


### PR DESCRIPTION
## TL;DR

#516 added project-local `boards/*.json` resolution but only wired it through `compile_many`. The far more common entry point — `fbuild build <dir> -e <env>` — goes through `BuildContext` on the daemon side, which still uses the legacy `from_board_id` (no project_dir), so 2.2.23 still fails with:

```
build error: config error: unknown board 'lpc845brk' (no built-in defaults)
```

This PR points the daemon's build path at `from_board_id_in_project`, completing the wiring for #515. **All three production board-resolution sites — `compile_many`, `pipeline::BuildContext`, `script_runtime` — now share `from_board_id_in_project`.**

## What was happening

```
fbuild build <dir> -e <env>
  └── CLI daemon_client::ensure_daemon_running()
      └── daemon receives BuildRequest
          └── pipeline::BuildContext::new_with_perf(params)
              └── from_board_id(board_id, &overrides)    ← ❌ no project_dir
```

`compile_many::platform_for_board` already used `from_board_id_in_project`, but `compile_many` is reached via `fbuild ci` / batch flows, not `fbuild build`. Daily users hit the daemon path and saw zero benefit from #516.

## Patch

| File | Change |
|---|---|
| `crates/fbuild-build/src/pipeline/context.rs` | `from_board_id` → `from_board_id_in_project(board_id, &overrides, Some(project_dir.as_path()))`. `project_dir` was already in scope (line 61). |
| `crates/fbuild-build/src/script_runtime.rs` | Thread `project_dir` through `build_script_runtime_board_config` (used by `extra_scripts` overlay setup) so it shares the same project-local fallback. |

No public API change.

## Verification

Local repro before fix (`fbuild 2.2.22` source-built off main):

```
$ target/x86_64-pc-windows-msvc/debug/fbuild.exe build <ArduinoCore-LPC8xx> -e lpc845brk
build error: config error: unknown board 'lpc845brk' (no built-in defaults)
```

After fix:

```
   0.00 =   BUILDING lpc845brk   =
   0.00 Board: NXP LPC845-BRK / LPC845 @ 30MHz
   0.00 Memory: 64.00KB Flash, 16.00KB RAM
   0.05 Toolchain: arm-none-eabi-gcc 15.2.1
   0.29 Compiled 6/6 files
   ...
```

(Hits a downstream failure that's the nxplpc orchestrator's framework-ingestion Stage 3 stub — `LED_BUILTIN` not declared because the variant header isn't pulled in. That's #479 territory, out of scope here.)

## Tests

```
soldr cargo test -p fbuild-build --lib
test result: ok. 687 passed; 0 failed
```

## Related

- Completes wiring for FastLED/fbuild#515 (project-local boards).
- An audit-of-duplicated-logic ask is being filed as a separate FR.
- The remaining `LED_BUILTIN` / framework-ingestion gap belongs to #479 (Stage 3 external-framework checkout).