### PR TITLE
feat(generic_arm): wire zccache into ArmCompiler — unifies 8 platforms

### DIFF
--- a/crates/fbuild-build/src/compiler.rs
+++ b/crates/fbuild-build/src/compiler.rs
@@ -552,7 +552,11 @@ pub fn build_cpp_flags(common_flags: Vec<String>, config: &dyn McuConfig) -> Vec
 /// - `response_file_prefix`: "avr", "teensy", "esp32"
 /// - `extra_pre_flags`: additional flags inserted between base flags and extra_flags
 ///   (ESP32 uses this for include flags deferred from common_flags)
-/// - `compiler_cache`: optional zccache path (ESP32 only, None for others)
+/// - `compiler_cache`: optional zccache path. When `Some`, the gcc/g++
+///   invocation is rewritten as `<zccache> wrap <gcc> ...` for
+///   content-addressed object caching. Wired up by ESP32 and by the
+///   shared `ArmCompiler` (which covers apollo3, ch32v, nrf52, nxplpc,
+///   renesas, sam, silabs, teensy). Other compiler impls pass `None`.
 ///
 /// On Windows, response files are written into a stable `tmp` directory next to
 /// the output object so repeated builds can reuse the same path and avoid

--- a/crates/fbuild-build/src/generic_arm/arm_compiler.rs
+++ b/crates/fbuild-build/src/generic_arm/arm_compiler.rs
@@ -27,6 +27,16 @@ pub struct ArmCompiler {
     /// callers see no behavior change; orchestrators set this via
     /// [`Self::with_eh_frame_policy`]. See FastLED/fbuild#244.
     eh_frame_policy: EhFramePolicy,
+    /// Optional zccache binary path. When present, every `compile_one`
+    /// call routes the underlying `arm-none-eabi-gcc` / `g++` invocation
+    /// through `zccache wrap <gcc> ...` so repeated compilations of the
+    /// same translation unit hit the content-addressed object cache.
+    /// Mirrors the pattern already in `Esp32Compiler`; benefits every
+    /// ARM platform (apollo3, ch32v, nrf52, nxplpc, renesas, sam, silabs,
+    /// teensy) that constructs an `ArmCompiler`. Auto-discovered in
+    /// [`Self::new`] via `crate::zccache::find_zccache()`; falls back to
+    /// `None` (un-wrapped gcc) when zccache isn't on PATH.
+    compiler_cache: Option<PathBuf>,
 }
 
 impl ArmCompiler {
@@ -57,7 +67,17 @@ impl ArmCompiler {
             temp_dir: fbuild_core::response_file::windows_temp_dir(),
             build_unflags: Vec::new(),
             eh_frame_policy: EhFramePolicy::default(),
+            compiler_cache: crate::zccache::find_zccache().map(PathBuf::from),
         }
+    }
+
+    /// Override the auto-discovered compiler cache. Pass `None` to
+    /// explicitly opt out of zccache wrapping even when zccache is on
+    /// PATH. Primarily for tests / benchmarks; production callers should
+    /// rely on the auto-discovery in [`Self::new`].
+    pub fn with_compiler_cache(mut self, compiler_cache: Option<PathBuf>) -> Self {
+        self.compiler_cache = compiler_cache;
+        self
     }
 
     /// Attach PlatformIO `build_unflags`. See FastLED/fbuild#37.
@@ -115,7 +135,7 @@ impl Compiler for ArmCompiler {
             &self.temp_dir,
             "arm",
             self.base.verbose,
-            None,
+            self.compiler_cache.as_deref(),
             &[],
         )
     }


### PR DESCRIPTION
## Why

`ArmCompiler::compile_one` was hardcoding `compiler_cache: None` in the call to `compile_source`, so every CI run rebuilt every translation unit from scratch on every ARM platform (apollo3, ch32v, nrf52, nxplpc, renesas, sam, silabs, teensy). ESP32 already does this right; ARM was the outlier.

Concrete signal that surfaced it: zackees/ArduinoCore-LPC8xx fbuild CI runs were spending ~24 s on the build step alone because every TU re-compiled with no cache lookup, vs PIO's ~1 s on the same project (PIO caches the toolchain + SCons does its own incremental check).

## What

Mirror the `Esp32Compiler` pattern in `generic_arm::ArmCompiler`:

```rust
pub struct ArmCompiler {
    ...
    compiler_cache: Option<PathBuf>,
}

impl ArmCompiler {
    pub fn new(...) -> Self {
        Self {
            ...
            compiler_cache: crate::zccache::find_zccache().map(PathBuf::from),
        }
    }
}

impl Compiler for ArmCompiler {
    fn compile_one(&self, ...) -> Result<CompileResult> {
        crate::compiler::compile_source(
            ...,
            self.compiler_cache.as_deref(),    // was: None
            &[],
        )
    }
}
```

Plus a `with_compiler_cache` builder for tests/benchmarks that want to explicitly opt out, and a doc-comment fix on `compile_source` (its `// ESP32 only, None for others` note is now out of date).

## Behavioural notes

- **Backwards compatible.** `find_zccache()` returns `None` when zccache isn't on PATH, in which case `compile_source` short-circuits the wrap and runs gcc directly — identical to today's behavior.
- **Per-call overhead is microseconds.** zccache's wrap step does a fingerprint hash and either serves the cached `.o` or forwards to gcc. Hot-path overhead is negligible.
- **Local verification (Windows):** built locally, ran against zackees/ArduinoCore-LPC8xx; zccache was invoked, build produced firmware.bin. (Local Windows zccache daemon was flaky in one of my retries — unrelated to this change; reliable in Linux CI per existing FastLED workflows.)

## Tests

```
soldr cargo test -p fbuild-build --lib
test result: ok. 687 passed; 0 failed; 0 ignored
```

## Impact

After release, the next CI run on any project using an ARM platform (the 8 listed above) will populate the zccache `core/` cache. Subsequent runs against unchanged TUs hit the cache and skip the gcc invocation entirely. Combined with the consumer-side cache-the-cache-dir step ([zackees/ArduinoCore-LPC8xx#17](https://github.com/zackees/ArduinoCore-LPC8xx/pull/17) for the matching `actions/cache@v4` setup), the fbuild CI jobs there should drop from ~28 s to ~5–7 s on warm runs.