### PR TITLE
chore(release): bump version 2.2.25 -> 2.2.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "async-trait",
  "blake3",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "blake3",
  "clap",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "libc",
  "running-process",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "async-trait",
  "axum",
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "criterion",
  "rayon",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "bincode",
  "blake3",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "axum",
  "bzip2",
@@ -1083,14 +1083,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "async-trait",
  "base64",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.25"
+version = "2.2.26"
 dependencies = [
  "fbuild-header-scan",
  "fbuild-library-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.25"
+version = "2.2.26"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.25"
+version = "2.2.26"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Version bump 2.2.25 → 2.2.26 (Cargo.toml, pyproject.toml, Cargo.lock) to cut a release carrying the running-process 4.1.0 upgrade (#534).
- Pushing this to main triggers `release-auto.yml` (Cargo.toml/pyproject.toml path filter).

Refs zackees/running-process#384

## Test plan
- [ ] CI green (or failures pre-existing on main)
- [ ] Autonomous Release publishes 2.2.26 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.2.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->