### PR TITLE
ci(boards): add LPC845-BRK + LPCXpresso804 stub workflows and README badges

### DIFF
--- a/.github/workflows/build-lpc845brk.yml
+++ b/.github/workflows/build-lpc845brk.yml
@@ -1,0 +1,47 @@
+name: Build LPC845-BRK
+
+# No-op stub. The NxpLpc orchestrator DOES build this variant —
+# proof: `fbuild build . -e lpc845brk` is green on `main` in upstream
+# `zackees/ArduinoCore-LPC8xx` CI (variant source of truth). This
+# stub only exists because there's no in-tree fixture for it yet
+# (no `tests/platform/lpc845brk/`; the board JSON
+# `boards/json/lpc845brk.json` landed in PR #514).
+#
+# Tracked: FastLED/fbuild#528 — Stage 8 of META #487. When the
+# fixture lands, swap this `jobs.build` body for:
+#
+#   jobs:
+#     build:
+#       uses: ./.github/workflows/template_build.yml
+#       with:
+#         workflow-name: "NXP LPC845-BRK"
+#         test-dir: "tests/platform/lpc845brk"
+#         env-name: "lpc845brk"
+#         firmware-ext: "bin"
+#
+# Variant source: https://github.com/zackees/ArduinoCore-LPC8xx
+# (variants/lpc845brk).
+#
+# History: a previous attempt used `continue-on-error: true` on the
+# reusable-workflow caller, but that keyword is NOT in GitHub's
+# allow-list for reusable callers — every push went red with a
+# "workflow file issue" before any job actually ran. The no-op pass
+# below sidesteps that limitation.
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: NXP LPC845-BRK (stub — fixture pending)
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "No in-tree fixture for lpc845brk yet (tests/platform/lpc845brk/)."
+          echo "See FastLED/fbuild#528 (Stage 8 of META #487)."
+          echo "This workflow stub passes intentionally; replace with the"
+          echo "template_build.yml caller once the fixture lands."

--- a/.github/workflows/build-lpcxpresso804.yml
+++ b/.github/workflows/build-lpcxpresso804.yml
@@ -1,0 +1,47 @@
+name: Build LPCXpresso804
+
+# No-op stub. The NxpLpc orchestrator DOES build this variant —
+# proof: `fbuild build . -e lpcxpresso804` is green on `main` in
+# upstream `zackees/ArduinoCore-LPC8xx` CI (variant source of truth).
+# This stub only exists because there's no in-tree fixture for it yet
+# (no `tests/platform/lpcxpresso804/`; the board JSON
+# `boards/json/lpcxpresso804.json` landed in PR #514).
+#
+# Tracked: FastLED/fbuild#528 — Stage 8 of META #487. When the
+# fixture lands, swap this `jobs.build` body for:
+#
+#   jobs:
+#     build:
+#       uses: ./.github/workflows/template_build.yml
+#       with:
+#         workflow-name: "NXP LPCXpresso804"
+#         test-dir: "tests/platform/lpcxpresso804"
+#         env-name: "lpcxpresso804"
+#         firmware-ext: "bin"
+#
+# Variant source: https://github.com/zackees/ArduinoCore-LPC8xx
+# (variants/lpcxpresso804).
+#
+# History: a previous attempt used `continue-on-error: true` on the
+# reusable-workflow caller, but that keyword is NOT in GitHub's
+# allow-list for reusable callers — every push went red with a
+# "workflow file issue" before any job actually ran. The no-op pass
+# below sidesteps that limitation.
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: NXP LPCXpresso804 (stub — fixture pending)
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "No in-tree fixture for lpcxpresso804 yet (tests/platform/lpcxpresso804/)."
+          echo "See FastLED/fbuild#528 (Stage 8 of META #487)."
+          echo "This workflow stub passes intentionally; replace with the"
+          echo "template_build.yml caller once the fixture lands."

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ that fbuild actively protects in CI.
 
 [![Build LPC804](https://github.com/fastled/fbuild/actions/workflows/build-lpc804.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc804.yml)
 [![Build LPC845](https://github.com/fastled/fbuild/actions/workflows/build-lpc845.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc845.yml)
+[![Build LPC845-BRK](https://github.com/fastled/fbuild/actions/workflows/build-lpc845brk.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpc845brk.yml)
+[![Build LPCXpresso804](https://github.com/fastled/fbuild/actions/workflows/build-lpcxpresso804.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpcxpresso804.yml)
+[![Build LPCXpresso845-MAX](https://github.com/fastled/fbuild/actions/workflows/build-lpcxpresso845max.yml/badge.svg)](https://github.com/fastled/fbuild/actions/workflows/build-lpcxpresso845max.yml)
 
 ### Silicon Labs
 


### PR DESCRIPTION
## Summary

- Adds two no-op stub CI workflows — `build-lpc845brk.yml` and `build-lpcxpresso804.yml` — plus three README badges (LPC845-BRK, LPCXpresso804, LPCXpresso845-MAX; the last workflow already exists on main via #514).
- Part of the board-coverage effort in #528 (Stage 8 of META #487): every protected board gets a named CI slot now; the stubs get swapped for real `template_build.yml` callers once in-tree fixtures land.

## Why stubs, not real builds

Quoting the in-file rationale:

> No-op stub. The NxpLpc orchestrator DOES build this variant — proof: `fbuild build . -e lpc845brk` is green on `main` in upstream `zackees/ArduinoCore-LPC8xx` CI (variant source of truth). This stub only exists because there's no in-tree fixture for it yet (no `tests/platform/lpc845brk/`; the board JSON `boards/json/lpc845brk.json` landed in PR #514).

> History: a previous attempt used `continue-on-error: true` on the reusable-workflow caller, but that keyword is NOT in GitHub's allow-list for reusable callers — every push went red with a "workflow file issue" before any job actually ran. The no-op pass below sidesteps that limitation.

## What was deliberately dropped from the original draft

The draft also contained a stub replacement for `build-lpcxpresso845max.yml`. That premise is stale: PR #514 (merged 2026-06-09) already shipped the real `template_build.yml` caller together with `tests/platform/lpcxpresso845max/platformio.ini` and `boards/json/lpcxpresso845max.json`, and the workflow has been green on main for its last 10 runs. Stubbing it out would regress a working build, so this PR leaves it untouched.

## Test plan

- [x] `actionlint` clean on both new workflow files
- [x] Stub jobs only run echo steps — expected green
- [ ] Full check matrix green (or failures pre-existing on main)

Refs #528, #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)