### PR TITLE
refactor(build): route compile_many platform lookup through resolution (#519)

### DIFF
--- a/crates/fbuild-build/src/compile_many.rs
+++ b/crates/fbuild-build/src/compile_many.rs
@@ -334,14 +334,7 @@ fn resolve_env_for_board(project_dir: &Path, board: &str) -> Result<String> {
 /// project-local board manifests and is how compile_many ingests boards
 /// shipped alongside a `platformio.ini` (FastLED/fbuild#515).
 fn platform_for_board(board: &str, project_dir: Option<&std::path::Path>) -> Result<Platform> {
-    let cfg =
-        fbuild_config::BoardConfig::from_board_id_in_project(board, &HashMap::new(), project_dir)?;
-    cfg.platform().ok_or_else(|| {
-        FbuildError::ConfigError(format!(
-            "could not determine platform for board '{}' (mcu '{}')",
-            board, cfg.mcu
-        ))
-    })
+    crate::resolution::platform_for_board(board, project_dir)
 }
 
 /// Build a single sketch through the platform orchestrator.

--- a/crates/fbuild-build/src/resolution.rs
+++ b/crates/fbuild-build/src/resolution.rs
@@ -13,6 +13,7 @@
 
 use fbuild_config::{BoardConfig, PlatformIOConfig};
 use fbuild_core::{FbuildError, Platform, Result};
+use std::collections::HashMap;
 use std::path::Path;
 
 /// All context needed to resolve a board (and its platform) for one
@@ -56,13 +57,29 @@ impl<'a> ResolutionContext<'a> {
     /// Resolve the [`Platform`] for this env's board.
     pub fn resolve_platform(&self) -> Result<Platform> {
         let board = self.resolve_board()?;
-        board.platform().ok_or_else(|| {
-            FbuildError::ConfigError(format!(
-                "could not determine platform for board '{}' (mcu '{}')",
-                board.board, board.mcu
-            ))
-        })
+        platform_of(&board, &board.board)
     }
+}
+
+/// Determine the [`Platform`] for a bare board id (no `[env]` overrides),
+/// honoring a project-local `boards/<id>.json`. This is the lookup used by
+/// sites that only know a board string — e.g. `compile_many`'s per-sketch
+/// dispatch — and shares the single "could not determine platform" error
+/// with [`ResolutionContext::resolve_platform`] (FastLED/fbuild#519).
+pub fn platform_for_board(board_id: &str, project_dir: Option<&Path>) -> Result<Platform> {
+    let board = BoardConfig::from_board_id_in_project(board_id, &HashMap::new(), project_dir)?;
+    platform_of(&board, board_id)
+}
+
+/// Shared mapping from a resolved [`BoardConfig`] to its [`Platform`], with a
+/// uniform error keyed by `label` (a board id or define) for diagnostics.
+fn platform_of(board: &BoardConfig, label: &str) -> Result<Platform> {
+    board.platform().ok_or_else(|| {
+        FbuildError::ConfigError(format!(
+            "could not determine platform for board '{}' (mcu '{}')",
+            label, board.mcu
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -85,6 +102,19 @@ mod tests {
         assert_eq!(ctx.board_id().unwrap(), "uno");
         assert_eq!(ctx.resolve_board().unwrap().mcu, "atmega328p");
         assert_eq!(ctx.resolve_platform().unwrap(), Platform::AtmelAvr);
+    }
+
+    #[test]
+    fn platform_for_board_free_fn_matches_context() {
+        assert_eq!(
+            super::platform_for_board("uno", None).unwrap(),
+            Platform::AtmelAvr
+        );
+    }
+
+    #[test]
+    fn platform_for_board_unknown_errors() {
+        assert!(super::platform_for_board("nonexistent_board", None).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `resolution::platform_for_board(board_id, project_dir)` — the bare-board-id platform lookup (no `[env]` overrides) — plus a shared private `platform_of` helper that owns the single "could not determine platform for board ..." error.
- Migrates `compile_many::platform_for_board` to delegate to it, deleting the duplicated `from_board_id_in_project` + error-format block.
- `ResolutionContext::resolve_platform` now also routes through `platform_of`, so both build-side platform lookups share one error path.

Fourth slice of #519, building on the `resolution` module added in #545. No behavior change: same primitive, same error text.

## Test plan
- [x] `soldr cargo test -p fbuild-build` — passes, incl. 2 new `resolution::tests` and the existing `compile_many::tests::platform_for_board_uno_is_avr`
- [x] `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings` clean
- [x] `soldr cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)