### PR TITLE
refactor(build): add ResolutionContext board-resolution entry point (#519)

### DIFF
--- a/crates/fbuild-build/src/lib.rs
+++ b/crates/fbuild-build/src/lib.rs
@@ -28,6 +28,7 @@ pub mod parallel;
 pub mod perf_log;
 pub mod pipeline;
 pub mod renesas;
+pub mod resolution;
 pub mod rp2040;
 pub mod sam;
 pub mod script_runtime;

--- a/crates/fbuild-build/src/pipeline/context.rs
+++ b/crates/fbuild-build/src/pipeline/context.rs
@@ -69,7 +69,6 @@ impl BuildContext {
         let pio_overrides = fbuild_config::PioEnvOverrides::from_map(params.pio_env.clone());
         let config =
             fbuild_config::PlatformIOConfig::from_path_with_overrides(&ini_path, pio_overrides)?;
-        let env_config = config.get_env_config(env_name)?;
         let overlay =
             crate::script_runtime::resolve_extra_script_overlay(project_dir, env_name, &config)?;
         if let Some(p) = perf.as_mut() {
@@ -78,22 +77,14 @@ impl BuildContext {
 
         // 2. Load board config
         //
-        // Use `from_board_id_in_project` (not the legacy `from_board_id`) so
-        // a `<project_dir>/boards/<board_id>.json` file is picked up when
-        // the bundled DB has no entry. Matches PlatformIO's auto-discovery
-        // of project-local board manifests and is the only knob `fbuild
-        // build` had to honor FastLED/fbuild#515 — without this the daemon
-        // build path silently dropped the project_dir context.
+        // `ResolutionContext::resolve_board` is the single board-resolution
+        // entry point (FastLED/fbuild#519); it honors project-local
+        // `<project_dir>/boards/<board_id>.json` discovery (FastLED/fbuild#515)
+        // and `[env]` board overrides. New resolution knobs go on that
+        // context, not here.
         let t0 = std::time::Instant::now();
-        let board_id = env_config.get("board").ok_or_else(|| {
-            fbuild_core::FbuildError::ConfigError("missing 'board' in environment config".into())
-        })?;
-        let overrides = config.get_board_overrides(env_name)?;
-        let board = fbuild_config::BoardConfig::from_board_id_in_project(
-            board_id,
-            &overrides,
-            Some(project_dir.as_path()),
-        )?;
+        let board = crate::resolution::ResolutionContext::new(project_dir, env_name, &config)
+            .resolve_board()?;
         if let Some(p) = perf.as_mut() {
             p.record("board-load", t0.elapsed());
         }

--- a/crates/fbuild-build/src/resolution.rs
+++ b/crates/fbuild-build/src/resolution.rs
@@ -1,0 +1,98 @@
+//! Single entry point for resolving a build's board + platform from a
+//! parsed `platformio.ini`.
+//!
+//! Historically every build-side call site assembled `(board_id, overrides,
+//! project_dir)` by hand and called [`BoardConfig::from_board_id_in_project`]
+//! independently (see FastLED/fbuild#519). When a new resolution parameter
+//! was added — e.g. project-local `boards/<id>.json` discovery in #515/#516 —
+//! each site had to be updated by hand, and a missed one silently dropped the
+//! feature (the build behaved as if the knob didn't exist).
+//!
+//! [`ResolutionContext`] carries that context once. New resolution inputs
+//! should be threaded through here, not re-plumbed into each consumer.
+
+use fbuild_config::{BoardConfig, PlatformIOConfig};
+use fbuild_core::{FbuildError, Platform, Result};
+use std::path::Path;
+
+/// All context needed to resolve a board (and its platform) for one
+/// `[env:<name>]` section of a project's `platformio.ini`.
+pub struct ResolutionContext<'a> {
+    /// Project root (the directory containing `platformio.ini`). Used to
+    /// discover a project-local `boards/<id>.json` override.
+    pub project_dir: &'a Path,
+    /// The `[env:<name>]` section to resolve against.
+    pub env_name: &'a str,
+    /// The already-parsed project config.
+    pub config: &'a PlatformIOConfig,
+}
+
+impl<'a> ResolutionContext<'a> {
+    pub fn new(project_dir: &'a Path, env_name: &'a str, config: &'a PlatformIOConfig) -> Self {
+        Self {
+            project_dir,
+            env_name,
+            config,
+        }
+    }
+
+    /// The `board` id declared in the env section, erroring if absent.
+    pub fn board_id(&self) -> Result<String> {
+        self.config
+            .get_env_config(self.env_name)?
+            .get("board")
+            .cloned()
+            .ok_or_else(|| FbuildError::ConfigError("missing 'board' in environment config".into()))
+    }
+
+    /// Resolve the board config, honoring `[env]` board overrides and a
+    /// project-local `boards/<id>.json` when the bundled DB has no entry.
+    pub fn resolve_board(&self) -> Result<BoardConfig> {
+        let board_id = self.board_id()?;
+        let overrides = self.config.get_board_overrides(self.env_name)?;
+        BoardConfig::from_board_id_in_project(&board_id, &overrides, Some(self.project_dir))
+    }
+
+    /// Resolve the [`Platform`] for this env's board.
+    pub fn resolve_platform(&self) -> Result<Platform> {
+        let board = self.resolve_board()?;
+        board.platform().ok_or_else(|| {
+            FbuildError::ConfigError(format!(
+                "could not determine platform for board '{}' (mcu '{}')",
+                board.board, board.mcu
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_project(ini: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(dir.path().join("platformio.ini")).unwrap();
+        f.write_all(ini.as_bytes()).unwrap();
+        dir
+    }
+
+    #[test]
+    fn resolves_board_and_platform() {
+        let dir = write_project("[env:uno]\nplatform = atmelavr\nboard = uno\n");
+        let config = PlatformIOConfig::from_path(&dir.path().join("platformio.ini")).unwrap();
+        let ctx = ResolutionContext::new(dir.path(), "uno", &config);
+        assert_eq!(ctx.board_id().unwrap(), "uno");
+        assert_eq!(ctx.resolve_board().unwrap().mcu, "atmega328p");
+        assert_eq!(ctx.resolve_platform().unwrap(), Platform::AtmelAvr);
+    }
+
+    #[test]
+    fn missing_board_errors() {
+        let dir = write_project("[env:none]\nplatform = atmelavr\n");
+        let config = PlatformIOConfig::from_path(&dir.path().join("platformio.ini")).unwrap();
+        let ctx = ResolutionContext::new(dir.path(), "none", &config);
+        assert!(ctx.board_id().is_err());
+        assert!(ctx.resolve_board().is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `fbuild_build::resolution::ResolutionContext` — the single, documented entry point for resolving a board (`resolve_board`) and its platform (`resolve_platform`) from a parsed `platformio.ini` env. It honors `[env]` board overrides and project-local `boards/<id>.json` discovery (#515/#516) in one place.
- Migrates the daemon's actual build path (`pipeline::BuildContext::new_with_perf`) onto it, replacing the hand-assembled `board_id` + overrides + `from_board_id_in_project` block.
- Module doc comment points future feature work at the right injection point, per the issue's acceptance criteria.

Third slice of #519, building on #543 (`from_board_id_or_default`) and #544 (`from_board_id_with_override_fallback`). This delivers the issue's "Proposed shape." Remaining build-side sites (`compile_many::platform_for_board`, `script_runtime`) carry different input shapes (no `PlatformIOConfig` in scope) and are candidates for follow-up once those paths thread the config through.

## Test plan
- [x] `soldr cargo test -p fbuild-build` — 691 tests pass, incl. 2 new `resolution::tests`
- [x] `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean
- No behavior change for valid inputs: same primitive, same overrides, same project-local fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new resolution module providing dedicated APIs for resolving boards and platforms from project configuration files.

* **Refactor**
  * Reorganized board resolution logic in the build pipeline to use the new resolution module for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->