### PR TITLE
refactor(daemon): route emulator board lookups through project-aware resolution (#519)

### DIFF
--- a/crates/fbuild-daemon/src/handlers/emulator/avr8js_deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/avr8js_deploy.rs
@@ -93,7 +93,11 @@ pub async fn deploy_avr8js(
         );
     }
 
-    let board = match fbuild_config::BoardConfig::from_board_id(&board_id, &HashMap::new()) {
+    let board = match fbuild_config::BoardConfig::from_board_id_in_project(
+        &board_id,
+        &HashMap::new(),
+        Some(project_dir.as_path()),
+    ) {
         Ok(board) => board,
         Err(e) => {
             return (

--- a/crates/fbuild-daemon/src/handlers/emulator/qemu_deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/qemu_deploy.rs
@@ -128,7 +128,11 @@ pub async fn deploy_qemu(
         );
     }
 
-    let board = match fbuild_config::BoardConfig::from_board_id(&board_id, &board_overrides) {
+    let board = match fbuild_config::BoardConfig::from_board_id_in_project(
+        &board_id,
+        &board_overrides,
+        Some(project_dir.as_path()),
+    ) {
         Ok(board) => board,
         Err(e) => {
             return (

--- a/crates/fbuild-daemon/src/handlers/emulator/select.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/select.rs
@@ -27,7 +27,11 @@ pub fn select_runner(
     board_overrides: &HashMap<String, String>,
     emulator: Option<&str>,
 ) -> fbuild_core::Result<Box<dyn EmulatorRunner>> {
-    let board = fbuild_config::BoardConfig::from_board_id(board_id, board_overrides)?;
+    let board = fbuild_config::BoardConfig::from_board_id_in_project(
+        board_id,
+        board_overrides,
+        Some(project_dir),
+    )?;
 
     if let Some(explicit) = emulator {
         return match explicit {
@@ -247,7 +251,12 @@ pub async fn test_emu(
         let needs_qemu_flags = platform == fbuild_core::Platform::Espressif32
             && req.emulator.as_deref() != Some("avr8js");
         let board_for_flags = if needs_qemu_flags {
-            fbuild_config::BoardConfig::from_board_id(&board_id, &board_overrides).ok()
+            fbuild_config::BoardConfig::from_board_id_in_project(
+                &board_id,
+                &board_overrides,
+                Some(project_dir.as_path()),
+            )
+            .ok()
         } else {
             None
         };


### PR DESCRIPTION
## Summary
Part of #519 (consolidate duplicated board/config resolution call sites).

The emulator path had three production call sites that resolved a board via the legacy `BoardConfig::from_board_id`, silently dropping the `project_dir` they already hold in scope:

- `select_runner` (`emulator/select.rs`) — runner selection
- `test_emu`'s QEMU-flags board load (`emulator/select.rs`)
- `deploy_avr8js` (`emulator/avr8js_deploy.rs`)
- `deploy_qemu` (`emulator/qemu_deploy.rs`)

This diverged from the build path (which routes through `ResolutionContext` / `from_board_id_in_project`): a project-local `boards/<id>.json` was honored when **building** an env but ignored when **selecting/launching the emulator** for that same env. All four sites now call `from_board_id_in_project(..., Some(project_dir))`.

Behavior is identical when no project-local board JSON exists — guaranteed by the existing `from_board_id_is_equivalent_to_in_project_with_none` equivalence test in `fbuild-config`.

## Test plan
- [x] `soldr cargo check -p fbuild-daemon --all-targets`
- [x] `soldr cargo clippy -p fbuild-daemon --all-targets -- -D warnings`
- [x] `soldr cargo test -p fbuild-daemon emulator` → 43 passed, 0 failed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced board configuration resolution in emulator deployment handlers (AVR8js and QEMU) and runner selection to better utilize project context for improved configuration accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->