### PR TITLE
chore(deps): bump running-process to 4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b463aaf22bc2a27eb0b7bf347c4aa315075796908f859fbd8bcd469041cfc940"
+checksum = "daa54a7b0d3487477cd1a91354883da6fb6bfe3c92b84a8c072c8d3e003cbd2b"
 dependencies = [
  "libc",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,11 @@ owo-colors = "4"
 # local-socket/named-pipe backends, and `/health` already provides the
 # liveness + staleness guarantees a BackendHandle probe would add. See
 # crates/fbuild-daemon/README.md "Why not the running-process broker".
-running-process = { version = "4.1.0", default-features = false }
+# 4.2.0 ships a broker backend SDK (`BackendEndpointMux`,
+# `probe_with_service_async`, conformance kit — zackees/running-process#412)
+# that lowers the adoption cost; that work is tracked in FastLED/fbuild#510
+# and does not change this core-only dependency.
+running-process = { version = "4.2.0", default-features = false }
 
 [profile.dev]
 debug = 0

--- a/crates/fbuild-daemon/README.md
+++ b/crates/fbuild-daemon/README.md
@@ -49,3 +49,11 @@ evaluated and declined (zackees/running-process#384):
 
 Revisit only if daemon RPC ever moves off HTTP or broker-managed lifecycle
 becomes desirable.
+
+running-process 4.2.0 added a broker backend SDK (`BackendEndpointMux`
+sans-io probe serving, `probe_with_service_async`, identity sidecar helpers,
+and a consumer conformance kit — zackees/running-process#412 §7.4). The SDK
+removes most of the hand-rolled plumbing the decline cited, but the RPC
+transport decision above is unchanged: fbuild stays on loopback HTTP, and
+SDK-based active BackendHandle probing remains tracked (stubbed) in
+FastLED/fbuild#510.


### PR DESCRIPTION
## Summary
- Bump `running-process` 4.1.0 → 4.2.0 (core-only, `default-features = false` unchanged — spawn API + containment).
- Document the 4.2.0 broker backend SDK (`BackendEndpointMux`, `probe_with_service_async`, conformance kit — zackees/running-process#412) in the workspace manifest comment and the fbuild-daemon "Why not the running-process broker" README section. The loopback-HTTP transport decision from zackees/running-process#384 is unchanged; SDK-based active BackendHandle probing remains tracked in FastLED/fbuild#510.

## Test plan
- [x] `soldr cargo check --workspace --all-targets` clean
- [x] Ignored containment contract test `daemon_children_die_when_daemon_dies` passes on 4.2.0
- [x] `soldr cargo tree -i running-process -e features` confirms core-only feature set

Refs zackees/running-process#412, FastLED/fbuild#510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `running-process` dependency from v4.1.0 to v4.2.0.

* **Documentation**
  * Updated documentation to reflect new broker backend SDK capabilities available in the updated dependency, including backend endpoint muxing, async probe support, identity sidecar helpers, and a consumer conformance kit. Clarified that existing transport mechanisms remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->