### PR TITLE
chore(deps): bump running-process to 4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64479526e50ccc2d842a78361bcf452e12e09329159e0beafd19d6e9d659d9e"
+checksum = "b463aaf22bc2a27eb0b7bf347c4aa315075796908f859fbd8bcd469041cfc940"
 dependencies = [
  "libc",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,11 +84,16 @@ owo-colors = "4"
 # Process containment: all subprocess spawns the daemon performs (compilers,
 # esptool, qemu, simavr, node, npm, …) and any grandchildren they fork must
 # die with the daemon. See FastLED/fbuild#32.
-# Migrated from `running-process-core 3.4` to `running-process 4.0.0` after
+# Migrated from `running-process-core 3.4` to `running-process 4.x` after
 # the upstream mono-crate consolidation. We only use the `core` feature
 # (spawn API + containment); the `client`/`daemon` features and the IPC
 # client/daemon binary remain unused, so we pin `default-features = false`.
-running-process = { version = "4.0.0", default-features = false }
+# Broker adoption was evaluated and declined (zackees/running-process#384):
+# fbuild-daemon speaks HTTP over loopback TCP, while the broker routes
+# local-socket/named-pipe backends, and `/health` already provides the
+# liveness + staleness guarantees a BackendHandle probe would add. See
+# crates/fbuild-daemon/README.md "Why not the running-process broker".
+running-process = { version = "4.1.0", default-features = false }
 
 [profile.dev]
 debug = 0

--- a/crates/fbuild-daemon/README.md
+++ b/crates/fbuild-daemon/README.md
@@ -31,3 +31,21 @@ Locks: `GET /api/locks/status`; `POST /api/locks/clear`
 WebSocket: `/ws/serial-monitor`, `/ws/status`, `/ws/logs`, `/ws/monitor/{session_id}`
 
 See `docs/architecture/overview.md` and `docs/architecture/runtime.md` for architecture details.
+
+## Why not the running-process broker
+
+fbuild uses the `running-process` crate for process containment only
+(`core` feature). Adopting its broker/BackendHandle daemon-control layer was
+evaluated and declined (zackees/running-process#384):
+
+- **Transport mismatch** — the broker discovers and routes backends over
+  local sockets / named pipes; fbuild-daemon serves HTTP over loopback TCP
+  (axum). Multiplexing the broker's nonce probe onto the HTTP listener would
+  require a second raw listener.
+- **Equivalent guarantees exist** — `GET /health` returns the daemon pid and
+  `source_mtime`, covering the liveness and stale-daemon detection a
+  BackendHandle probe would provide, and the CLI self-heals via
+  `ensure_daemon_running()`.
+
+Revisit only if daemon RPC ever moves off HTTP or broker-managed lifecycle
+becomes desirable.


### PR DESCRIPTION
## Summary

- Bump `running-process` workspace dep from 4.0.0 → 4.1.0 (fbuild continues to consume only the `core` feature via `default-features = false` — spawn API + containment, no client/daemon/IPC).
- Document the deliberate **broker-adoption decline** in `crates/fbuild-daemon/README.md` ("Why not the running-process broker"):
  - **Transport mismatch** — running-process broker discovers/routes backends over local sockets / named pipes; fbuild-daemon serves HTTP over loopback TCP (axum). Multiplexing the broker's nonce probe onto the HTTP listener would require a second raw listener.
  - **Equivalent guarantees exist** — `GET /health` already returns the daemon pid + `source_mtime`, covering the liveness and stale-daemon detection a `BackendHandle` probe would add; the CLI self-heals via `ensure_daemon_running()`.
  - Revisit only if daemon RPC ever moves off HTTP, or if broker-managed lifecycle becomes desirable.

Refs zackees/running-process#384

## Test plan

- [x] `soldr cargo check --workspace --all-targets`
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings`
- [x] `uv run ci/test.py` (full workspace test suite — green)
- [ ] CI matrix (Linux / macOS / Windows) green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to version 4.1.0.

* **Documentation**
  * Added documentation clarifying architectural design decisions and health monitoring approaches for the daemon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->