### PR TITLE
refactor: consolidate board override-fallback resolution (#519)

### DIFF
--- a/crates/fbuild-cli/src/cli/deploy.rs
+++ b/crates/fbuild-cli/src/cli/deploy.rs
@@ -42,11 +42,10 @@ pub fn infer_cli_default_emulator_kind(
         return Ok(None);
     };
     let board_overrides = config.get_board_overrides(&env_name).unwrap_or_default();
-    let board = fbuild_config::BoardConfig::from_board_id(&board_id, &board_overrides)
-        .or_else(|_| {
-            fbuild_config::BoardConfig::from_board_id(&board_id, &std::collections::HashMap::new())
-        })
-        .ok();
+    let board = fbuild_config::BoardConfig::from_board_id_with_override_fallback(
+        &board_id,
+        &board_overrides,
+    );
     Ok(
         match (platform, board.as_ref().map(|board| board.mcu.as_str())) {
             (fbuild_core::Platform::AtmelAvr, _) | (fbuild_core::Platform::AtmelMegaAvr, _) => {

--- a/crates/fbuild-config/src/board/loaders.rs
+++ b/crates/fbuild-config/src/board/loaders.rs
@@ -203,6 +203,22 @@ impl BoardConfig {
         })
     }
 
+    /// Resolve `board_id` with `overrides`, retrying without overrides if the
+    /// override-applied resolution fails. Returns `None` only when `board_id`
+    /// is unknown even without overrides.
+    ///
+    /// Used by best-effort call sites (e.g. emulator-kind inference) that want
+    /// a board for hints but must not hard-fail when a user override is
+    /// malformed.
+    pub fn from_board_id_with_override_fallback(
+        board_id: &str,
+        overrides: &HashMap<String, String>,
+    ) -> Option<Self> {
+        Self::from_board_id(board_id, overrides)
+            .or_else(|_| Self::from_board_id(board_id, &HashMap::new()))
+            .ok()
+    }
+
     /// Load board config from built-in defaults with a project-local fallback.
     ///
     /// When the built-in board database has no entry for `board_id`, fall

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -125,6 +125,27 @@ fn test_from_board_id_or_default_carries_overrides_into_fallback() {
 }
 
 #[test]
+fn test_from_board_id_with_override_fallback_known() {
+    let board = BoardConfig::from_board_id_with_override_fallback("uno", &HashMap::new());
+    assert_eq!(board.unwrap().mcu, "atmega328p");
+}
+
+#[test]
+fn test_from_board_id_with_override_fallback_unknown_returns_none() {
+    let board =
+        BoardConfig::from_board_id_with_override_fallback("nonexistent_board", &HashMap::new());
+    assert!(board.is_none());
+}
+
+#[test]
+fn test_from_board_id_with_override_fallback_applies_overrides() {
+    let mut overrides = HashMap::new();
+    overrides.insert("f_cpu".to_string(), "8000000L".to_string());
+    let board = BoardConfig::from_board_id_with_override_fallback("uno", &overrides);
+    assert_eq!(board.unwrap().f_cpu, "8000000L");
+}
+
+#[test]
 fn test_from_board_id_with_overrides() {
     let mut overrides = HashMap::new();
     overrides.insert("f_cpu".to_string(), "8000000L".to_string());

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -11,7 +11,6 @@ use crate::models::{DeployRequest, OperationResponse};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -151,9 +150,10 @@ pub async fn deploy(
             .unwrap_or_else(|_| "unknown".to_string())
     });
     let board_overrides = config.get_board_overrides(&env_name).unwrap_or_default();
-    let board = fbuild_config::BoardConfig::from_board_id(&board_id, &board_overrides)
-        .or_else(|_| fbuild_config::BoardConfig::from_board_id(&board_id, &HashMap::new()))
-        .ok();
+    let board = fbuild_config::BoardConfig::from_board_id_with_override_fallback(
+        &board_id,
+        &board_overrides,
+    );
     let deploy_route = match parse_deploy_route(
         &req,
         board


### PR DESCRIPTION
## Summary
- Adds `BoardConfig::from_board_id_with_override_fallback(board_id, overrides) -> Option<BoardConfig>` to `fbuild-config`: resolves the board with overrides, retries without overrides if that fails, and returns `None` only when the id is unknown even bare.
- Replaces the two byte-identical `from_board_id(id, overrides).or_else(|_| from_board_id(id, &HashMap::new())).ok()` blocks in `fbuild-cli/src/cli/deploy.rs` and `fbuild-daemon/src/handlers/operations/deploy.rs` (the best-effort emulator-kind inference path).
- Drops the now-unused `HashMap` import in the daemon handler.

Continues #519. Follows #543, which consolidated the *different-default* fallback (`from_board_id_or_default`). This covers the distinct *same-id, drop-overrides → Option* pattern. No behavior change.

## Test plan
- [x] `soldr cargo test -p fbuild-config with_override_fallback` — 3 new tests (known id, unknown→None, overrides applied) pass
- [x] `soldr cargo clippy -p fbuild-config -p fbuild-daemon -p fbuild-cli --all-targets -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved board configuration resolution with simplified fallback handling when board overrides are applied.

* **Tests**
  * Added unit tests for board configuration override resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->