### PR TITLE
feat(build): widen extra_scripts compatibility shim (#554)

### DIFF
--- a/crates/fbuild-build/README.md
+++ b/crates/fbuild-build/README.md
@@ -23,18 +23,32 @@ Supported in native mode:
 - `pre:` and `post:` script entries
 - `Import("env")` in PRE/POST scripts
 - `Import("projenv")` in POST scripts only
+- `from SCons.Script import DefaultEnvironment` followed by `DefaultEnvironment()` (returns the same mock env as `Import("env")`)
 - `Append`, `AppendUnique`, `Prepend`, and `Replace` over `CPPDEFINES`, `CPPPATH`, `CCFLAGS`, `CFLAGS`, `CXXFLAGS`, `ASFLAGS`, `LINKFLAGS`, `LIBPATH`, and `LIBS`
+- `BUILD_FLAGS` (PlatformIO's aggregate compile-flag list) — mutations fold into the common compile flags on export
+- tuple-shaped `CPPDEFINES` appended in place (`env["CPPDEFINES"].append(("NAME", value))`) export as `-DNAME=value`
+- project introspection: `GetBuildType`, `GetProjectOptions`, `GetProjectOption`, and `env.get(key, default)` (falls through env vars → project options → default)
 - helper shims such as `Dump`, `BoardConfig`, `PioPlatform`, `Flatten`, `VerboseAction`, and `Execute`
+- non-flag tool/output scopes (e.g. `MKSPIFFSTOOL`, `PROGNAME`, `UPLOAD_PROTOCOL`) are **recorded as notes** rather than failing, so tool-path scripts no longer abort the native build
 
 Rejected or out of scope:
 
 - unsupported script prefixes
 - PRE scripts that request `projenv`
-- mutations on unsupported SCons scopes
+- mutations on genuinely unknown SCons scopes (anything outside the supported flag scopes and the known-ignored tool scopes)
 - unsupported `Import(...)` targets
 - builders, middleware, upload/package hooks, and other arbitrary Python-driven build behavior
 
 Unsupported `extra_scripts` behavior fails the native build early with a recommendation to use `--platformio`.
+
+### Structural limitations of the mock
+
+The shim runs scripts against a mock SCons `env`; it does **not** run real SCons. As a result:
+
+1. **Mock scopes start empty.** The mock does not seed `CCFLAGS`/`LINKFLAGS`/etc. with the platform's existing flags. Scripts that read-transform-and-rewrite (e.g. remove a flag the toolchain injected) see an empty list, so removals are no-ops.
+2. **No real SCons graph.** Builders, node dependencies, and the SConscript hierarchy do not exist; `SConscript(...)` bails to `--platformio`.
+3. **Effectful `Execute` is a no-op.** `env.Execute(...)` / `VerboseAction` do not run external commands — they are recorded as notes. Scripts that generate headers or download artifacts at build time will not have those side effects.
+4. **`build_flags = !python ...` stdout-capture pattern is out of scope.** Only `extra_scripts` entries are interpreted, not flag-emitting shell substitutions in `build_flags`.
 
 ## Compile Database (compile_commands.json)
 

--- a/crates/fbuild-build/src/script_runtime.rs
+++ b/crates/fbuild-build/src/script_runtime.rs
@@ -732,4 +732,255 @@ Import(\"env\")
         );
         assert!(err.contains("Recommendation: use --platformio"), "{err}");
     }
+
+    /// Write a project whose `platformio.ini` carries extra `[env:demo]` lines
+    /// (e.g. `build_type = debug`) alongside a single `extra_scripts` entry.
+    fn write_runtime_project_with_config(
+        env_lines: &str,
+        extra_scripts: &str,
+        script_name: &str,
+        script_body: &str,
+    ) -> tempfile::TempDir {
+        let temp = tempfile::tempdir().unwrap();
+        let project_dir = temp.path();
+        fs::write(
+            project_dir.join("platformio.ini"),
+            format!(
+                "\
+[env:demo]
+platform = atmelavr
+board = uno
+framework = arduino
+{env_lines}extra_scripts = {extra_scripts}
+"
+            ),
+        )
+        .unwrap();
+        fs::write(project_dir.join(script_name), script_body).unwrap();
+        temp
+    }
+
+    fn resolve_runtime_overlay(project_dir: &Path) -> BuildOverlay {
+        let config =
+            fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini"))
+                .unwrap();
+        resolve_extra_script_overlay(project_dir, "demo", &config).unwrap()
+    }
+
+    // ---- SIMPLE tier ------------------------------------------------------
+
+    /// Marlin `common-cxxflags.py`-style script: language-specific append,
+    /// `GetBuildType()` gating, in-place `BUILD_FLAGS` append, and a no-op
+    /// `AddPostAction`. Source: MarlinFirmware/Marlin buildroot scripts.
+    #[test]
+    fn test_shim_simple_marlin_cxxflags_style() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = write_runtime_project_with_config(
+            "build_type = debug\n",
+            "post:common_cxxflags.py",
+            "common_cxxflags.py",
+            "\
+Import(\"env\")
+flags = []
+if \"teensy\" not in env[\"PIOENV\"]:
+    flags.append(\"-Wno-register\")
+env.Append(CXXFLAGS=flags)
+if env.GetBuildType() == \"debug\":
+    env.Append(CPPDEFINES=[\"MARLIN_DEBUG\"])
+env[\"BUILD_FLAGS\"].append(\"-DBOARD_F_CPU=16000000\")
+env.AddPostAction(\"$PROGPATH\", lambda *a, **k: None)
+",
+        );
+
+        let overlay = resolve_runtime_overlay(temp.path());
+        assert!(
+            overlay
+                .global_compile
+                .cxx
+                .contains(&"-Wno-register".to_string()),
+            "{overlay:?}"
+        );
+        assert!(
+            overlay
+                .global_compile
+                .common
+                .contains(&"-DMARLIN_DEBUG".to_string()),
+            "{overlay:?}"
+        );
+        assert!(
+            overlay
+                .global_compile
+                .common
+                .contains(&"-DBOARD_F_CPU=16000000".to_string()),
+            "BUILD_FLAGS should fold into common compile flags: {overlay:?}"
+        );
+    }
+
+    /// Tuple-shaped `CPPDEFINES` appended in place via `__getitem__` must still
+    /// emit `-Dkey=value`, not a malformed array entry.
+    #[test]
+    fn test_shim_simple_inplace_tuple_cppdefine() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = write_runtime_project_with_config(
+            "",
+            "post:tuple_define.py",
+            "tuple_define.py",
+            "\
+Import(\"env\")
+env[\"CPPDEFINES\"].append((\"VERSION\", 7))
+env.Append(CPPDEFINES=[\"PLAIN\"])
+",
+        );
+
+        let overlay = resolve_runtime_overlay(temp.path());
+        assert!(
+            overlay
+                .global_compile
+                .common
+                .contains(&"-DVERSION=7".to_string()),
+            "{overlay:?}"
+        );
+        assert!(
+            overlay
+                .global_compile
+                .common
+                .contains(&"-DPLAIN".to_string()),
+            "{overlay:?}"
+        );
+    }
+
+    // ---- MEDIUM tier ------------------------------------------------------
+
+    /// namf `platformio_script.py`-style script: obtains env via
+    /// `from SCons.Script import DefaultEnvironment`, reads + rewrites
+    /// `LINKFLAGS`, and registers a no-op post action.
+    #[test]
+    fn test_shim_medium_default_environment_linkflags() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = write_runtime_project_with_config(
+            "",
+            "post:namf_style.py",
+            "namf_style.py",
+            "\
+from SCons.Script import DefaultEnvironment
+env = DefaultEnvironment()
+flags = \" \".join(env[\"LINKFLAGS\"])
+flags = flags.replace(\"-u _printf_float\", \"\")
+env.Replace(LINKFLAGS=flags.split())
+env.Append(LINKFLAGS=[\"-Wl,--gc-sections\"])
+def after_build(*a, **k):
+    pass
+env.AddPostAction(\"$BUILD_DIR/firmware.bin\", after_build)
+",
+        );
+
+        let overlay = resolve_runtime_overlay(temp.path());
+        assert!(
+            overlay
+                .link
+                .flags
+                .contains(&"-Wl,--gc-sections".to_string()),
+            "{overlay:?}"
+        );
+    }
+
+    /// m5panel `littlefsbuilder.py`-style script: `env.get()` plus a
+    /// `Replace` on a non-flag tool scope. The tool scope must be recorded as
+    /// a note (not a hard failure) while the real flag mutation lands.
+    #[test]
+    fn test_shim_medium_nonflag_scope_recorded_not_rejected() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = write_runtime_project_with_config(
+            "",
+            "post:littlefs.py",
+            "littlefs.py",
+            "\
+Import(\"env\")
+env.Replace(MKSPIFFSTOOL=env.get(\"PROJECT_DIR\") + \"/tools/mklittlefs\")
+env.Append(CPPDEFINES=[\"LFS_OK\"])
+",
+        );
+
+        let overlay = resolve_runtime_overlay(temp.path());
+        assert!(
+            overlay
+                .global_compile
+                .common
+                .contains(&"-DLFS_OK".to_string()),
+            "{overlay:?}"
+        );
+        assert!(
+            overlay.notes.iter().any(|n| n.contains("MKSPIFFSTOOL")),
+            "non-flag scope should be recorded as a note: {overlay:?}"
+        );
+    }
+
+    // ---- COMPLEX tier (graceful refusal / no-op) --------------------------
+
+    /// amsreader `generate_includes.py`-style script: a no-op `Execute` of a
+    /// `VerboseAction`. The script makes no flag mutations; the runtime must
+    /// succeed, collect nothing, and note the ignored action.
+    #[test]
+    fn test_shim_complex_execute_verbose_action_is_noop() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = write_runtime_project_with_config(
+            "",
+            "post:generate_includes.py",
+            "generate_includes.py",
+            "\
+from SCons.Script import DefaultEnvironment
+env = DefaultEnvironment()
+env.Execute(env.VerboseAction(\"$PYTHONEXE -m pip install css_html_js_minify\", \"Installing\"))
+",
+        );
+
+        let overlay = resolve_runtime_overlay(temp.path());
+        assert!(
+            overlay.global_compile.is_empty() && overlay.project_compile.is_empty(),
+            "effectful codegen script should contribute no flags: {overlay:?}"
+        );
+        assert!(
+            overlay.notes.iter().any(|n| n.contains("Execute")),
+            "{overlay:?}"
+        );
+    }
+
+    /// Marlin `common-dependencies.py`-style script: `SConscript` recursion is
+    /// structurally unshimmable and must bail with a `--platformio` hint
+    /// rather than silently producing wrong flags.
+    #[test]
+    fn test_shim_complex_sconscript_bails() {
+        if find_python().is_none() {
+            return;
+        }
+
+        let temp = write_runtime_project_with_config(
+            "",
+            "post:common_dependencies.py",
+            "common_dependencies.py",
+            "\
+Import(\"env\")
+env.Append(CPPDEFINES=[\"EARLY\"])
+env.SConscript(\"feature.py\", exports=\"env\")
+",
+        );
+        let err = resolve_runtime_error(temp.path());
+        assert!(err.contains("SConscript is not supported"), "{err}");
+        assert!(err.contains("Recommendation: use --platformio"), "{err}");
+    }
 }

--- a/crates/fbuild-build/src/script_runtime_harness.py
+++ b/crates/fbuild-build/src/script_runtime_harness.py
@@ -3,8 +3,10 @@ import json
 import os
 import re
 import sys
+import types
 
 
+# Compiler/linker scopes the runtime knows how to translate into native flags.
 SUPPORTED_SCOPES = {
     "CPPDEFINES",
     "CPPPATH",
@@ -15,6 +17,28 @@ SUPPORTED_SCOPES = {
     "LINKFLAGS",
     "LIBPATH",
     "LIBS",
+}
+
+# `BUILD_FLAGS` is PlatformIO's aggregate compile-flag list. Scripts commonly
+# append to it (e.g. Marlin `common-cxxflags.py`); fold it into the common
+# compile flags on export. Tracked as a mutable scope but not a direct
+# compiler scope, so it is kept separate from SUPPORTED_SCOPES.
+MUTABLE_SCOPES = SUPPORTED_SCOPES | {"BUILD_FLAGS"}
+
+# Non-flag construction variables that real scripts mutate (tool paths, output
+# naming, upload settings). They have no effect on native compile/link flags,
+# so the runtime records them as notes instead of failing — this keeps
+# tool-path scripts (e.g. m5panel `littlefsbuilder.py`) from aborting the build.
+# Genuinely unknown scopes still fail fast to surface real divergence.
+KNOWN_IGNORED_SCOPES = {
+    "MKSPIFFSTOOL",
+    "MKFSTOOL",
+    "BUILD_DIR",
+    "PROGNAME",
+    "PROGSUFFIX",
+    "UPLOAD_PROTOCOL",
+    "UPLOADER",
+    "UPLOADCMD",
 }
 
 NOOP_METHODS = {
@@ -67,17 +91,30 @@ class MockEnv:
         self._pio_platform = MockPioPlatform(platform_name, platformio_home)
         self._notes = notes
         self._unsupported = unsupported
-        self._scopes = {key: [] for key in SUPPORTED_SCOPES}
+        self._scopes = {key: [] for key in MUTABLE_SCOPES}
         self._vars = {
             "PROJECT_DIR": project_dir,
             "PIOENV": env_name,
         }
 
+    def _export_cppdefines(self):
+        # In-place mutations (`env["CPPDEFINES"].append((name, value))`) bypass
+        # `Append`/`_normalize_items`, so re-normalize every entry on export to
+        # keep tuple-shaped defines from leaking out as raw JSON arrays the
+        # Rust side cannot decode.
+        out = []
+        for entry in self._scopes["CPPDEFINES"]:
+            out.extend(self._normalize_cppdefine(entry))
+        return out
+
     def export_state(self):
+        # `BUILD_FLAGS` folds into the common compile flags (`CCFLAGS`).
+        ccflags = [str(item) for item in self._scopes["BUILD_FLAGS"]]
+        ccflags.extend(self._scopes["CCFLAGS"])
         return {
-            "cppdefines": self._scopes["CPPDEFINES"],
+            "cppdefines": self._export_cppdefines(),
             "cpppath": self._scopes["CPPPATH"],
-            "ccflags": self._scopes["CCFLAGS"],
+            "ccflags": ccflags,
             "cflags": self._scopes["CFLAGS"],
             "cxxflags": self._scopes["CXXFLAGS"],
             "asflags": self._scopes["ASFLAGS"],
@@ -147,7 +184,13 @@ class MockEnv:
 
     def _mutate(self, mode, kwargs):
         for scope, value in kwargs.items():
-            if scope not in SUPPORTED_SCOPES:
+            if scope not in MUTABLE_SCOPES:
+                if scope in KNOWN_IGNORED_SCOPES:
+                    self._notes.append(
+                        f"{self._label}.{mode} on non-flag scope '{scope}' ignored "
+                        "by native extra_scripts runtime"
+                    )
+                    continue
                 self._record_unsupported(
                     f"{self._label}.{mode} on unsupported scope '{scope}'"
                 )
@@ -217,10 +260,21 @@ class MockEnv:
         return re.sub(r"\$([A-Za-z_][A-Za-z0-9_]*)|\$\{([^}]+)\}", repl, text)
 
     def get(self, key, default=None):
-        return self._vars.get(key, default)
+        if key in self._vars:
+            return self._vars[key]
+        return self._project_options.get(key, default)
 
     def GetProjectOption(self, key, default=None):
         return self._project_options.get(key, default)
+
+    def GetProjectOptions(self):
+        return list(self._project_options.items())
+
+    def GetBuildType(self):
+        return self._project_options.get("build_type", "release")
+
+    def __contains__(self, key):
+        return key in self._vars or key in self._scopes
 
     def __getitem__(self, key):
         if key in self._vars:
@@ -230,7 +284,7 @@ class MockEnv:
         raise KeyError(key)
 
     def __setitem__(self, key, value):
-        if key in SUPPORTED_SCOPES:
+        if key in MUTABLE_SCOPES:
             self._scopes[key] = self._normalize_items(key, value)
         else:
             self._vars[key] = value
@@ -254,12 +308,30 @@ def resolve_script_entry(env, raw):
     return "post", os.path.abspath(env.subst(raw))
 
 
-def execute_script(path, import_fn, project_dir):
+def install_scons_module():
+    # Many real extra_scripts obtain the environment via
+    # `from SCons.Script import DefaultEnvironment` rather than `Import("env")`.
+    # Provide a stub `SCons.Script` module so that import resolves; its
+    # `Import`/`DefaultEnvironment` attributes are rebound per script in
+    # `execute_script` to the currently-running script's dispatcher.
+    scons = sys.modules.get("SCons") or types.ModuleType("SCons")
+    script_mod = sys.modules.get("SCons.Script") or types.ModuleType("SCons.Script")
+    scons.Script = script_mod
+    sys.modules["SCons"] = scons
+    sys.modules["SCons.Script"] = script_mod
+    return script_mod
+
+
+def execute_script(path, import_fn, project_dir, scons_script_mod):
     script_dir = os.path.dirname(path)
     old_sys_path = list(sys.path)
     sys.path.insert(0, script_dir)
     if project_dir not in sys.path:
         sys.path.insert(0, project_dir)
+    scons_script_mod.Import = import_fn
+    scons_script_mod.DefaultEnvironment = import_fn.default_environment
+    scons_script_mod.COMMAND_LINE_TARGETS = []
+    scons_script_mod.ARGUMENTS = {}
     scope = {
         "__file__": path,
         "__name__": "__main__",
@@ -340,11 +412,12 @@ def main():
     pre_scripts = [path for scope, path in script_entries if scope == "pre"]
     post_scripts = [path for scope, path in script_entries if scope == "post"]
 
+    scons_script_mod = install_scons_module()
     try:
         for path in pre_scripts:
-            execute_script(path, ImportDispatcher(env, projenv, False), project_dir)
+            execute_script(path, ImportDispatcher(env, projenv, False), project_dir, scons_script_mod)
         for path in post_scripts:
-            execute_script(path, ImportDispatcher(env, projenv, True), project_dir)
+            execute_script(path, ImportDispatcher(env, projenv, True), project_dir, scons_script_mod)
     except RuntimeFailure as exc:
         unsupported.append(str(exc))
 

--- a/docs/reference/platformio-ini.md
+++ b/docs/reference/platformio-ini.md
@@ -107,6 +107,11 @@ overrides.
 
 ## Native `extra_scripts`
 
-Native fbuild supports only a narrow subset of PlatformIO `extra_scripts`.
-Unsupported behavior fails early with a recommendation to use `--platformio`.
-See [`crates/fbuild-build/README.md`](../../crates/fbuild-build/README.md).
+Native fbuild interprets `extra_scripts` against a mock SCons `env` — it does not
+run real SCons. It covers the common flag/path mutations (`Append`/`Replace`/etc.
+over `CPPDEFINES`, `CCFLAGS`, `CXXFLAGS`, `LINKFLAGS`, `LIBS`, …), `BUILD_FLAGS`,
+`DefaultEnvironment()`, and project introspection (`GetBuildType`,
+`GetProjectOptions`). Non-flag tool scopes are recorded as notes; genuinely
+unsupported behavior fails early with a recommendation to use `--platformio`.
+See [`crates/fbuild-build/README.md`](../../crates/fbuild-build/README.md) for the
+full supported/rejected list and the structural limitations of the mock.


### PR DESCRIPTION
## Summary

Widens fbuild's native `extra_scripts` compatibility shim (the mock SCons `env` in `script_runtime_harness.py`) so common real-world PlatformIO `build_flags.py` / `extra_scripts` patterns parse and apply without bailing to `--platformio`. Implements Choice (C) from the assessment in #553.

New shim coverage:
- `from SCons.Script import DefaultEnvironment` → `DefaultEnvironment()` returns the same mock env as `Import("env")`
- `BUILD_FLAGS` aggregate scope, folded into the common compile flags on export
- in-place tuple `CPPDEFINES` (`env["CPPDEFINES"].append(("NAME", value))`) exported as `-DNAME=value`
- `GetBuildType`, `GetProjectOptions`, and `env.get(key, default)` fallthrough (env vars → project options → default)
- non-flag tool/output scopes (`MKSPIFFSTOOL`, `PROGNAME`, `UPLOAD_PROTOCOL`, …) recorded as notes instead of failing the build

## Tests

Tiered tests added to `script_runtime.rs` (gated on Python availability):
- **simple** — Marlin-style language-specific `CXXFLAGS` + `GetBuildType` gating + in-place `BUILD_FLAGS`; tuple-CPPDEFINES export
- **medium** — namf-style `DefaultEnvironment` + `LINKFLAGS` read/rewrite; littlefs tool-path `Replace` recorded as a note, not rejected
- **complex** — `Execute(VerboseAction(...))` no-op with note; `SConscript(...)` gracefully bails with `--platformio` recommendation

## Docs

`crates/fbuild-build/README.md` and `docs/reference/platformio-ini.md` updated with the widened supported surface and the four structural limitations of the mock (empty starting scopes, no real SCons graph, no-op `Execute`, `build_flags = !python` out of scope).

## Test plan

- [x] `soldr cargo test -p fbuild-build --lib script_runtime` — 18 passed
- [x] `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings` — clean
- [x] `soldr cargo fmt --all`

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified supported PlatformIO `extra_scripts` capabilities and limitations
  * Enhanced guidance on flag mutations, build variable handling, and mock SCons behavior
  * Added recommendations for unsupported script features

* **Tests**
  * Expanded test coverage for build script execution scenarios and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->