### PR TITLE
feat(nxplpc): pick up project-local variants/<variant>/pins_arduino.h

### DIFF
--- a/crates/fbuild-build/src/nxplpc/assets/arduino_stub/Arduino.h
+++ b/crates/fbuild-build/src/nxplpc/assets/arduino_stub/Arduino.h
@@ -8,6 +8,20 @@
 #include <stdbool.h>
 #endif
 
+// Stage-3 hookup (FastLED/fbuild#479, partial): if the project ships its own
+// Arduino-style variant directory (e.g. zackees/ArduinoCore-LPC8xx with
+// `<project>/variants/<variant>/pins_arduino.h`), fbuild's nxplpc
+// orchestrator prepends that directory to the include path. When that's the
+// case, the variant's `pins_arduino.h` (typically `#include "variant.h"` →
+// `LED_BUILTIN`, `PIN_SPI_*`, etc.) becomes available here transparently.
+// Without a project-local variant the include is a no-op and the bundled
+// stub's behavior is unchanged.
+#if defined(__has_include)
+#  if __has_include("pins_arduino.h")
+#    include "pins_arduino.h"
+#  endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/crates/fbuild-build/src/nxplpc/orchestrator.rs
+++ b/crates/fbuild-build/src/nxplpc/orchestrator.rs
@@ -170,14 +170,39 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
         //    sketch/project discovery (libs under lib/, etc.). These fbuild-
         //    owned roots replace the misplaced example-local include tree from
         //    FastLED/FastLED#2988 and flow into build_info.json.
+        //
+        //    Stage-3 hookup (partial, FastLED/fbuild#479): when the project
+        //    ships an Arduino-style hardware-package layout next to its
+        //    `platformio.ini` (`<project>/variants/<variant>/pins_arduino.h`,
+        //    a la zackees/ArduinoCore-LPC8xx), prepend that variant dir to
+        //    the include path. The bundled `Arduino.h` stub conditionally
+        //    `#include "pins_arduino.h"` when `__has_include` succeeds, so
+        //    LED_BUILTIN / PIN_SPI_* / pin maps become available with no
+        //    other code changes. Project-local takes precedence so symbols
+        //    from the real variant always win over any stub default.
         let build_dir = crate::compiler::absolute_from_cwd(&ctx.build_dir);
         let src_dir = crate::compiler::absolute_from_cwd(&ctx.src_dir);
-        let mut include_dirs = vec![
+        let project_dir_abs = crate::compiler::absolute_from_cwd(&params.project_dir);
+        let mut include_dirs: Vec<PathBuf> = Vec::with_capacity(8);
+        let project_variant_dir = project_dir_abs
+            .join("variants")
+            .join(&ctx.board.variant);
+        if project_variant_dir.join("pins_arduino.h").is_file() {
+            tracing::info!(
+                "nxplpc: using project-local variant include {}",
+                project_variant_dir.display()
+            );
+            include_dirs.push(project_variant_dir);
+            // Also expose the parent variants/ dir so that variant-chain
+            // includes like `#include "../<base>/variant.h"` resolve.
+            include_dirs.push(project_dir_abs.join("variants"));
+        }
+        include_dirs.extend([
             build_dir.join("arduino_stub"),
             build_dir.join("device_headers"),
             cmsis.get_core_include_dir(),
             src_dir,
-        ];
+        ]);
         pipeline::discover_project_includes(&params.project_dir, &mut include_dirs);
         let lib_extra_dirs = ctx.config.get_lib_extra_dirs(&params.env_name)?;
         let extra_library_roots =


### PR DESCRIPTION
Minimum cheap step toward FastLED/fbuild#479 (Stage 3) — gets a real Arduino-style hardware-package project building under fbuild without a full external-framework checkout flow.

## What

When the project ships `<project>/variants/<variant>/pins_arduino.h` next to its `platformio.ini` (e.g. [zackees/ArduinoCore-LPC8xx](https://github.com/zackees/ArduinoCore-LPC8xx)), the nxplpc orchestrator prepends the variant dir to the include path. The bundled `Arduino.h` stub gains a `__has_include` guard that pulls in `pins_arduino.h` when it's available, transparently surfacing `LED_BUILTIN`, `PIN_SPI_*`, etc. Without a project-local variant the include is a no-op — bundled stub behavior is preserved for the existing test fixtures.

## Verified locally

Against `zackees/ArduinoCore-LPC8xx examples/Blink`:

**Before:**

```
Blink.ino:5:13: error: 'LED_BUILTIN' was not declared in this scope
```

**After (real artifact emitted):**

```
Board: NXP LPC845-BRK / LPC845 @ 30MHz
Memory: 64.00KB Flash, 16.00KB RAM
Compiled 6/6 files
Compiled 1/1 files
Linking firmware.elf
Building firmware.bin
Flash: 384 bytes / 64.00KB (0.6%)
RAM:   8 bytes / 16.00KB (0.0%)
build succeeded in 1.8s (flash: 384 bytes, ram: 8 bytes)
```

`firmware.bin` and `firmware.elf` produced at the expected path.

## Tests

```
soldr cargo test -p fbuild-build nxplpc --lib
test result: ok. 18 passed; 0 failed
```

## What this does NOT do

Intentionally scoped to the cheapest user-unblock:

- Does **not** compile user-provided `cores/<core>/` sources — the bundled `arduino_stub/` + `lpc8xx_main.cpp` shim still owns the runtime.
- Does **not** honor `board_build.ldscript`; bundled per-MCU linker script still wins.
- Does **not** resolve `framework-arduino-lpc8xx` via PlatformIO's package manager.

Those are the remaining Stage 3 pieces (#479). Filed separately if anyone wants to take them.

## Why this scoping

`zackees/ArduinoCore-LPC8xx`'s fbuild CI is currently red exclusively on `LED_BUILTIN`. Adding the variant dir to the include path is the surgical fix; full external-framework ingestion is a larger lift that can land independently. Doing the smaller change first means we ship green CI now and can take the bigger refactor when there's time.