### PR TITLE
docs: restructure README taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,517 +1,176 @@
+# fbuild
+
 ![fbuild](https://github.com/user-attachments/assets/7db78eba-b10f-44c7-ae32-7fc0b5e46642)
 
-*A fast, next-generation multi-platform compiler, deployer, and monitor for embedded development, directly compatible with `platformio.ini`.*
-
-## CI status
+`fbuild` is a fast, multi-platform compiler, deployer, emulator runner, and
+serial monitor for embedded development. It reads the same `platformio.ini`
+files already used by PlatformIO sketches, but uses a Rust-native, data-driven
+build pipeline.
 
 [![Check Ubuntu](https://github.com/fastled/fbuild/actions/workflows/check-ubuntu.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/check-ubuntu.yml)
 [![Check macOS](https://github.com/fastled/fbuild/actions/workflows/check-macos.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/check-macos.yml)
 [![Check Windows](https://github.com/fastled/fbuild/actions/workflows/check-windows.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/check-windows.yml)
 [![Formatting](https://github.com/fastled/fbuild/actions/workflows/fmt.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/fmt.yml)
-[![Min Rust Version](https://github.com/fastled/fbuild/actions/workflows/msrv.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/msrv.yml)
 [![Documentation](https://github.com/fastled/fbuild/actions/workflows/docs.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/docs.yml)
-[![Validate Boards](https://github.com/fastled/fbuild/actions/workflows/validate-boards.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/validate-boards.yml)
 [![Build Native Binaries](https://github.com/fastled/fbuild/actions/workflows/build.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build.yml)
-[![Library Selection Acceptance (#205)](https://github.com/fastled/fbuild/actions/workflows/acceptance-205.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/acceptance-205.yml)
-[![Library Selection Perf (#205)](https://github.com/fastled/fbuild/actions/workflows/bench-205.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/bench-205.yml)
-[![LOC Gate](https://github.com/fastled/fbuild/actions/workflows/loc-gate.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/loc-gate.yml)
-
-<details>
-<summary><strong>Per-platform board build badges</strong> (click to expand)</summary>
-
-### AVR
-[![Build Arduino Uno](https://github.com/fastled/fbuild/actions/workflows/build-uno.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-uno.yml)
-[![Build Leonardo](https://github.com/fastled/fbuild/actions/workflows/build-leonardo.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-leonardo.yml)
-[![Build ATmega8A](https://github.com/fastled/fbuild/actions/workflows/build-atmega8a.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-atmega8a.yml)
-[![Build ATtiny85](https://github.com/fastled/fbuild/actions/workflows/build-attiny85.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny85.yml)
-[![Build ATtiny88](https://github.com/fastled/fbuild/actions/workflows/build-attiny88.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny88.yml)
-[![Build ATtiny4313](https://github.com/fastled/fbuild/actions/workflows/build-attiny4313.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny4313.yml)
-
-### MegaAVR
-[![Build ATtiny1604](https://github.com/fastled/fbuild/actions/workflows/build-attiny1604.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny1604.yml)
-[![Build ATtiny1616](https://github.com/fastled/fbuild/actions/workflows/build-attiny1616.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-attiny1616.yml)
-[![Build Nano Every](https://github.com/fastled/fbuild/actions/workflows/build-nano_every.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nano_every.yml)
-
-### Renesas
-[![Build UNO R4 WiFi](https://github.com/fastled/fbuild/actions/workflows/build-uno_r4_wifi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-uno_r4_wifi.yml)
-
-### ESP8266
-[![Build ESP8266](https://github.com/fastled/fbuild/actions/workflows/build-esp8266.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp8266.yml)
-
-### ESP32
-[![Build ESP32 Dev](https://github.com/fastled/fbuild/actions/workflows/build-esp32dev.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32dev.yml)
-[![Build ESP32-C2](https://github.com/fastled/fbuild/actions/workflows/build-esp32c2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c2.yml)
-[![Build ESP32-C3](https://github.com/fastled/fbuild/actions/workflows/build-esp32c3.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c3.yml)
-[![Build ESP32-C5](https://github.com/fastled/fbuild/actions/workflows/build-esp32c5.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c5.yml)
-[![Build ESP32-C6](https://github.com/fastled/fbuild/actions/workflows/build-esp32c6.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32c6.yml)
-[![Build ESP32-H2](https://github.com/fastled/fbuild/actions/workflows/build-esp32h2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32h2.yml)
-[![Build ESP32-P4](https://github.com/fastled/fbuild/actions/workflows/build-esp32p4.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32p4.yml)
-[![Build ESP32-S2](https://github.com/fastled/fbuild/actions/workflows/build-esp32s2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32s2.yml)
-[![Build ESP32-S3](https://github.com/fastled/fbuild/actions/workflows/build-esp32s3.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-esp32s3.yml)
-
-### CH32V (RISC-V)
-[![Build CH32V003](https://github.com/fastled/fbuild/actions/workflows/build-ch32v003.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v003.yml)
-[![Build CH32V103](https://github.com/fastled/fbuild/actions/workflows/build-ch32v103.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v103.yml)
-[![Build CH32V203](https://github.com/fastled/fbuild/actions/workflows/build-ch32v203.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v203.yml)
-[![Build CH32V208](https://github.com/fastled/fbuild/actions/workflows/build-ch32v208.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v208.yml)
-[![Build CH32V303](https://github.com/fastled/fbuild/actions/workflows/build-ch32v303.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v303.yml)
-[![Build CH32V307](https://github.com/fastled/fbuild/actions/workflows/build-ch32v307.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32v307.yml)
-
-### CH32X (RISC-V, USB PD)
-[![Build CH32X035](https://github.com/fastled/fbuild/actions/workflows/build-ch32x035.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-ch32x035.yml)
-
-### Teensy
-[![Build Teensy 4.1](https://github.com/fastled/fbuild/actions/workflows/build-teensy41.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy41.yml)
-[![Build Teensy 4.0](https://github.com/fastled/fbuild/actions/workflows/build-teensy40.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy40.yml)
-[![Build Teensy 3.6](https://github.com/fastled/fbuild/actions/workflows/build-teensy36.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy36.yml)
-[![Build Teensy 3.5](https://github.com/fastled/fbuild/actions/workflows/build-teensy35.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy35.yml)
-[![Build Teensy 3.2](https://github.com/fastled/fbuild/actions/workflows/build-teensy32.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy32.yml)
-[![Build Teensy 3.1](https://github.com/fastled/fbuild/actions/workflows/build-teensy31.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy31.yml)
-[![Build Teensy 3.0](https://github.com/fastled/fbuild/actions/workflows/build-teensy30.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensy30.yml)
-[![Build Teensy LC](https://github.com/fastled/fbuild/actions/workflows/build-teensylc.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-teensylc.yml)
-
-### STM32
-[![Build STM32F103C8](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103c8.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103c8.yml)
-[![Build STM32F103CB](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103cb.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103cb.yml)
-[![Build STM32F103TB](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103tb.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f103tb.yml)
-[![Build STM32F411CE](https://github.com/fastled/fbuild/actions/workflows/build-stm32f411ce.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32f411ce.yml)
-[![Build STM32H747XI](https://github.com/fastled/fbuild/actions/workflows/build-stm32h747xi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-stm32h747xi.yml)
-[![Build Nucleo F429ZI](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f429zi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f429zi.yml)
-[![Build Nucleo F439ZI](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f439zi.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nucleo_f439zi.yml)
-[![Build Arduino Giga R1](https://github.com/fastled/fbuild/actions/workflows/build-giga-r1.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-giga-r1.yml)
-
-### SAM / SAMD
-[![Build Arduino Due](https://github.com/fastled/fbuild/actions/workflows/build-sam3x8e_due.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-sam3x8e_due.yml)
-[![Build SAMD21](https://github.com/fastled/fbuild/actions/workflows/build-samd21.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd21.yml)
-[![Build Arduino Zero](https://github.com/fastled/fbuild/actions/workflows/build-samd21_zero.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd21_zero.yml)
-[![Build SAMD51J](https://github.com/fastled/fbuild/actions/workflows/build-samd51j.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd51j.yml)
-[![Build SAMD51P](https://github.com/fastled/fbuild/actions/workflows/build-samd51p.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-samd51p.yml)
-
-### RP2040 / RP2350
-[![Build RP2040](https://github.com/fastled/fbuild/actions/workflows/build-rp2040.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rp2040.yml)
-[![Build RP2350](https://github.com/fastled/fbuild/actions/workflows/build-rp2350.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rp2350.yml)
-
-### Nordic NRF52
-[![Build nRF52840 DK](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml)
-[![Build SuperMini nRF52840](https://github.com/fastled/fbuild/actions/workflows/build-supermini_nrf52840.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-supermini_nrf52840.yml)
-[![Build nice!nano nRF52840](https://github.com/fastled/fbuild/actions/workflows/build-nice_nano_nrf52840.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nice_nano_nrf52840.yml)
-[![Build nRFMicro nRF52840](https://github.com/fastled/fbuild/actions/workflows/build-nrfmicro_nrf52840.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrfmicro_nrf52840.yml)
-
-### Apollo3
-[![Build Apollo3 RedBoard](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_red.yml)
-[![Build Apollo3 expLoRaBLE](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-apollo3_thing_explorable.yml)
-
-### NXP LPC (Cortex-M0+)
-[![Build LPC804](https://github.com/fastled/fbuild/actions/workflows/build-lpc804.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc804.yml)
-[![Build LPC845](https://github.com/fastled/fbuild/actions/workflows/build-lpc845.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc845.yml)
-
-### Silicon Labs
-[![Build MGM240](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-mgm240.yml)
-
-### NRF52
-[![Build Adafruit Feather NRF52840 Sense](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840-sense.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840-sense.yml)
-[![Build NRF52840 DK](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-nrf52840_dk.yml)
-
-### Raspberry Pi Pico
-[![Build Raspberry Pi Pico](https://github.com/fastled/fbuild/actions/workflows/build-rpipico.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rpipico.yml)
-[![Build Raspberry Pi Pico 2](https://github.com/fastled/fbuild/actions/workflows/build-rpipico2.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-rpipico2.yml)
-
-### Silicon Labs
-[![Build SparkFun Thing Plus Matter](https://github.com/fastled/fbuild/actions/workflows/build-thingplusmatter.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-thingplusmatter.yml)
-
-</details>
-
-Board descriptions and family deep-dives live in [`docs/BOARD_STATUS.md`](docs/BOARD_STATUS.md).
-
-# fbuild
-
-`fbuild` is a next-generation embedded development tool featuring a clean, extensible, data-driven architecture. It provides fast incremental builds, URL-based package management, and comprehensive multi-platform support for Arduino and ESP32 development.
-
-**`platformio.ini` compatible** — fbuild uses the same `platformio.ini` already used in your PlatformIO sketches.
-
-Note: fbuild's release binaries on Teensy/STM32/RP2040/NRF52/ESP8266 are smaller than PlatformIO's by default due to `.eh_frame` stripping — see the [`PlatformIO compatibility: .eh_frame strip`](#platformio-compatibility-eh_frame-strip) section.
-
-**Current status**: v2.0.6 — Rust rewrite. Full ESP32 / Teensy support with a working build system.
-
-## Docs index
-
-For a full FAQ-style map of every doc in this repo, see [`docs/INDEX.md`](docs/INDEX.md). Common entry points:
-
-- **Why fbuild exists, key benefits, performance** → [`docs/WHY.md`](docs/WHY.md)
-- **Is my board supported?** → [`docs/BOARD_STATUS.md`](docs/BOARD_STATUS.md)
-- **Architecture / daemon / serial internals** → [`docs/architecture/`](docs/architecture/) (start at [`overview.md`](docs/architecture/overview.md))
-- **Crate dependency graph** → [`crates/CLAUDE.md`](crates/CLAUDE.md)
-- **Testing, troubleshooting, local setup** → [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
-- **Design decisions (ADRs)** → [`docs/DESIGN_DECISIONS.md`](docs/DESIGN_DECISIONS.md)
-- **Implementation roadmap** → [`docs/ROADMAP.md`](docs/ROADMAP.md)
 
 ## Installation
 
 ```bash
-# Install from PyPI
 pip install fbuild
-
-# Or install from source
-git clone https://github.com/fastled/fbuild.git
-cd fbuild
-pip install -e .
 ```
+
+For source installs, platform notes, and first-run cache behavior, start with
+the [getting started guide](docs/getting-started/README.md).
 
 ## Quick Start
 
-### Build an Arduino Uno project
+Create a minimal Arduino project:
 
-1. **Create project structure**:
-   ```bash
-   mkdir my-project && cd my-project
-   mkdir src
-   ```
+```bash
+mkdir my-project
+cd my-project
+mkdir src
+```
 
-2. **Create `platformio.ini`**:
-   ```ini
-   [env:uno]
-   platform = atmelavr
-   board = uno
-   framework = arduino
-   ```
+Add `platformio.ini`:
 
-3. **Write your sketch** (`src/main.ino`):
-   ```cpp
-   void setup() {
-     pinMode(LED_BUILTIN, OUTPUT);
-   }
+```ini
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+```
 
-   void loop() {
-     digitalWrite(LED_BUILTIN, HIGH);
-     delay(1000);
-     digitalWrite(LED_BUILTIN, LOW);
-     delay(1000);
-   }
-   ```
+Add `src/main.ino`:
 
-4. **Build**:
-   ```bash
-   fbuild build
-   ```
+```cpp
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
+}
 
-On first build, fbuild will download the AVR-GCC toolchain (~50MB, one-time), download the Arduino AVR core (~5MB, one-time), compile your sketch, and emit `firmware.hex` under `.fbuild/build/uno/`.
+void loop() {
+  digitalWrite(LED_BUILTIN, HIGH);
+  delay(1000);
+  digitalWrite(LED_BUILTIN, LOW);
+  delay(1000);
+}
+```
 
-**Build time**: ~19s first build, ~3s subsequent builds, <1s incremental.
+Build it:
+
+```bash
+fbuild build
+```
+
+On the first build, fbuild downloads the toolchain and framework packages it
+needs, then caches them for later builds. A successful Uno build writes
+`.fbuild/build/uno/firmware.hex`.
 
 ## Examples
 
-Build, deploy, and monitor in one command:
+Common workflows:
 
 ```bash
-# Default action: build + deploy
-fbuild tests/platform/esp32c6
-
-# Default action: build + deploy + monitor
-fbuild tests/platform/esp32c6 --monitor
+fbuild build
+fbuild deploy --clean
+fbuild deploy --monitor
+fbuild test-emu . -e uno
+fbuild monitor --timeout 60 --halt-on-success "TEST PASSED"
 ```
 
-**Deploy commands**:
+Detailed build, deploy, monitor, and emulator examples live in the
+[CLI reference](docs/reference/cli.md) and
+[emulator testing guide](docs/guides/emulator-testing.md).
 
-```bash
-# Deploy with clean build
-fbuild deploy tests/platform/esp32c6 --clean
+## Docs Index
 
-# Deploy with monitoring and test patterns
-fbuild deploy tests/platform/esp32c6 \
-  --monitor="--timeout 60 --halt-on-error \"TEST FAILED\" --halt-on-success \"TEST PASSED\""
+The full FAQ-style map is [`docs/INDEX.md`](docs/INDEX.md). Common entry
+points:
 
-# Deploy to the default emulator backend
-fbuild deploy tests/platform/uno -e uno --to emu
+| Goal | Start here |
+|---|---|
+| Install fbuild and run the first build | [`docs/getting-started/`](docs/getting-started/README.md) |
+| Use build, deploy, monitor, or test-emu | [`docs/reference/cli.md`](docs/reference/cli.md) |
+| Configure `platformio.ini` | [`docs/reference/platformio-ini.md`](docs/reference/platformio-ini.md) |
+| Check board and platform support | [`docs/platforms/`](docs/platforms/README.md) |
+| Understand the project rationale | [`docs/WHY.md`](docs/WHY.md) |
+| Work on fbuild itself | [`docs/development/`](docs/development/README.md) |
+| Read architecture internals | [`docs/architecture/overview.md`](docs/architecture/overview.md) |
 
-# Deploy to the default emulator backend and open the monitor page
-fbuild deploy tests/platform/uno -e uno --to emu --monitor
+## Key Features
 
-# Deploy ESP32-S3 to the default emulator backend
-fbuild deploy tests/platform/esp32s3 -e esp32s3 --to emu --monitor --timeout 10 --verbose
+- `platformio.ini` compatibility for existing Arduino and ESP32 sketches
+- Fast incremental builds with cached toolchains, frameworks, and libraries
+- URL-based package and library management, including GitHub `lib_deps`
+- Build, deploy, serial monitor, and emulator test workflows from one CLI
+- Cross-platform support on Windows, macOS, and Linux
+- Transparent architecture with Rust workspace internals documented under
+  [`docs/architecture/`](docs/architecture/README.md)
 
-# Deploy to an explicit emulator backend
-fbuild deploy tests/platform/esp32s3 -e esp32s3 --to emu --emulator qemu --monitor --timeout 10
-```
-
-**`test-emu`** — build + run in emulator in one step (CI-friendly, exits with emulator exit code):
-
-```bash
-# Auto-detect emulator backend from the board
-fbuild test-emu tests/platform/uno -e uno
-
-# Explicit backend, with pattern matching
-fbuild test-emu tests/platform/esp32s3 -e esp32s3 --emulator qemu --timeout 10
-
-# AVR with simavr backend
-fbuild test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
-
-# Halt on first test result
-fbuild test-emu tests/platform/uno -e uno \
-  --halt-on-success "TEST PASSED" --halt-on-error "TEST FAILED"
-```
-
-| Option | Description |
-|--------|-------------|
-| `--emulator <backend>` | Force backend: `avr8js`, `qemu`, or `simavr` (auto-detected if omitted) |
-| `--timeout <secs>` | Kill the emulator after N seconds |
-| `--halt-on-success <regex>` | Stop and report pass when pattern matches |
-| `--halt-on-error <regex>` | Stop and report fail when pattern matches |
-| `--expect <regex>` | Require this pattern in output (fail on timeout if missing) |
-| `--no-timestamp` | Disable timestamp prefix on output lines |
-| `-v, --verbose` | Show emulator command and build details |
-
-**Monitor command**:
-
-```bash
-# Monitor serial output with pattern matching
-fbuild monitor --timeout 60 --halt-on-error "TEST FAILED" --halt-on-success "TEST PASSED"
-```
-
-Serial monitoring requires pyserial to attach to the USB device. Port auto-detection works similarly to PlatformIO.
-
-## Emulator testing
-
-fbuild can build and run firmware in emulators without physical hardware. Two entry points:
-
-- **`fbuild test-emu`** — one-shot build + emulate + exit (CI-friendly)
-- **`fbuild deploy --to emu`** — deploy flow with optional `--monitor`
-
-Both auto-detect the emulator backend from the board, or accept `--emulator <backend>`.
-
-### Emulator backends
-
-| Backend | Platforms | MCUs | Requirements |
-|---------|-----------|------|--------------|
-| **avr8js** | AtmelAVR | ATmega328P | Node.js (bundled headless script) |
-| **simavr** | AtmelAVR, MegaAVR | ATmega2560, ATmega32U4, and others | `simavr` binary on PATH |
-| **qemu** | Espressif32 | ESP32, ESP32-S3 (Xtensa); ESP32-C3, ESP32-C6, ESP32-H2 (RISC-V) | Native QEMU (auto-downloaded) |
-
-Auto-detection rules when `--emulator` is omitted:
-
-- ATmega328P defaults to **avr8js** (no external binary needed)
-- Other AVR MCUs with `simavr` in `debug_tools` default to **simavr**
-- ESP32, ESP32-S3 (Xtensa) and ESP32-C3, ESP32-C6, ESP32-H2 (RISC-V) default to **qemu**
-
-### QEMU notes
-
-ESP32-family QEMU runs from a normal Arduino environment. fbuild launches the correct Espressif QEMU binary (`qemu-system-xtensa` for ESP32/ESP32-S3; `qemu-system-riscv32` for ESP32-C3/C6/H2) based on the selected `board`. The required QEMU build flags are injected automatically when deploying to `--to emu`.
-
-```ini
-[env:esp32s3]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
-board = esp32-s3-devkitc-1
-framework = arduino
-board_build.flash_mode = dio
-board_upload.flash_mode = dio
-
-[env:esp32c3]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
-board = esp32-c3-devkitm-1
-framework = arduino
-board_build.flash_mode = dio
-board_upload.flash_mode = dio
-```
-
-QEMU requires DIO flash mode. Boards configured with `qio` or `qout` will fail fast before building.
-
-QEMU runtime is native-only. Supported hosts: Linux x86_64/arm64, macOS x86_64/arm64, Windows x86_64. On Windows, fbuild stages the required QEMU runtime DLLs for the managed install.
-
-**Known limitations**:
-
-1. **ESP32 QEMU** supports ESP32, ESP32-S3 (Xtensa) and ESP32-C3, ESP32-C6, ESP32-H2 (RISC-V). ESP32-S2 and ESP32-P4 are not yet supported by upstream Espressif QEMU.
-2. **QEMU-specific firmware patching**: fbuild patches the generated ESP32-S3 app image for QEMU to bypass an ADC calibration constructor that hangs under emulation, then repairs the image checksum and hash. RISC-V variants (C3/C6/H2) do not require this patch.
-3. **Performance**: QEMU emulation is slower than real hardware. Use it for functional validation, not timing-sensitive behavior.
-4. **Peripheral coverage**: Not all peripherals are fully emulated. Real hardware is still required for production validation.
+See [`docs/WHY.md`](docs/WHY.md) for the full rationale, benefits, and
+performance notes.
 
 ## CLI Usage
 
-### Build
-
-```bash
-# Build with auto-detected environment
-fbuild build
-
-# Build a specific environment
-fbuild build --environment uno
-fbuild build -e mega
-
-# Clean build (remove all build artifacts)
-fbuild build --clean
-
-# Verbose output (shows all compiler commands)
-fbuild build --verbose
-
-# Build in a different directory
-fbuild build --project-dir /path/to/project
-```
-
-Typical output:
-
-```
-Building environment: uno
-Downloading toolchain: avr-gcc 7.3.0-atmel3.6.1-arduino7
-Downloading: 100% ████████████████████ 50.1MB/50.1MB
-Extracting package...
-Toolchain ready at: .fbuild/cache/...
-Downloading Arduino core: 1.8.6
-Compiling sketch...
-Compiling Arduino core...
-Linking firmware...
-Converting to Intel HEX...
-
-✓ Build successful!
-
-Firmware: .fbuild/build/uno/firmware.hex
-Program: 1058 bytes (3.3% of 32256 bytes)
-RAM: 9 bytes (0.4% of 2048 bytes)
-Build time: 3.06s
-```
+The user-facing command reference is
+[`docs/reference/cli.md`](docs/reference/cli.md). It covers core workflows
+(`build`, `deploy`, `monitor`, `test-emu`) and diagnostics such as `symbols`,
+`bloat`, `lib-select`, `compile-many`, and `ci`.
 
 ## Configuration
 
-### `platformio.ini` summary
+fbuild reads `platformio.ini` project files. The configuration reference,
+including `default_envs`, `build_flags`, `lib_deps`, upload and monitor
+settings, and compatibility notes, lives in
+[`docs/reference/platformio-ini.md`](docs/reference/platformio-ini.md).
 
-**Minimal configuration**:
+## Emulator Testing
 
-```ini
-[env:uno]
-platform = atmelavr
-board = uno
-framework = arduino
-```
+fbuild can build firmware and run it without hardware via `fbuild test-emu` or
+`fbuild deploy --to emu`. Emulator backends, auto-detection rules, QEMU notes,
+and known limitations live in
+[`docs/guides/emulator-testing.md`](docs/guides/emulator-testing.md).
 
-**Fuller configuration**:
+## PlatformIO Compatibility: `.eh_frame` Strip
 
-```ini
-[platformio]
-default_envs = uno
+On supported release builds, fbuild may strip unused GCC `.eh_frame` unwind
+metadata to reduce firmware size. The policy, opt-out controls, and rationale
+are documented in
+[`docs/reference/platformio-compatibility.md`](docs/reference/platformio-compatibility.md).
 
-[env:uno]
-platform = atmelavr
-board = uno
-framework = arduino
-upload_port = COM3
-monitor_speed = 9600
-build_flags =
-    -DDEBUG
-    -DLED_PIN=13
-lib_deps =
-    https://github.com/FastLED/FastLED
-    https://github.com/adafruit/Adafruit_NeoPixel
-```
+## Supported Platforms
 
-### Library dependencies
+fbuild supports AVR, MegaAVR, Renesas RA, ESP8266, ESP32 variants, CH32
+RISC-V, Teensy, STM32, SAM/SAMD, RP2040/RP2350, Nordic NRF52, Apollo3,
+Silicon Labs EFR32, NXP LPC, and WASM via Emscripten.
 
-fbuild supports downloading and compiling Arduino libraries directly from GitHub URLs:
+For the canonical per-board CI badge matrix, support table, and board-family
+notes, see [`docs/BOARD_STATUS.md`](docs/BOARD_STATUS.md) or the
+[platforms docs](docs/platforms/README.md).
 
-```ini
-[env:uno]
-platform = atmelavr
-board = uno
-framework = arduino
-lib_deps =
-    https://github.com/FastLED/FastLED
-```
+## Project Structure
 
-Features:
-
-- Automatic GitHub URL optimization (converts repo URLs to zip downloads)
-- Automatic branch detection (main vs master)
-- Proper Arduino library structure handling
-- LTO (Link-Time Optimization) for optimal code size
-- Support for complex libraries with assembly optimizations
-
-## Key features
-
-- **URL-based package management** — direct URLs to toolchains and platforms, no hidden registries
-- **Library management** — download and compile Arduino libraries from GitHub URLs
-- **Fast incremental builds** — 0.76s rebuilds, 3s full builds (cached)
-- **LTO support** — Link-Time Optimization for optimal code size
-- **Transparent architecture** — know exactly what's happening at every step
-- **Real downloads, no mocks** — all packages are real, validated, and checksummed
-- **Cross-platform** — Windows, macOS, and Linux
-- **`platformio.ini` compatible** — drop-in replacement for PlatformIO builds
-
-See [`docs/WHY.md`](docs/WHY.md) for the full rationale, benefits, and performance benchmarks.
-
-## PlatformIO compatibility: `.eh_frame` strip
-
-By default, fbuild strips GCC's `.eh_frame` exception-unwinding tables on release builds for platforms that don't use them (Teensy, STM32, RP2040, NRF52, ESP8266). This saves 40–180 KB of flash on a typical FastLED sketch. PlatformIO does not do this — running the same project under `pio run` produces a larger binary. ESP32 with the stock Arduino sdkconfig preserves `.eh_frame` because `esp32_exception_decoder` and panic-print-backtrace consume it.
-
-### Policy
-
-The decision is made per build via the following precedence (first match wins):
-
-| Condition | Policy |
-|---|---|
-| `FBUILD_STRIP_EH_FRAME=1` env var | Strip |
-| `FBUILD_KEEP_EH_FRAME=1` env var | Preserve |
-| `build_type = debug` in platformio.ini | Preserve |
-| `-fexceptions` / `-funwind-tables` / `-fasynchronous-unwind-tables` in `build_flags` | Preserve |
-| ESP32 with `CONFIG_ESP_SYSTEM_PANIC_PRINT_BACKTRACE=y` (Arduino default) | Preserve |
-| Otherwise (release on Teensy/STM32/RP2040/NRF52/ESP8266) | Strip |
-
-### Opt out (per project)
-
-Add an unwind-tables flag to your `platformio.ini` to keep `.eh_frame` for a specific environment:
-
-```ini
-[env:teensy41]
-platform = teensy
-board = teensy41
-framework = arduino
-build_flags = -funwind-tables
-```
-
-Or set an environment variable to force preservation for any build:
-
-```bash
-FBUILD_KEEP_EH_FRAME=1 fbuild build
-```
-
-### Why we deviate
-
-GCC emits `.eh_frame` by default even when nothing consumes it. On the platforms above, the toolchain JSON already ships `-fno-exceptions`, no runtime calls `_Unwind_*`, and no debugger or decoder reads the tables — so `.eh_frame` is pure dead metadata occupying flash. A byte-level audit on an ESP32-S3 FastLED Blink build ([FastLED/FastLED#2473](https://github.com/FastLED/FastLED/issues/2473)) found `.eh_frame` accounted for 36% of firmware size. Stripping it at the compiler level (cc1 flags `-fno-asynchronous-unwind-tables -fno-unwind-tables`) is the only reliable fix; library-side pragmas are no-ops on modern GCC. Implementation details and the full decision matrix are in [#245](https://github.com/fastled/fbuild/pull/245).
-
-## Supported platforms
-
-fbuild supports AVR, MegaAVR, Renesas RA, ESP8266, ESP32 (all variants incl. S2/S3/C2/C3/C5/C6/H2/P4), CH32V/CH32X RISC-V, Teensy (LC–4.1), STM32, Atmel SAM/SAMD, RP2040/RP2350, Nordic NRF52, Apollo3, Silicon Labs EFR32, and WASM via Emscripten.
-
-For the live per-platform CI badge matrix, per-board status, and family deep-dives, see [`docs/BOARD_STATUS.md`](docs/BOARD_STATUS.md).
-
-## Project structure
-
-The repo is a Rust workspace. For the full crate dependency graph and per-crate responsibilities, see [`crates/CLAUDE.md`](crates/CLAUDE.md).
-
-A typical user project on disk looks like:
-
-```
-my-project/
-├── platformio.ini       # Configuration file
-├── src/
-│   ├── main.ino         # Your Arduino sketch
-│   └── helpers.cpp      # Additional C++ files
-└── .fbuild/             # Build artifacts (auto-generated)
-    ├── cache/
-    │   ├── packages/    # Downloaded toolchains
-    │   └── extracted/   # Arduino cores
-    └── build/
-        └── uno/
-            ├── src/           # Compiled sketch objects
-            ├── core/          # Compiled Arduino core
-            └── firmware.hex   # Final output ← upload this
-```
+The repository is a Rust workspace with a Python package boundary. The human
+development guide is [`docs/development/`](docs/development/README.md), and the
+crate dependency map is [`crates/CLAUDE.md`](crates/CLAUDE.md).
 
 ## Architecture
 
-Architecture docs are decentralized under [`docs/architecture/`](docs/architecture/). Start with [`overview.md`](docs/architecture/overview.md), then read the subsystem-specific docs listed in [`docs/CLAUDE.md`](docs/CLAUDE.md).
+Architecture docs are decentralized under
+[`docs/architecture/`](docs/architecture/README.md). Start with
+[`docs/architecture/overview.md`](docs/architecture/overview.md), then follow
+the subsystem-specific docs.
 
 ## Development
 
-Testing, troubleshooting, linting, and local setup instructions live in [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md). Project-wide rules for contributors and LLM agents are in [`CLAUDE.md`](CLAUDE.md).
+Testing, troubleshooting, linting, release, and local setup instructions live
+in [`docs/development/`](docs/development/README.md). Project-wide rules for
+contributors and LLM agents are in [`CLAUDE.md`](CLAUDE.md).
 
 ## License
 
-In the spirit of Dan Garcia's permissively licensed software, `fbuild` is presented as free software.
+In the spirit of Dan Garcia's permissively licensed software, `fbuild` is
+presented as free software.
 
 BSD 3-Clause License

--- a/crates/fbuild-build/src/nxplpc/orchestrator.rs
+++ b/crates/fbuild-build/src/nxplpc/orchestrator.rs
@@ -184,9 +184,7 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
         let src_dir = crate::compiler::absolute_from_cwd(&ctx.src_dir);
         let project_dir_abs = crate::compiler::absolute_from_cwd(&params.project_dir);
         let mut include_dirs: Vec<PathBuf> = Vec::with_capacity(8);
-        let project_variant_dir = project_dir_abs
-            .join("variants")
-            .join(&ctx.board.variant);
+        let project_variant_dir = project_dir_abs.join("variants").join(&ctx.board.variant);
         if project_variant_dir.join("pins_arduino.h").is_file() {
             tracing::info!(
                 "nxplpc: using project-local variant include {}",

--- a/docs/BOARD_STATUS.md
+++ b/docs/BOARD_STATUS.md
@@ -1,6 +1,9 @@
 # Board Status
 
-Live per-platform CI status and supported-board reference for fbuild.
+Live per-platform CI status and supported-board reference for fbuild. This is
+the canonical board/platform status document; the root README keeps only a
+short platform summary so per-board badges and support notes do not drift
+between files.
 
 ## Per-platform CI badges
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,52 +1,68 @@
 # Documentation Index
 
-A grep-friendly FAQ that maps common questions to the file that answers them. Both humans and LLM agents should use this table as the entry point into the fbuild docs.
+A grep-friendly FAQ that maps common questions to the file that answers them.
+Both humans and LLM agents should use this table as the entry point into the
+fbuild docs.
 
-| Question                                                  | File                                                       |
-|-----------------------------------------------------------|------------------------------------------------------------|
-| How do I install fbuild?                                  | [../README.md](../README.md#installation)                  |
-| How do I run my first build / deploy / monitor?           | [../README.md](../README.md#quick-start)                   |
-| What does `platformio.ini` need to contain?               | [../README.md](../README.md#configuration)                 |
-| Why does fbuild exist?                                    | [WHY.md](WHY.md)                                           |
-| What are fbuild's key benefits and performance numbers?   | [WHY.md](WHY.md#key-benefits)                              |
-| Is my board supported?                                    | [BOARD_STATUS.md](BOARD_STATUS.md)                         |
-| How do I add a new board?                                  | [BOARD_STATUS.md](BOARD_STATUS.md#adding-a-new-board)      |
-| What's the crate dependency graph?                        | [../crates/CLAUDE.md](../crates/CLAUDE.md)                 |
-| How does fbuild's architecture fit together?              | [architecture/overview.md](architecture/overview.md)       |
-| How does the daemon work?                                 | [architecture/runtime.md](architecture/runtime.md)         |
-| How does the serial / monitor subsystem work?             | [architecture/serial.md](architecture/serial.md)           |
-| How do the PyO3 Python bindings work?                     | [architecture/pyo3-bindings.md](architecture/pyo3-bindings.md) |
-| How does deploy preemption work?                          | [architecture/deploy-preemption.md](architecture/deploy-preemption.md) |
-| What are the cross-platform portability constraints?      | [architecture/portability.md](architecture/portability.md) |
-| How does library selection (LDF) work in fbuild?          | [architecture/library-selection.md](architecture/library-selection.md) |
+| Question | File |
+|---|---|
+| How do I install fbuild? | [getting-started/README.md](getting-started/README.md#install) |
+| How do I run my first build? | [getting-started/README.md](getting-started/README.md#first-project) |
+| How do I deploy or monitor for the first time? | [getting-started/README.md](getting-started/README.md#first-deploy-and-monitor) |
+| What does `platformio.ini` need to contain? | [reference/platformio-ini.md](reference/platformio-ini.md) |
+| What CLI commands and options exist? | [reference/cli.md](reference/cli.md) |
+| How do I use `fbuild build` / `deploy` / `monitor` / `test-emu`? | [reference/cli.md](reference/cli.md#core-workflows) |
+| How do I use the emulator (QEMU / avr8js / simavr)? | [guides/emulator-testing.md](guides/emulator-testing.md) |
+| What is fbuild's PlatformIO compatibility policy? | [reference/platformio-compatibility.md](reference/platformio-compatibility.md) |
+| Why does fbuild strip `.eh_frame` on some builds? | [reference/platformio-compatibility.md#eh_frame-strip-policy](reference/platformio-compatibility.md#eh_frame-strip-policy) |
+| Why does fbuild exist? | [WHY.md](WHY.md) |
+| What are fbuild's key benefits and performance numbers? | [WHY.md](WHY.md#key-benefits) |
+| Is my board supported? | [BOARD_STATUS.md](BOARD_STATUS.md) |
+| Where is the canonical board/platform matrix? | [BOARD_STATUS.md](BOARD_STATUS.md#supported-platforms-and-boards) |
+| How do I add a new board? | [BOARD_STATUS.md](BOARD_STATUS.md#adding-a-new-board) |
+| What's the crate dependency graph? | [../crates/CLAUDE.md](../crates/CLAUDE.md) |
+| How does fbuild's architecture fit together? | [architecture/overview.md](architecture/overview.md) |
+| How does the daemon work? | [architecture/runtime.md](architecture/runtime.md) |
+| How does the serial / monitor subsystem work? | [architecture/serial.md](architecture/serial.md) |
+| How do the PyO3 Python bindings work? | [architecture/pyo3-bindings.md](architecture/pyo3-bindings.md) |
+| How does deploy preemption work? | [architecture/deploy-preemption.md](architecture/deploy-preemption.md) |
+| What are the cross-platform portability constraints? | [architecture/portability.md](architecture/portability.md) |
+| How does library selection (LDF) work in fbuild? | [architecture/library-selection.md](architecture/library-selection.md) |
 | Why was my library wrongly compiled (#204) / not found (#202)? | [architecture/library-selection.md](architecture/library-selection.md#why) |
-| Why did we choose X over Y?                               | [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md)                 |
-| What's on the implementation roadmap?                     | [ROADMAP.md](ROADMAP.md)                                   |
-| How do I run tests / lint / fmt?                          | [DEVELOPMENT.md](DEVELOPMENT.md#testing)                   |
-| Why is my build failing?                                  | [DEVELOPMENT.md](DEVELOPMENT.md#troubleshooting)           |
-| How do I use the emulator (QEMU / avr8js / simavr)?       | [../README.md](../README.md#emulator-testing)              |
-| What CI cache block should consumers copy?                | [CI_CACHE.md](CI_CACHE.md#copy-paste-github-actions-block) |
-| What cache keys and invalidation pattern should CI use?   | [CI_CACHE.md](CI_CACHE.md#key-composition)                 |
-| How do I cache fbuild across CI runs?                     | [CI_CACHING.md](CI_CACHING.md)                             |
-| What's safe to cache in GitHub Actions?                   | [CI_CACHING.md](CI_CACHING.md#what-the-cache-holds)        |
-| Why does warm-pass build take ~30 s per sketch? (#91)     | [PERF_WARM_BUILD.md](PERF_WARM_BUILD.md)                   |
-| What does `FBUILD_PERF_LOG=1` do?                          | [PERF_WARM_BUILD.md](PERF_WARM_BUILD.md#instrumentation)   |
-| Does warm rebuild + deploy + monitor land under 4 s? (#114) | [PERF_WARM_DEPLOY.md](PERF_WARM_DEPLOY.md)                 |
-| How fast is `soldr` when building fbuild itself?            | [SOLDR_BUILD_PERF.md](SOLDR_BUILD_PERF.md)                 |
-| How can a user override ESP-IDF `CONFIG_*` / `sdkconfig` settings? | [sdkconfig.md](sdkconfig.md)                          |
-| Where does the framework's pre-baked `sdkconfig.h` come from? | [sdkconfig.md](sdkconfig.md#whats-there-today)            |
-| What's the precedence chain for `CONFIG_*` overrides?       | [sdkconfig.md](sdkconfig.md#tldr)                          |
+| Why did we choose X over Y? | [DESIGN_DECISIONS.md](DESIGN_DECISIONS.md) |
+| What's on the implementation roadmap? | [ROADMAP.md](ROADMAP.md) |
+| How do I run tests / lint / fmt? | [development/README.md](development/README.md) |
+| Why is my build failing? | [DEVELOPMENT.md](DEVELOPMENT.md#troubleshooting) |
+| What CI cache block should consumers copy? | [CI_CACHE.md](CI_CACHE.md#copy-paste-github-actions-block) |
+| What cache keys and invalidation pattern should CI use? | [CI_CACHE.md](CI_CACHE.md#key-composition) |
+| How do I cache fbuild across CI runs? | [CI_CACHING.md](CI_CACHING.md) |
+| What's safe to cache in GitHub Actions? | [CI_CACHING.md](CI_CACHING.md#what-the-cache-holds) |
+| Why does warm-pass build take ~30 s per sketch? (#91) | [PERF_WARM_BUILD.md](PERF_WARM_BUILD.md) |
+| What does `FBUILD_PERF_LOG=1` do? | [PERF_WARM_BUILD.md](PERF_WARM_BUILD.md#instrumentation) |
+| Does warm rebuild + deploy + monitor land under 4 s? (#114) | [PERF_WARM_DEPLOY.md](PERF_WARM_DEPLOY.md) |
+| How fast is `soldr` when building fbuild itself? | [SOLDR_BUILD_PERF.md](SOLDR_BUILD_PERF.md) |
+| How can a user override ESP-IDF `CONFIG_*` / `sdkconfig` settings? | [sdkconfig.md](sdkconfig.md) |
+| Where does the framework's pre-baked `sdkconfig.h` come from? | [sdkconfig.md](sdkconfig.md#whats-there-today) |
+| What's the precedence chain for `CONFIG_*` overrides? | [sdkconfig.md](sdkconfig.md#tldr) |
 | Where do end-to-end perf benchmarks live (FastLED matrix, P-01)? | [../bench/fastled-examples/README.md](../bench/fastled-examples/README.md) |
-| What architecture docs should I read for a given crate?   | [CLAUDE.md](CLAUDE.md)                                     |
+| What architecture docs should I read for a given crate? | [CLAUDE.md](CLAUDE.md) |
 
 ## Conventions
 
-- The top-level `README.md` is the install + Quick Start entry point for humans.
-- `CLAUDE.md` at the repo root is the LLM-entry file; `docs/CLAUDE.md` is the LLM map into architecture docs.
+- The top-level `README.md` is the concise project front door for humans.
+- `docs/getting-started/` owns first-run workflows.
+- `docs/guides/` owns task-oriented workflows.
+- `docs/reference/` owns stable user references such as CLI and configuration.
+- `docs/platforms/` routes platform questions; `BOARD_STATUS.md` remains the
+  canonical board-status and per-board CI badge document.
+- `CLAUDE.md` at the repo root is the LLM-entry file; `docs/CLAUDE.md` is the
+  LLM map into architecture docs.
 - Architecture docs live under `docs/architecture/`, one file per subsystem.
 - ADR-style decisions go in `docs/DESIGN_DECISIONS.md`.
-- Per-directory `README.md` files are enforced by a pre-commit hook — every directory with files needs one.
+- Per-directory `README.md` files are enforced by a pre-commit hook; every
+  directory with files needs one.
 
-## Keeping this index current
+## Keeping This Index Current
 
-When a new doc is added under `docs/`, add a row to the table above. Prefer one FAQ-style question per row so readers can grep for the question they have.
+When a new doc is added under `docs/`, add a row to the table above. Prefer one
+FAQ-style question per row so readers can grep for the question they have.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,34 @@
 # Documentation
 
-Architecture and design documentation for the fbuild project.
+Documentation is organized by reader intent. Start with
+[`INDEX.md`](INDEX.md) when you have a specific question.
 
-## Contents
+## User Docs
 
-- **`INDEX.md`** -- FAQ-style index mapping questions to files (start here)
-- **`ARCHITECTURE.md`** -- Index of all architecture documents
-- **`CLAUDE.md`** -- Guide mapping crates to relevant architecture docs
-- **`WHY.md`** -- Why fbuild exists, key benefits, performance benchmarks
-- **`BOARD_STATUS.md`** -- Per-platform CI badges and supported boards
-- **`DEVELOPMENT.md`** -- Testing, troubleshooting, local development setup
-- **`CI_CACHE.md`** -- Consumer-facing cross-run CI cache strategy
-- **`CI_CACHING.md`** -- How to save/restore fbuild's cache across CI runs
-- **`SOLDR_BUILD_PERF.md`** -- Local soldr build benchmark for the Rust workspace
+- **`getting-started/`** -- install, first build, first deploy, first emulator run
+- **`guides/`** -- task workflows such as emulator testing and CI caching
+- **`reference/`** -- CLI, `platformio.ini`, compatibility, and other stable references
+- **`platforms/`** -- board/platform support routing
+- **`BOARD_STATUS.md`** -- canonical per-platform CI badges and supported boards
+- **`WHY.md`** -- why fbuild exists, key benefits, performance benchmarks
+
+## Contributor And Internal Docs
+
+- **`development/`** -- human entry point for working on fbuild itself
+- **`DEVELOPMENT.md`** -- testing, troubleshooting, local development setup
+- **`ARCHITECTURE.md`** -- index of all architecture documents
+- **`architecture/`** -- subsystem-specific architecture documents
+- **`CLAUDE.md`** -- guide mapping crates to relevant architecture docs
 - **`DESIGN_DECISIONS.md`** -- ADR-style decisions with rationale
-- **`ROADMAP.md`** -- Implementation phases for the Rust port
-- **`architecture/`** -- Subsystem-specific architecture documents
+- **`ROADMAP.md`** -- implementation phases for the Rust port
+- **`RELEASING.md`** -- release workflow
+
+## Operations And Performance
+
+- **`CI_CACHE.md`** -- consumer-facing cross-run CI cache strategy
+- **`CI_CACHING.md`** -- detailed save/restore design for CI runners
+- **`PERF_WARM_BUILD.md`** -- warm-pass build performance investigation
+- **`PERF_WARM_DEPLOY.md`** -- warm deploy and monitor timing results
+- **`SOLDR_BUILD_PERF.md`** -- local soldr build benchmark for the Rust workspace
+- **`symbols.md`** -- per-symbol bloat analysis reference
+- **`sdkconfig.md`** -- ESP `sdkconfig` user-override design

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,29 @@
+# Development
+
+This directory is the human-facing entry point for working on fbuild itself.
+
+## Start Here
+
+The existing project-wide development guide remains in
+[`../DEVELOPMENT.md`](../DEVELOPMENT.md). It covers:
+
+- Test commands.
+- Troubleshooting.
+- Local setup on Windows and other hosts.
+- Linting and formatting.
+- Distribution and release notes.
+- Python / PyO3 extension builds.
+- Enforced hooks.
+
+## Troubleshooting
+
+Troubleshooting content currently lives in
+[`../DEVELOPMENT.md#troubleshooting`](../DEVELOPMENT.md#troubleshooting).
+
+## Related Docs
+
+- Architecture overview: [`../architecture/overview.md`](../architecture/overview.md)
+- Crate dependency graph: [`../../crates/CLAUDE.md`](../../crates/CLAUDE.md)
+- Design decisions: [`../DESIGN_DECISIONS.md`](../DESIGN_DECISIONS.md)
+- Releasing: [`../RELEASING.md`](../RELEASING.md)
+- Roadmap: [`../ROADMAP.md`](../ROADMAP.md)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,106 @@
+# Getting Started
+
+Use this guide when you want to install fbuild, compile a first sketch, and
+understand what happens on the first run.
+
+## Install
+
+Install the published Python package:
+
+```bash
+pip install fbuild
+```
+
+Or install from a local checkout:
+
+```bash
+git clone https://github.com/fastled/fbuild.git
+cd fbuild
+pip install -e .
+```
+
+## First Project
+
+Create a project with a PlatformIO-compatible layout:
+
+```bash
+mkdir my-project
+cd my-project
+mkdir src
+```
+
+Create `platformio.ini`:
+
+```ini
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+```
+
+Create `src/main.ino`:
+
+```cpp
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+  digitalWrite(LED_BUILTIN, HIGH);
+  delay(1000);
+  digitalWrite(LED_BUILTIN, LOW);
+  delay(1000);
+}
+```
+
+Build it:
+
+```bash
+fbuild build
+```
+
+The first build downloads the AVR-GCC toolchain and Arduino AVR core, then
+caches them. Later builds reuse the cache and write firmware under
+`.fbuild/build/<env>/`.
+
+## First Deploy And Monitor
+
+Deploy to a connected board:
+
+```bash
+fbuild deploy -e uno
+```
+
+Deploy and attach the serial monitor:
+
+```bash
+fbuild deploy -e uno --monitor
+```
+
+Run the monitor by itself:
+
+```bash
+fbuild monitor -e uno --timeout 60
+```
+
+Serial monitoring uses pyserial and follows the same general port-selection
+model as PlatformIO. You can pass `--port COM3` or `--port /dev/ttyUSB0` when
+auto-detection is not enough.
+
+## First Emulator Run
+
+Run a build in the default emulator for the board:
+
+```bash
+fbuild test-emu . -e uno --timeout 10
+```
+
+See the [emulator testing guide](../guides/emulator-testing.md) for backend
+selection, QEMU notes, and CI-friendly halt conditions.
+
+## Next Steps
+
+- CLI commands and options: [reference/cli.md](../reference/cli.md)
+- `platformio.ini` keys: [reference/platformio-ini.md](../reference/platformio-ini.md)
+- Supported boards: [BOARD_STATUS.md](../BOARD_STATUS.md)
+- Troubleshooting: [development/README.md](../development/README.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,14 @@
+# Guides
+
+Task-oriented docs for using fbuild in real workflows.
+
+## Contents
+
+- [Emulator testing](emulator-testing.md) - run firmware under avr8js, simavr,
+  or QEMU without physical hardware.
+- [CI cache strategy](../CI_CACHE.md) - copy-paste setup for consumer GitHub
+  Actions workflows.
+- [CI caching internals](../CI_CACHING.md) - detailed save/restore behavior for
+  fbuild and zccache.
+- [Troubleshooting](../development/README.md#troubleshooting) - local setup and
+  common failure modes.

--- a/docs/guides/emulator-testing.md
+++ b/docs/guides/emulator-testing.md
@@ -1,0 +1,109 @@
+# Emulator Testing
+
+fbuild can build and run firmware in emulators without physical hardware.
+There are two user-facing entry points:
+
+- `fbuild test-emu` - build, emulate, stream output, and exit with the emulator
+  result. This is the CI-friendly path.
+- `fbuild deploy --to emu` - use the deploy flow and optionally open a monitor
+  page or stream monitor output.
+
+Both commands auto-detect the emulator backend from the selected board, or
+accept `--emulator <backend>`.
+
+## Quick Examples
+
+```bash
+# Auto-detect the emulator backend from the board.
+fbuild test-emu tests/platform/uno -e uno
+
+# Explicit backend with a timeout.
+fbuild test-emu tests/platform/esp32s3 -e esp32s3 --emulator qemu --timeout 10
+
+# AVR with simavr.
+fbuild test-emu tests/platform/mega -e megaatmega2560 --emulator simavr
+
+# Halt on the first test result pattern.
+fbuild test-emu tests/platform/uno -e uno \
+  --halt-on-success "TEST PASSED" --halt-on-error "TEST FAILED"
+```
+
+Deploy to an emulator:
+
+```bash
+fbuild deploy tests/platform/uno -e uno --to emu
+fbuild deploy tests/platform/uno -e uno --to emu --monitor
+fbuild deploy tests/platform/esp32s3 -e esp32s3 --to emu --emulator qemu --monitor --timeout 10
+```
+
+## Common Options
+
+| Option | Description |
+|---|---|
+| `--emulator <backend>` | Force `avr8js`, `qemu`, or `simavr`. |
+| `--timeout <secs>` | Stop the emulator after N seconds. |
+| `--halt-on-success <regex>` | Stop and report success when output matches. |
+| `--halt-on-error <regex>` | Stop and report failure when output matches. |
+| `--expect <regex>` | Require this pattern in output; timeout fails if missing. |
+| `--no-timestamp` | Disable timestamp prefixes on output lines. |
+| `-v`, `--verbose` | Show emulator command and build details. |
+
+## Backends
+
+| Backend | Platforms | MCUs | Requirements |
+|---|---|---|---|
+| `avr8js` | AtmelAVR | ATmega328P | Node.js; fbuild includes the headless runner. |
+| `simavr` | AtmelAVR, MegaAVR | ATmega2560, ATmega32U4, and others | `simavr` binary on `PATH`. |
+| `qemu` | Espressif32 | ESP32, ESP32-S3, ESP32-C3, ESP32-C6, ESP32-H2 | Native QEMU; fbuild manages supported runtime packages. |
+
+Auto-detection rules when `--emulator` is omitted:
+
+- ATmega328P defaults to `avr8js`.
+- Other AVR MCUs with `simavr` in `debug_tools` default to `simavr`.
+- ESP32, ESP32-S3, ESP32-C3, ESP32-C6, and ESP32-H2 default to `qemu`.
+
+The canonical board support matrix is [BOARD_STATUS.md](../BOARD_STATUS.md).
+
+## QEMU Notes
+
+ESP32-family QEMU runs from a normal Arduino environment. fbuild launches
+`qemu-system-xtensa` for ESP32 and ESP32-S3, and `qemu-system-riscv32` for
+ESP32-C3, ESP32-C6, and ESP32-H2. Required QEMU build flags are injected when
+deploying to `--to emu`.
+
+Example ESP32-S3 / ESP32-C3 settings:
+
+```ini
+[env:esp32s3]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.flash_mode = dio
+board_upload.flash_mode = dio
+
+[env:esp32c3]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
+board = esp32-c3-devkitm-1
+framework = arduino
+board_build.flash_mode = dio
+board_upload.flash_mode = dio
+```
+
+QEMU requires DIO flash mode. Boards configured with `qio` or `qout` fail fast
+before building.
+
+Supported QEMU hosts are Linux x86_64/arm64, macOS x86_64/arm64, and Windows
+x86_64. On Windows, fbuild stages the required QEMU runtime DLLs for the
+managed install.
+
+## Known Limitations
+
+1. ESP32 QEMU supports ESP32, ESP32-S3, ESP32-C3, ESP32-C6, and ESP32-H2.
+   ESP32-S2 and ESP32-P4 are not yet supported by upstream Espressif QEMU.
+2. ESP32-S3 images are patched for QEMU to bypass an ADC calibration
+   constructor that hangs under emulation; fbuild repairs the image checksum
+   and hash after patching. RISC-V variants do not require this patch.
+3. QEMU is slower than real hardware. Use it for functional validation, not
+   timing-sensitive behavior.
+4. Peripheral coverage is incomplete. Real hardware is still required for
+   production validation.

--- a/docs/platforms/README.md
+++ b/docs/platforms/README.md
@@ -1,0 +1,33 @@
+# Platforms
+
+Board and platform support lives here.
+
+## Canonical Support Matrix
+
+[`docs/BOARD_STATUS.md`](../BOARD_STATUS.md) is the canonical board-status
+document. It owns:
+
+- Per-platform CI badges.
+- Supported board and platform tables.
+- Board-family notes.
+- The process for adding a new board.
+
+The root README intentionally keeps only a short supported-platform summary so
+that board badges and board status do not drift between files.
+
+## Supported Families
+
+fbuild supports AVR, MegaAVR, Renesas RA, ESP8266, ESP32 variants, CH32
+RISC-V, Teensy, STM32, SAM/SAMD, RP2040/RP2350, Nordic NRF52, Apollo3,
+Silicon Labs EFR32, NXP LPC, and WASM via Emscripten.
+
+## Emulator Support
+
+Emulator backend behavior is documented in
+[`docs/guides/emulator-testing.md`](../guides/emulator-testing.md). In short:
+
+- ATmega328P defaults to `avr8js`.
+- Other AVR MCUs with `simavr` in board metadata default to `simavr`.
+- ESP32, ESP32-S3, ESP32-C3, ESP32-C6, and ESP32-H2 default to `qemu`.
+
+Use `fbuild test-emu` for CI-friendly emulator runs.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,14 @@
+# Reference
+
+Stable user-facing reference material for fbuild.
+
+## Contents
+
+- [CLI reference](cli.md) - commands, options, and common examples.
+- [`platformio.ini` reference](platformio-ini.md) - supported project settings
+  and configuration patterns.
+- [PlatformIO compatibility](platformio-compatibility.md) - known behavioral
+  differences and `.eh_frame` strip policy.
+- [Symbol analysis](../symbols.md) - per-symbol bloat reports for fbuild and
+  PlatformIO builds.
+- [ESP `sdkconfig`](../sdkconfig.md) - ESP-IDF config override design.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,156 @@
+# CLI Reference
+
+`fbuild` accepts either `fbuild <subcommand> <project-dir>` or
+`fbuild <project-dir> <subcommand>` for project-oriented commands.
+
+Global options:
+
+| Option | Description |
+|---|---|
+| `-e`, `--environment <env>` | Select a `platformio.ini` environment. |
+| `-v`, `--verbose` | Print more detail. |
+| `-p`, `--port <port>` | Select a serial port. |
+| `-c`, `--clean` | Clean before deploy when used by deploy-compatible paths. |
+| `--monitor[=<flags>]` | Attach monitor after deploy. |
+| `--timeout <secs>` | Set monitor/emulator timeout where supported. |
+| `--halt-on-error <regex>` | Stop monitor/emulator on an error pattern. |
+| `--halt-on-success <regex>` | Stop monitor/emulator on a success pattern. |
+| `--expect <regex>` | Require a pattern in monitor/emulator output. |
+| `--platformio` | Use PlatformIO compatibility mode where supported. |
+| `--shrink[=<mode>]` | Flash-size reduction mode: `auto`, `off`, `safe`, `aggressive`, or `printf`. |
+| `--no-shrink` | Disable all shrink optimizations. |
+
+## Core Workflows
+
+### `fbuild build`
+
+Compile firmware.
+
+```bash
+fbuild build
+fbuild build -e uno
+fbuild build --clean
+fbuild build --verbose
+fbuild build --project-dir /path/to/project
+```
+
+Common options include `--clean`, `--jobs`, `--quick`, `--release`,
+`--platformio`, `--dry-run`, `--target compiledb`, `--symbol-analysis`,
+`--no-timestamp`, `--output-dir`, `--shrink`, and `--no-shrink`.
+
+### `fbuild deploy`
+
+Build and flash firmware, or deploy an existing build with `--skip-build`.
+
+```bash
+fbuild deploy
+fbuild deploy -e esp32s3 --port COM5
+fbuild deploy --clean
+fbuild deploy --monitor
+fbuild deploy --monitor="--timeout 60 --halt-on-success \"TEST PASSED\""
+```
+
+Common options include `--port`, `--clean`, `--monitor`, `--timeout`,
+`--halt-on-error`, `--halt-on-success`, `--expect`, `--no-timestamp`,
+`--skip-build`, `--baud`, `--to device|emu|emulator`, `--emulator`, and
+`--output-dir`.
+
+### `fbuild monitor`
+
+Attach to serial output.
+
+```bash
+fbuild monitor
+fbuild monitor -e uno --port COM3 --baud 115200
+fbuild monitor --timeout 60 --halt-on-error "TEST FAILED" --halt-on-success "TEST PASSED"
+```
+
+### `fbuild test-emu`
+
+Build and run firmware in an emulator, then exit with the emulator result.
+
+```bash
+fbuild test-emu . -e uno
+fbuild test-emu tests/platform/esp32s3 -e esp32s3 --emulator qemu --timeout 10
+```
+
+See [emulator testing](../guides/emulator-testing.md) for backend rules and
+known limitations.
+
+## Device And Daemon Operations
+
+| Command | Purpose |
+|---|---|
+| `fbuild reset` | Reset a device without flashing. |
+| `fbuild device list` | List connected devices. |
+| `fbuild device status <port>` | Show detailed device status. |
+| `fbuild device lease <port>` | Acquire a device lease. |
+| `fbuild device release <port>` | Release a device lease. |
+| `fbuild device take <port> --reason <text>` | Preempt the current holder. |
+| `fbuild daemon status` | Show daemon status. |
+| `fbuild daemon stop` | Stop the daemon gracefully. |
+| `fbuild daemon restart` | Restart the daemon. |
+| `fbuild daemon list` | List running daemon instances. |
+| `fbuild daemon kill [--pid <pid>] [--force]` | Kill one daemon process. |
+| `fbuild daemon kill-all [--force]` | Kill all daemon processes. |
+| `fbuild daemon locks` | Show project and serial locks. |
+| `fbuild daemon clear-locks` | Clear stale locks. |
+| `fbuild daemon cache-stats` | Show disk cache statistics. |
+| `fbuild daemon gc` | Run disk cache garbage collection. |
+| `fbuild daemon monitor` | Tail daemon logs. |
+| `fbuild show daemon` | Show daemon logs. |
+| `fbuild purge` | Purge cached packages or run `--gc`. |
+
+## Diagnostics And Analysis
+
+| Command | Purpose |
+|---|---|
+| `fbuild symbols <elf-or-project>` | Per-symbol bloat analysis. See [symbols.md](../symbols.md). |
+| `fbuild bloat graph <input> --symbol <name>` | Render a Graphviz back-reference graph. |
+| `fbuild bloat lookup <input> --symbol <name>` | Inspect one symbol's size and references. |
+| `fbuild lib-select` | Debug LDF-style library selection. |
+| `fbuild clang-tidy` | Run clang-tidy against project sources. |
+| `fbuild iwyu` | Run include-what-you-use analysis. |
+| `fbuild clang-query` | Run a clang-query matcher. |
+| `fbuild lnk pull` | Fetch `.lnk` resource blobs into the cache. |
+| `fbuild lnk check` | Verify cached `.lnk` resources. |
+| `fbuild lnk add <url>` | Create a `.lnk` manifest for a remote blob. |
+| `fbuild mcp` | Start the MCP server for AI assistant integration. |
+
+## Batch And CI Commands
+
+### `fbuild compile-many`
+
+Build many sketches against one board using a two-stage pipeline: framework and
+library archives are built once, then sketch compile/link jobs fan out.
+
+```bash
+fbuild compile-many --board uno examples/Blink examples/Fire2012
+fbuild compile-many --board teensy41 --framework-jobs 2 --sketch-jobs 8 --release sketches/*
+```
+
+### `fbuild ci`
+
+PlatformIO-compatible CI entry point. It maps common `pio ci` flags onto
+`compile-many`.
+
+```bash
+fbuild ci --board uno --lib ./libs --lib ./more -c custom.ini \
+  examples/Blink/Blink.ino examples/Fire2012/Fire2012.ino
+```
+
+| `fbuild ci` flag | `pio ci` equivalent | Behavior |
+|---|---|---|
+| `--board <b>`, `-b <b>` | `--board`, `-b` | Required board id. |
+| `--lib <path>`, `-l <path>` | `--lib`, `-l` | Repeatable extra library search path. |
+| `--project-conf <path>`, `-c <path>` | `--project-conf`, `-c` | Use a shared `platformio.ini`. |
+| `--keep-build-dir` | `--keep-build-dir` | Accepted; fbuild always keeps `.fbuild/build/...`. |
+| `--build-dir <path>` | `--build-dir` | Accepted but not yet honored. |
+| `--framework-jobs`, `--sketch-jobs`, `--quick`, `--release`, `--verbose` | n/a | fbuild-native controls. |
+
+## Keeping This Reference Current
+
+This file is the user-facing CLI reference. Crate-local README files under
+`crates/` describe implementation internals. When the Clap command surface
+changes, update this reference or add generation/CI validation so it cannot
+drift.

--- a/docs/reference/platformio-compatibility.md
+++ b/docs/reference/platformio-compatibility.md
@@ -1,0 +1,63 @@
+# PlatformIO Compatibility
+
+fbuild is designed to consume existing `platformio.ini` projects while using a
+Rust-native build, deploy, and monitor pipeline. This page owns compatibility
+notes that are too detailed for the root README.
+
+## `.eh_frame` Strip Policy
+
+By default, fbuild strips GCC's `.eh_frame` exception-unwinding tables on
+release builds for platforms that do not use them: Teensy, STM32, RP2040,
+NRF52, and ESP8266. This can save 40-180 KB of flash on a typical FastLED
+sketch. PlatformIO does not strip these tables by default.
+
+ESP32 with the stock Arduino sdkconfig preserves `.eh_frame` because
+`esp32_exception_decoder` and panic-print-backtrace consume it.
+
+The decision is made per build by this precedence chain:
+
+| Condition | Policy |
+|---|---|
+| `FBUILD_STRIP_EH_FRAME=1` env var | Strip |
+| `FBUILD_KEEP_EH_FRAME=1` env var | Preserve |
+| `build_type = debug` in `platformio.ini` | Preserve |
+| `-fexceptions`, `-funwind-tables`, or `-fasynchronous-unwind-tables` in `build_flags` | Preserve |
+| ESP32 with `CONFIG_ESP_SYSTEM_PANIC_PRINT_BACKTRACE=y` | Preserve |
+| Otherwise, on supported release platforms | Strip |
+
+## Opt Out Per Project
+
+Add an unwind-tables flag to `platformio.ini`:
+
+```ini
+[env:teensy41]
+platform = teensy
+board = teensy41
+framework = arduino
+build_flags = -funwind-tables
+```
+
+Or set an environment variable:
+
+```bash
+FBUILD_KEEP_EH_FRAME=1 fbuild build
+```
+
+## Why fbuild Deviates
+
+GCC emits `.eh_frame` by default even when nothing consumes it. On the
+platforms above, toolchain JSON already ships `-fno-exceptions`, no runtime
+calls `_Unwind_*`, and no debugger or decoder reads the tables. In that case
+`.eh_frame` is dead metadata occupying flash.
+
+A byte-level audit on an ESP32-S3 FastLED Blink build
+([FastLED/FastLED#2473](https://github.com/FastLED/FastLED/issues/2473)) found
+`.eh_frame` accounted for 36% of firmware size. Stripping at the compiler level
+with `-fno-asynchronous-unwind-tables -fno-unwind-tables` is the reliable fix.
+Implementation details and the original decision matrix are in
+[#245](https://github.com/fastled/fbuild/pull/245).
+
+## PlatformIO-Compatible CI
+
+`fbuild ci` is a drop-in replacement for `pio ci` for supported workflows. See
+the [`fbuild ci` reference](cli.md#fbuild-ci) for flag mapping and examples.

--- a/docs/reference/platformio-ini.md
+++ b/docs/reference/platformio-ini.md
@@ -1,0 +1,112 @@
+# `platformio.ini` Reference
+
+fbuild reads PlatformIO-style project configuration. The minimum project has a
+`platformio.ini` and a `src/` directory.
+
+## Minimal Configuration
+
+```ini
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+```
+
+Build it with:
+
+```bash
+fbuild build -e uno
+```
+
+## Common Configuration
+
+```ini
+[platformio]
+default_envs = uno
+
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+upload_port = COM3
+monitor_speed = 9600
+build_flags =
+    -DDEBUG
+    -DLED_PIN=13
+lib_deps =
+    https://github.com/FastLED/FastLED
+    https://github.com/adafruit/Adafruit_NeoPixel
+```
+
+Common keys:
+
+| Key | Purpose |
+|---|---|
+| `[platformio] default_envs` | Default environment when `-e` is omitted. |
+| `[env:<name>] platform` | Platform or platform package URL. |
+| `[env:<name>] board` | Board id. See [BOARD_STATUS.md](../BOARD_STATUS.md). |
+| `[env:<name>] framework` | Framework, usually `arduino`. |
+| `upload_port` | Preferred deploy port. |
+| `monitor_speed` | Serial monitor baud rate. |
+| `build_flags` | Extra compiler flags. |
+| `lib_deps` | Library dependencies, including GitHub URLs. |
+| `build_type` | Build profile; `debug` preserves unwind metadata. |
+| `board_build.*` | Board-specific build overrides. |
+| `board_upload.*` | Upload/deploy overrides. |
+
+The config parser also supports environment inheritance and variable
+substitution. Architecture notes for the parser live in
+[`docs/architecture/overview.md`](../architecture/overview.md).
+
+## Library Dependencies
+
+fbuild can download and compile Arduino libraries directly from GitHub URLs:
+
+```ini
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+lib_deps =
+    https://github.com/FastLED/FastLED
+```
+
+Supported behavior includes:
+
+- GitHub URL optimization to zip downloads.
+- Branch detection for common default branches.
+- Arduino library layout handling.
+- LDF-style transitive header scanning for library selection.
+- LTO-aware library builds for smaller firmware.
+
+The library selection design is documented in
+[`docs/architecture/library-selection.md`](../architecture/library-selection.md).
+
+## ESP QEMU Flash Mode
+
+ESP32-family QEMU requires DIO flash mode:
+
+```ini
+[env:esp32s3]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+board_build.flash_mode = dio
+board_upload.flash_mode = dio
+```
+
+See [emulator testing](../guides/emulator-testing.md) for backend-specific
+requirements.
+
+## ESP `sdkconfig`
+
+ESP-IDF `CONFIG_*` override design is documented in
+[`docs/sdkconfig.md`](../sdkconfig.md). Prefer `sdkconfig.fragment` for larger
+config changes; use `build_flags = -D CONFIG_*` for simple PlatformIO-compatible
+overrides.
+
+## Native `extra_scripts`
+
+Native fbuild supports only a narrow subset of PlatformIO `extra_scripts`.
+Unsupported behavior fails early with a recommendation to use `--platformio`.
+See [`crates/fbuild-build/README.md`](../../crates/fbuild-build/README.md).


### PR DESCRIPTION
﻿## Summary

- shrink the root README into a 176-line project front door with install, quick start, core badges, and intent-based routing
- add scalable docs categories for getting started, guides, reference, platforms, and development
- move detailed CLI, `platformio.ini`, emulator, and `.eh_frame` compatibility material into canonical reference/guide pages
- mark `docs/BOARD_STATUS.md` as the canonical board/status source and update `docs/INDEX.md` / `docs/README.md` routing
- include one rustfmt-only cleanup needed for the current fmt gate

Closes #523

## Tests

- project Markdown relative-link scan
- `git diff --check`
- `soldr cargo fmt --all --check`
- `RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps`
- `soldr cargo test --workspace --`
- `soldr cargo clippy --workspace --all-targets -- -D warnings`

Note: `uv run test` could not spawn the Bash `test` wrapper from this Windows PowerShell session, so I ran the equivalent `soldr cargo test --workspace --` directly.
