### PR TITLE
feat: add running-process daemon diagnostics

### DIFF
--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -662,6 +662,13 @@ pub enum DaemonAction {
         #[arg(long, default_value = "50")]
         lines: usize,
     },
+    /// Preview running-process service metadata and deferred broker wiring
+    #[command(alias = "servicedef")]
+    RunningProcess {
+        /// Emit machine-readable JSON instead of text
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Subcommands under `fbuild bloat`. The parent enum lives so future

--- a/crates/fbuild-cli/src/cli/daemon_cmd.rs
+++ b/crates/fbuild-cli/src/cli/daemon_cmd.rs
@@ -103,8 +103,98 @@ pub async fn run_daemon(action: DaemonAction) -> fbuild_core::Result<()> {
         DaemonAction::Monitor { no_follow, lines } => {
             return run_show("daemon", !no_follow, lines);
         }
+        DaemonAction::RunningProcess { json } => {
+            run_daemon_running_process(json)?;
+        }
     }
     Ok(())
+}
+
+fn run_daemon_running_process(json: bool) -> fbuild_core::Result<()> {
+    use fbuild_paths::running_process as rp;
+
+    let mode = rp::running_process_daemon_mode();
+    let service_definition_path = rp::running_process_service_definition_path();
+    let daemon_candidate = daemon_executable_candidate();
+    let daemon_candidate_exists = daemon_candidate.exists();
+    let deferred_items = [
+        "binary .servicedef encoding/install",
+        "active BackendHandle endpoint-response probing",
+        "running_process::broker::client::connect_to_backend",
+        "broker/direct integration matrix",
+        "full lint/dylint and broad three-OS acceptance",
+    ];
+
+    if json {
+        let payload = serde_json::json!({
+            "service_name": rp::SERVICE_NAME,
+            "broker_isolation": rp::BROKER_ISOLATION,
+            "service_definition": {
+                "file_name": rp::SERVICE_DEFINITION_FILE_NAME,
+                "template": rp::SERVICE_DEFINITION_TEMPLATE,
+                "path": service_definition_path.display().to_string(),
+                "binary_install": "stubbed",
+            },
+            "daemon": {
+                "binary_name": rp::DAEMON_BINARY_NAME,
+                "candidate_path": daemon_candidate.display().to_string(),
+                "candidate_exists": daemon_candidate_exists,
+            },
+            "mode": {
+                "current": mode.as_str(),
+                "uses_direct_fallback": mode.uses_direct_fallback(),
+                "running_process_disabled": rp::running_process_disabled(),
+                "broker_requested": rp::running_process_broker_requested(),
+                "summary": rp::running_process_adoption_summary(),
+            },
+            "deferred": deferred_items,
+        });
+        let output = serde_json::to_string_pretty(&payload)
+            .map_err(|e| fbuild_core::FbuildError::Other(format!("json serialize: {e}")))?;
+        println!("{output}");
+        return Ok(());
+    }
+
+    println!("running-process broker adoption");
+    println!("  Service:              {}", rp::SERVICE_NAME);
+    println!("  Isolation:            {}", rp::BROKER_ISOLATION);
+    println!(
+        "  Service definition:   {}",
+        service_definition_path.display()
+    );
+    println!(
+        "  Template:             {}",
+        rp::SERVICE_DEFINITION_TEMPLATE
+    );
+    println!("  Mode:                 {}", mode.as_str());
+    println!(
+        "  Direct fallback:      {}",
+        if mode.uses_direct_fallback() {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+    println!("  Daemon binary:        {}", daemon_candidate.display());
+    println!(
+        "  Daemon binary exists: {}",
+        if daemon_candidate_exists { "yes" } else { "no" }
+    );
+    println!("  Deferred:");
+    for item in deferred_items {
+        println!("    - {item}");
+    }
+    Ok(())
+}
+
+fn daemon_executable_candidate() -> std::path::PathBuf {
+    let Some(parent) = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    else {
+        return std::path::PathBuf::from(fbuild_paths::running_process::DAEMON_BINARY_NAME);
+    };
+    parent.join(fbuild_paths::running_process::DAEMON_BINARY_NAME)
 }
 
 pub async fn run_daemon_list(client: &DaemonClient) -> fbuild_core::Result<()> {

--- a/crates/fbuild-cli/src/cli/tests.rs
+++ b/crates/fbuild-cli/src/cli/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for CLI argument normalization and `fbuild ci` parsing.
 
-use super::args::{Cli, Commands};
+use super::args::{Cli, Commands, DaemonAction};
 use super::compile_many::{build_ci_pio_env, normalize_ci_sketch_entry, normalize_ci_sketches};
 use clap::Parser;
 
@@ -131,6 +131,30 @@ fn ci_short_board_flag_b_is_accepted() {
 fn ci_requires_at_least_one_sketch() {
     let argv = ["fbuild", "ci", "--board", "uno"];
     assert!(Cli::try_parse_from(argv).is_err());
+}
+
+#[test]
+fn daemon_running_process_json_flag_is_accepted() {
+    let argv = ["fbuild", "daemon", "running-process", "--json"];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Daemon {
+            action: DaemonAction::RunningProcess { json },
+        }) => assert!(json),
+        _ => panic!("expected daemon running-process subcommand"),
+    }
+}
+
+#[test]
+fn daemon_servicedef_alias_uses_running_process_action() {
+    let argv = ["fbuild", "daemon", "servicedef"];
+    let cli = Cli::try_parse_from(argv).expect("parse");
+    match cli.command {
+        Some(Commands::Daemon {
+            action: DaemonAction::RunningProcess { json },
+        }) => assert!(!json),
+        _ => panic!("expected daemon servicedef alias"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
Summary:
- Add `fbuild daemon running-process` diagnostics with `--json` output.
- Add `fbuild daemon servicedef` as an alias for the same preview.
- Report service name, `SHARED_BROKER` isolation, computed service-definition path, current direct-fallback mode, daemon binary candidate/existence, and explicitly deferred broker work.

Stubbed / deferred:
- Binary `.servicedef` encoding/install.
- Active `BackendHandle` endpoint-response probing.
- `running_process::broker::client::connect_to_backend` / Hello-skip broker path.
- Broker/direct integration matrix.
- Full lint/dylint and broad three-OS acceptance.

Critical Windows host checks:
- `soldr rustfmt --edition 2021 crates\fbuild-cli\src\cli\args.rs crates\fbuild-cli\src\cli\daemon_cmd.rs crates\fbuild-cli\src\cli\tests.rs`
- `git diff --check`
- `soldr cargo test -p fbuild-paths running_process -- --nocapture`
- `soldr cargo test -p fbuild-cli daemon_running_process -- --nocapture`
- `soldr cargo test -p fbuild-cli daemon_servicedef -- --nocapture`
- `soldr cargo check -p fbuild-cli`
- `soldr cargo run -p fbuild-cli -- daemon running-process --json`
- `soldr cargo run -p fbuild-cli -- daemon servicedef --json`

Refs FastLED/fbuild#510
Refs zackees/running-process#242
Refs zackees/running-process#228