### PR TITLE
feat(lpc8xx): real Arduino Blink fixtures for lpc804/lpc845 (Stage 3 of #487)

### DIFF
--- a/crates/fbuild-build/src/nxplpc/assets/main.cpp
+++ b/crates/fbuild-build/src/nxplpc/assets/main.cpp
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: MIT
 //
-// NXP LPC8xx — hand-rolled Arduino `main()` shim (Stage 2 of #487).
+// NXP LPC8xx — bundled Arduino `main()` (#487 Stage 3, #479).
 //
-// The Stage-1 LPC8xx test fixtures (tests/platform/lpc845/lpc845.ino,
-// tests/platform/lpc804/lpc804.ino) define `setup()` and `loop()` but
-// have no `main()`. The orchestrator embeds this file and emits it into
-// the build dir as a third source so the linker has an entry point.
+// The LPC8xx test fixtures (tests/platform/lpc804/lpc804.ino,
+// tests/platform/lpc845/lpc845.ino) define `setup()` and `loop()` but
+// have no `main()`. The orchestrator embeds this file alongside the rest
+// of the bundled `arduino_stub` core (Arduino.h, wiring_digital.c,
+// wiring_time.c, …) and emits it into the build dir so the linker has an
+// entry point. It mirrors `zackees/ArduinoCore-LPC8xx`'s framework-owned
+// `main()`; a project that ships that variant core simply overrides it.
 //
-// This shim is intentionally minimal — it does NOT touch peripherals,
-// does NOT initialise GPIO, does NOT set up timing. Stage-1 startup_.S
-// runs SystemInit() (clock + flash wait states) before this `main()` is
+// This `main()` is intentionally minimal — it does NOT touch peripherals,
+// does NOT initialise GPIO, does NOT set up timing. startup_.S runs
+// SystemInit() (clock + flash wait states) before this `main()` is
 // reached. Anything else the sketch needs must be done in `setup()`.
-//
-// This shim is replaced by the framework-owned `main()` in
-// `zackees/ArduinoCore-LPC8xx::cores/lpc8xx/main.cpp` once #479 lands
-// (tracked in #487, Stage 4: "vendor the framework into fbuild").
 
 // User-provided Arduino entry points. The .ino preprocessor emits normal
 // C++ prototypes, so keep these declarations in C++ linkage.

--- a/crates/fbuild-config/assets/boards/json/lpc804.json
+++ b/crates/fbuild-config/assets/boards/json/lpc804.json
@@ -16,6 +16,7 @@
   },
   "fcpu": 15000000,
   "frameworks": [
+    "arduino",
     "cmsis"
   ],
   "id": "lpc804",

--- a/crates/fbuild-config/assets/boards/json/lpc845.json
+++ b/crates/fbuild-config/assets/boards/json/lpc845.json
@@ -18,6 +18,7 @@
   },
   "fcpu": 30000000,
   "frameworks": [
+    "arduino",
     "cmsis"
   ],
   "id": "lpc845",

--- a/tests/platform/lpc804/lpc804.ino
+++ b/tests/platform/lpc804/lpc804.ino
@@ -1,4 +1,22 @@
-// Minimal LPC804 sketch. Stage-2 FastLED port (FastLED/FastLED#2836) will
-// replace this with a real LED-blink fixture once the orchestrator can compile.
-void setup() {}
-void loop() {}
+// LPC804 Arduino-framework Blink fixture (FastLED/fbuild#479).
+//
+// Exercises the minimum Arduino surface the orchestrator must compile and
+// link: pinMode + digitalWrite (GPIO) and delay (SysTick timing). The
+// bundled nxplpc Arduino core resolves these symbols; a project that ships
+// its own variant core (zackees/ArduinoCore-LPC8xx) provides the real
+// register-level GPIO implementation.
+
+#ifndef LED_BUILTIN
+#define LED_BUILTIN 0
+#endif
+
+void setup() {
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+}

--- a/tests/platform/lpc845/lpc845.ino
+++ b/tests/platform/lpc845/lpc845.ino
@@ -1,4 +1,22 @@
-// Minimal LPC845 sketch. Stage-2 FastLED port (FastLED/FastLED#2836) will
-// replace this with a real LED-blink fixture once the orchestrator can compile.
-void setup() {}
-void loop() {}
+// LPC845 Arduino-framework Blink fixture (FastLED/fbuild#479).
+//
+// Exercises the minimum Arduino surface the orchestrator must compile and
+// link: pinMode + digitalWrite (GPIO) and delay (SysTick timing). The
+// bundled nxplpc Arduino core resolves these symbols; a project that ships
+// its own variant core (zackees/ArduinoCore-LPC8xx) provides the real
+// register-level GPIO implementation.
+
+#ifndef LED_BUILTIN
+#define LED_BUILTIN 0
+#endif
+
+void setup() {
+    pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(500);
+    digitalWrite(LED_BUILTIN, LOW);
+    delay(500);
+}


### PR DESCRIPTION
## Summary
- Upgrade `tests/platform/lpc804/lpc804.ino` and `tests/platform/lpc845/lpc845.ino` from empty stubs to a real Arduino Blink (`pinMode` / `digitalWrite` / `delay`), exercising the minimum GPIO + SysTick surface the bundled `arduino_stub` core must compile and link.
- Add `"arduino"` to the `frameworks` list in `lpc804.json` and `lpc845.json` so the boards advertise Arduino framework support.
- Refresh the comment in the bundled `nxplpc/assets/main.cpp` to reflect its in-tree role (mirroring `zackees/ArduinoCore-LPC8xx`'s framework-owned `main()`), rather than describing it as a temporary shim to be replaced.

Closes #479.

## Test plan
- [x] `fbuild build tests/platform/lpc804 -e lpc804` → links `firmware.bin` (368 B flash, 8 B RAM)
- [x] `fbuild build tests/platform/lpc845 -e lpc845` → links `firmware.bin` (384 B flash, 8 B RAM)
- [x] `soldr cargo test -p fbuild-build` → all nxplpc tests pass (693 passed)
- [ ] CI green (LPC804 / LPC845 board workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)