### PR TITLE
fix(esp32): detect ESP ROM download-mode in serial monitor (#532)

### DIFF
--- a/crates/fbuild-daemon/src/handlers/operations/monitor.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/monitor.rs
@@ -28,6 +28,11 @@ pub(crate) struct MonitorState {
     timeout_dur: Option<std::time::Duration>,
     expect_found: bool,
     show_timestamp: bool,
+    /// Set once an ESP ROM download-mode signal has been diagnosed, so the
+    /// boot-mode warning is emitted at most once per monitor session rather
+    /// than on every repeated `waiting for download` line. See
+    /// FastLED/fbuild#532.
+    boot_mode_warned: bool,
 }
 
 impl MonitorState {
@@ -64,6 +69,7 @@ impl MonitorState {
             timeout_dur: timeout_secs.map(std::time::Duration::from_secs_f64),
             expect_found: false,
             show_timestamp,
+            boot_mode_warned: false,
         }
     }
 
@@ -95,6 +101,13 @@ impl MonitorState {
             tracing::info!("{:02}:{:05.2} {}", minutes, seconds, line);
         } else {
             tracing::info!("{}", line);
+        }
+
+        if !self.boot_mode_warned {
+            if let Some(signal) = fbuild_serial::boot_mode::detect_download_mode(line) {
+                self.boot_mode_warned = true;
+                tracing::warn!("{}", signal.diagnostic());
+            }
         }
 
         if let Some(ref re) = self.expect_re {

--- a/crates/fbuild-serial/src/boot_mode.rs
+++ b/crates/fbuild-serial/src/boot_mode.rs
@@ -1,0 +1,105 @@
+//! ESP ROM boot-mode detection.
+//!
+//! After a flash / reset / monitor handoff, an ESP chip can be left in the
+//! serial ROM bootloader ("download mode") instead of running application
+//! firmware. On the wire this shows up as a fixed set of ROM strings, e.g.
+//! `waiting for download` and `boot:0x23 DOWNLOAD(USB/UART0)`.
+//!
+//! Surfacing a targeted diagnostic when those appear — rather than letting the
+//! monitor sit silently while the board does nothing — lets callers (and
+//! humans reading the logs) recognise the boot-mode lockup and recover, rather
+//! than mistaking a stuck-in-ROM board for a host-side deadlock. See
+//! FastLED/fbuild#532.
+
+/// A detected ESP ROM download-mode signal on the serial stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootModeSignal {
+    /// ROM is idle, waiting for a download over USB/UART
+    /// (`waiting for download`).
+    WaitingForDownload,
+    /// Boot straps selected ROM download mode
+    /// (`boot:0x.. DOWNLOAD(USB/UART...)`).
+    DownloadModeSelected,
+}
+
+impl BootModeSignal {
+    /// A human-readable, actionable diagnostic for this signal.
+    pub fn diagnostic(self) -> &'static str {
+        match self {
+            BootModeSignal::WaitingForDownload => {
+                "ESP chip is in ROM download mode (\"waiting for download\") — it is \
+                 not running application firmware. Power-cycle the board or issue a \
+                 DTR/RTS reset to return to run mode."
+            }
+            BootModeSignal::DownloadModeSelected => {
+                "ESP boot straps selected ROM download mode (DOWNLOAD(USB/UART)) — the \
+                 board will not run firmware until reset. Power-cycle or DTR/RTS-reset \
+                 to recover."
+            }
+        }
+    }
+}
+
+/// Inspect one serial line for an ESP ROM download-mode indicator.
+///
+/// Matching is case-insensitive and substring-based so it survives the leading
+/// `boot:0xNN ` strap prefix and any timestamp the monitor prepends.
+pub fn detect_download_mode(line: &str) -> Option<BootModeSignal> {
+    let lower = line.to_ascii_lowercase();
+    if lower.contains("waiting for download") {
+        return Some(BootModeSignal::WaitingForDownload);
+    }
+    if lower.contains("download(usb/uart") || lower.contains("download(uart") {
+        return Some(BootModeSignal::DownloadModeSelected);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn waiting_for_download_detected() {
+        assert_eq!(
+            detect_download_mode("waiting for download"),
+            Some(BootModeSignal::WaitingForDownload)
+        );
+    }
+
+    #[test]
+    fn download_strap_line_detected() {
+        assert_eq!(
+            detect_download_mode("boot:0x23 (DOWNLOAD(USB/UART0))"),
+            Some(BootModeSignal::DownloadModeSelected)
+        );
+        assert_eq!(
+            detect_download_mode("rst:0x1 (POWERON),boot:0x23 DOWNLOAD(UART0)"),
+            Some(BootModeSignal::DownloadModeSelected)
+        );
+    }
+
+    #[test]
+    fn case_insensitive_and_timestamp_prefixed() {
+        assert_eq!(
+            detect_download_mode("00:03.21 WAITING FOR DOWNLOAD"),
+            Some(BootModeSignal::WaitingForDownload)
+        );
+    }
+
+    #[test]
+    fn normal_boot_and_app_lines_ignored() {
+        assert_eq!(
+            detect_download_mode("boot:0x13 (SPI_FAST_FLASH_BOOT)"),
+            None
+        );
+        assert_eq!(detect_download_mode("Hello from app_main"), None);
+        assert_eq!(detect_download_mode(""), None);
+    }
+
+    #[test]
+    fn diagnostics_are_non_empty() {
+        assert!(!BootModeSignal::WaitingForDownload.diagnostic().is_empty());
+        assert!(!BootModeSignal::DownloadModeSelected.diagnostic().is_empty());
+    }
+}

--- a/crates/fbuild-serial/src/lib.rs
+++ b/crates/fbuild-serial/src/lib.rs
@@ -30,6 +30,7 @@
 //! 3. Deploy preemption forcibly closes sessions, notifies monitors via WebSocket
 //! 4. Windows USB-CDC needs 30 retries with exponential backoff after hard reset
 
+pub mod boot_mode;
 pub mod crash_decoder;
 pub mod manager;
 pub mod messages;


### PR DESCRIPTION
## Summary
- Adds `fbuild_serial::boot_mode::detect_download_mode`, which recognises the fixed ESP ROM bootloader signals on the serial stream (`waiting for download` and `boot:0x.. DOWNLOAD(USB/UART...)`). Matching is case-insensitive, substring-based, and tolerant of a leading `boot:0xNN ` strap prefix or a monitor timestamp.
- Wires detection into the daemon monitor loop (`MonitorState::process_line`) so that when a board is stuck in ROM download mode, fbuild emits a single actionable `tracing::warn!` diagnostic (power-cycle / DTR-RTS reset) instead of sitting silently — addressing the boot-mode-lockup half of #532.

## Why
After a flash/reset/monitor handoff an ESP chip can be left in the serial ROM bootloader rather than running application firmware. Previously the monitor stayed silent, making a stuck-in-ROM board indistinguishable from a host-side deadlock.

## Test plan
- [x] `soldr cargo test -p fbuild-serial boot_mode` — 5 unit tests (waiting-for-download, strap line, case-insensitive + timestamp prefix, normal boot lines ignored, diagnostics non-empty)
- [x] `soldr cargo clippy -p fbuild-serial -p fbuild-daemon --all-targets -- -D warnings`
- [x] `soldr cargo fmt --all -- --check`

Refs #532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Serial monitor now prevents duplicate warnings when ESP ROM boot mode signals are detected within a session.

* **Improvements**
  * Added ESP ROM boot mode signal detection on serial connections, including case-insensitive pattern matching for download modes and waiting states with diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->