### PR TITLE
ci(lpc8xx): un-stub lpc845brk + lpcxpresso804 builds (Stage 8 of #487)

### DIFF
--- a/.github/workflows/build-lpc845brk.yml
+++ b/.github/workflows/build-lpc845brk.yml
@@ -1,33 +1,5 @@
 name: Build LPC845-BRK
 
-# No-op stub. The NxpLpc orchestrator DOES build this variant —
-# proof: `fbuild build . -e lpc845brk` is green on `main` in upstream
-# `zackees/ArduinoCore-LPC8xx` CI (variant source of truth). This
-# stub only exists because there's no in-tree fixture for it yet
-# (no `tests/platform/lpc845brk/`; the board JSON
-# `boards/json/lpc845brk.json` landed in PR #514).
-#
-# Tracked: FastLED/fbuild#528 — Stage 8 of META #487. When the
-# fixture lands, swap this `jobs.build` body for:
-#
-#   jobs:
-#     build:
-#       uses: ./.github/workflows/template_build.yml
-#       with:
-#         workflow-name: "NXP LPC845-BRK"
-#         test-dir: "tests/platform/lpc845brk"
-#         env-name: "lpc845brk"
-#         firmware-ext: "bin"
-#
-# Variant source: https://github.com/zackees/ArduinoCore-LPC8xx
-# (variants/lpc845brk).
-#
-# History: a previous attempt used `continue-on-error: true` on the
-# reusable-workflow caller, but that keyword is NOT in GitHub's
-# allow-list for reusable callers — every push went red with a
-# "workflow file issue" before any job actually ran. The no-op pass
-# below sidesteps that limitation.
-
 on:
   workflow_dispatch: {}
   push:
@@ -37,11 +9,9 @@ on:
 
 jobs:
   build:
-    name: NXP LPC845-BRK (stub — fixture pending)
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "No in-tree fixture for lpc845brk yet (tests/platform/lpc845brk/)."
-          echo "See FastLED/fbuild#528 (Stage 8 of META #487)."
-          echo "This workflow stub passes intentionally; replace with the"
-          echo "template_build.yml caller once the fixture lands."
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "NXP LPC845-BRK"
+      test-dir: "tests/platform/lpc845brk"
+      env-name: "lpc845brk"
+      firmware-ext: "bin"

--- a/.github/workflows/build-lpcxpresso804.yml
+++ b/.github/workflows/build-lpcxpresso804.yml
@@ -1,33 +1,5 @@
 name: Build LPCXpresso804
 
-# No-op stub. The NxpLpc orchestrator DOES build this variant —
-# proof: `fbuild build . -e lpcxpresso804` is green on `main` in
-# upstream `zackees/ArduinoCore-LPC8xx` CI (variant source of truth).
-# This stub only exists because there's no in-tree fixture for it yet
-# (no `tests/platform/lpcxpresso804/`; the board JSON
-# `boards/json/lpcxpresso804.json` landed in PR #514).
-#
-# Tracked: FastLED/fbuild#528 — Stage 8 of META #487. When the
-# fixture lands, swap this `jobs.build` body for:
-#
-#   jobs:
-#     build:
-#       uses: ./.github/workflows/template_build.yml
-#       with:
-#         workflow-name: "NXP LPCXpresso804"
-#         test-dir: "tests/platform/lpcxpresso804"
-#         env-name: "lpcxpresso804"
-#         firmware-ext: "bin"
-#
-# Variant source: https://github.com/zackees/ArduinoCore-LPC8xx
-# (variants/lpcxpresso804).
-#
-# History: a previous attempt used `continue-on-error: true` on the
-# reusable-workflow caller, but that keyword is NOT in GitHub's
-# allow-list for reusable callers — every push went red with a
-# "workflow file issue" before any job actually ran. The no-op pass
-# below sidesteps that limitation.
-
 on:
   workflow_dispatch: {}
   push:
@@ -37,11 +9,9 @@ on:
 
 jobs:
   build:
-    name: NXP LPCXpresso804 (stub — fixture pending)
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "No in-tree fixture for lpcxpresso804 yet (tests/platform/lpcxpresso804/)."
-          echo "See FastLED/fbuild#528 (Stage 8 of META #487)."
-          echo "This workflow stub passes intentionally; replace with the"
-          echo "template_build.yml caller once the fixture lands."
+    uses: ./.github/workflows/template_build.yml
+    with:
+      workflow-name: "NXP LPCXpresso804"
+      test-dir: "tests/platform/lpcxpresso804"
+      env-name: "lpcxpresso804"
+      firmware-ext: "bin"

--- a/tests/platform/lpc845brk/README.md
+++ b/tests/platform/lpc845brk/README.md
@@ -1,0 +1,11 @@
+# LPC845-BRK build fixture
+
+Arduino-framework build fixture for the NXP **LPC845-BRK** (LPC845M301JBD48,
+Cortex-M0+, 64 KB Flash, 16 KB RAM, 30 MHz).
+
+Drives `.github/workflows/build-lpc845brk.yml` via `template_build.yml`.
+The `NxpLpc` orchestrator compiles this empty sketch against the
+`zackees/ArduinoCore-LPC8xx` Arduino core (`framework = arduino`,
+`board = lpc845brk`) and links `firmware.bin`.
+
+Part of Stage 8 of META FastLED/fbuild#487 (#528).

--- a/tests/platform/lpc845brk/lpc845brk.ino
+++ b/tests/platform/lpc845brk/lpc845brk.ino
@@ -1,0 +1,2 @@
+void setup() {}
+void loop() {}

--- a/tests/platform/lpc845brk/platformio.ini
+++ b/tests/platform/lpc845brk/platformio.ini
@@ -1,0 +1,4 @@
+[env:lpc845brk]
+platform = nxplpc
+board = lpc845brk
+framework = arduino

--- a/tests/platform/lpcxpresso804/README.md
+++ b/tests/platform/lpcxpresso804/README.md
@@ -1,0 +1,11 @@
+# LPCXpresso804 build fixture
+
+Arduino-framework build fixture for the NXP **LPCXpresso804** (LPC804M101JDH24,
+Cortex-M0+, 32 KB Flash, 4 KB RAM, 15 MHz).
+
+Drives `.github/workflows/build-lpcxpresso804.yml` via `template_build.yml`.
+The `NxpLpc` orchestrator compiles this empty sketch against the
+`zackees/ArduinoCore-LPC8xx` Arduino core (`framework = arduino`,
+`board = lpcxpresso804`) and links `firmware.bin`.
+
+Part of Stage 8 of META FastLED/fbuild#487 (#528).

--- a/tests/platform/lpcxpresso804/lpcxpresso804.ino
+++ b/tests/platform/lpcxpresso804/lpcxpresso804.ino
@@ -1,0 +1,2 @@
+void setup() {}
+void loop() {}

--- a/tests/platform/lpcxpresso804/platformio.ini
+++ b/tests/platform/lpcxpresso804/platformio.ini
@@ -1,0 +1,4 @@
+[env:lpcxpresso804]
+platform = nxplpc
+board = lpcxpresso804
+framework = arduino


### PR DESCRIPTION
## Summary
- Adds in-tree build fixtures for the two remaining stubbed LPC8xx variants: `tests/platform/lpc845brk/` and `tests/platform/lpcxpresso804/` (each `platformio.ini` + empty `.ino` + `README.md`, mirroring the green `lpcxpresso845max` fixture).
- Swaps the no-op stub bodies in `build-lpc845brk.yml` and `build-lpcxpresso804.yml` for real `template_build.yml` callers — same shape as the already-green `build-lpc804` / `build-lpc845` / `build-lpcxpresso845max` workflows.

## Why
The `NxpLpc` orchestrator already builds both variants (board JSONs landed in #514); the stubs only existed because no in-tree fixture had been added. This closes the last Stage-8 gap for #487 so all five LPC8xx variants have real per-board CI.

## Local verification
Built both new fixtures end-to-end with the local daemon (zccache disabled to dodge an unrelated local zccache-daemon flake):

```
fbuild build tests/platform/lpc845brk     -e lpc845brk     -> firmware.bin 324 B (flash 0.5%, ram 0.0%)
fbuild build tests/platform/lpcxpresso804  -e lpcxpresso804 -> firmware.bin 308 B (flash 0.9%, ram 0.1%)
```
Toolchain `arm-none-eabi-gcc 15.2.1`, framework core 6/6 + sketch 1/1 compiled, `firmware.elf` + `firmware.bin` produced for both. `soldr cargo test -p fbuild-build nxplpc` — 19/19 green.

## Test plan
- [x] `fbuild build` produces firmware for both new fixtures locally
- [x] 19 nxplpc orchestrator unit tests pass
- [ ] CI: the two un-stubbed workflows go green on this PR

Closes #528. Part of META #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)