### PR TITLE
refactor(daemon): consolidate board-resolution fallback (#519)

### DIFF
--- a/crates/fbuild-config/src/board/loaders.rs
+++ b/crates/fbuild-config/src/board/loaders.rs
@@ -185,6 +185,24 @@ impl BoardConfig {
         Self::from_board_id_in_project(board_id, overrides, None)
     }
 
+    /// Load `board_id`, falling back to a known-good `default_board_id`
+    /// (e.g. `"esp32dev"`, `"uno"`, `"teensy41"`) when the primary id is
+    /// unknown, carrying the same `overrides` through to the fallback.
+    ///
+    /// `default_board_id` is expected to be a compile-time platform default
+    /// that always exists in the board database, so a failure to resolve it
+    /// is a programming error and panics rather than being swallowed.
+    pub fn from_board_id_or_default(
+        board_id: &str,
+        default_board_id: &str,
+        overrides: &HashMap<String, String>,
+    ) -> Self {
+        Self::from_board_id(board_id, overrides).unwrap_or_else(|_| {
+            Self::from_board_id(default_board_id, overrides)
+                .unwrap_or_else(|e| panic!("default board '{default_board_id}' must resolve: {e}"))
+        })
+    }
+
     /// Load board config from built-in defaults with a project-local fallback.
     ///
     /// When the built-in board database has no entry for `board_id`, fall

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -104,6 +104,27 @@ fn test_from_board_id_unknown() {
 }
 
 #[test]
+fn test_from_board_id_or_default_uses_primary_when_known() {
+    let config = BoardConfig::from_board_id_or_default("mega", "uno", &HashMap::new());
+    assert_eq!(config.mcu, "atmega2560");
+}
+
+#[test]
+fn test_from_board_id_or_default_falls_back_when_unknown() {
+    let config = BoardConfig::from_board_id_or_default("nonexistent_board", "uno", &HashMap::new());
+    assert_eq!(config.mcu, "atmega328p");
+}
+
+#[test]
+fn test_from_board_id_or_default_carries_overrides_into_fallback() {
+    let mut overrides = HashMap::new();
+    overrides.insert("f_cpu".to_string(), "8000000L".to_string());
+    let config = BoardConfig::from_board_id_or_default("nonexistent_board", "uno", &overrides);
+    assert_eq!(config.f_cpu, "8000000L");
+    assert_eq!(config.mcu, "atmega328p");
+}
+
+#[test]
 fn test_from_board_id_with_overrides() {
     let mut overrides = HashMap::new();
     overrides.insert("f_cpu".to_string(), "8000000L".to_string());

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -423,15 +423,11 @@ pub async fn deploy(
         let mut trusted_hash_update: Option<([u8; 32], String)> = None;
         let deployer: Box<dyn fbuild_deploy::Deployer> = match platform {
             fbuild_core::Platform::Espressif32 => {
-                let board_config =
-                    fbuild_config::BoardConfig::from_board_id(&board_id, &deploy_board_overrides)
-                        .unwrap_or_else(|_| {
-                            fbuild_config::BoardConfig::from_board_id(
-                                "esp32dev",
-                                &deploy_board_overrides,
-                            )
-                            .unwrap()
-                        });
+                let board_config = fbuild_config::BoardConfig::from_board_id_or_default(
+                    &board_id,
+                    "esp32dev",
+                    &deploy_board_overrides,
+                );
                 // Load MCU config to get flash offsets and esptool defaults.
                 // Fail loudly on an unknown MCU instead of silently falling
                 // back to esp32's `0x1000` bootloader offset — that offset is
@@ -663,15 +659,11 @@ pub async fn deploy(
                 Box::new(deployer)
             }
             fbuild_core::Platform::AtmelAvr | fbuild_core::Platform::AtmelMegaAvr => {
-                let board_config =
-                    fbuild_config::BoardConfig::from_board_id(&board_id, &deploy_board_overrides)
-                        .unwrap_or_else(|_| {
-                            fbuild_config::BoardConfig::from_board_id(
-                                "uno",
-                                &deploy_board_overrides,
-                            )
-                            .unwrap()
-                        });
+                let board_config = fbuild_config::BoardConfig::from_board_id_or_default(
+                    &board_id,
+                    "uno",
+                    &deploy_board_overrides,
+                );
                 let avr_config = fbuild_build::avr::mcu_config::get_avr_config().unwrap();
                 let avrdude_params = fbuild_deploy::avr::AvrdudeParams {
                     default_programmer: avr_config.avrdude.default_programmer.clone(),
@@ -695,15 +687,11 @@ pub async fn deploy(
                 // Initial wire-up was #430/#431; the deployer itself now owns
                 // baud-134 soft reboot, bounded retry, post-flash port
                 // discovery, and the optional first-byte advisory probe.
-                let board_config =
-                    fbuild_config::BoardConfig::from_board_id(&board_id, &deploy_board_overrides)
-                        .unwrap_or_else(|_| {
-                            fbuild_config::BoardConfig::from_board_id(
-                                "teensy41",
-                                &deploy_board_overrides,
-                            )
-                            .unwrap()
-                        });
+                let board_config = fbuild_config::BoardConfig::from_board_id_or_default(
+                    &board_id,
+                    "teensy41",
+                    &deploy_board_overrides,
+                );
                 let loader_params = fbuild_deploy::teensy::TeensyLoaderParams::default();
                 let loader_path = find_teensy_loader_cli();
                 let deployer = fbuild_deploy::teensy::TeensyDeployer::new(


### PR DESCRIPTION
## Summary
- Adds `BoardConfig::from_board_id_or_default(board_id, default_board_id, overrides)` to `fbuild-config`, encapsulating the "resolve `board_id`, else fall back to a known-good platform default carrying the same overrides" pattern.
- Replaces three byte-identical `from_board_id(...).unwrap_or_else(|_| from_board_id(DEFAULT, ...).unwrap())` blocks in the daemon deploy handler (ESP32 → `esp32dev`, AVR → `uno`, Teensy → `teensy41`).
- Behavior preserved: primary id wins when known; unknown id falls back to the default; overrides are carried into the fallback; a default that fails to resolve panics (programming error, same as before).

A slice of #519 (consolidate duplicated board/config resolution call sites). The deploy handler's first call site (line ~154) intentionally keeps its own shape — it falls back to the *same* id with empty overrides and returns `Option`, which is a different contract.

## Test plan
- [x] `soldr cargo test -p fbuild-config from_board_id_or_default` — 3 new tests (primary-known, fallback-on-unknown, overrides-carried) pass
- [x] `soldr cargo clippy -p fbuild-config -p fbuild-daemon --all-targets -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)