### PR TITLE
fix(nxplpc): bake LPC8xx boot-ROM vector checksum into linked image

### DIFF
--- a/crates/fbuild-build/src/nxplpc/README.md
+++ b/crates/fbuild-build/src/nxplpc/README.md
@@ -35,3 +35,14 @@ References:
 Primary path: ISP-via-UART with the on-die boot ROM, driven by `lpc21isp`.
 Alternative: SWD via CMSIS-DAP / J-Link / pyOCD (entries in the board JSON
 `debug.tools` map).
+
+### Boot-ROM vector checksum
+
+The LPC8xx boot ROM only runs an image whose first 8 vector words sum to
+zero (mod 2^32); the word at offset `0x1C` is reserved for the two's
+complement that makes the sum zero. `lpc21isp` patches this slot during ISP
+flashing, but raw SWD programmers do **not** — so the checksum is baked into
+the linked image: the linker script (`assets/lpc8xx.ld`) computes
+`_isr_vector_checksum` and the startup table emits it at `0x1C`. No external
+linker script or `board_build.ldscript` declaration is required anywhere for
+the produced firmware to boot.

--- a/crates/fbuild-build/src/nxplpc/assets/lpc804.ld
+++ b/crates/fbuild-build/src/nxplpc/assets/lpc804.ld
@@ -22,6 +22,24 @@ MEMORY
 /* Top of RAM — initial stack pointer. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
+/*
+ * LPC8xx boot-ROM validity check: the first 8 vector words must sum to
+ * zero (mod 2^32) or the boot ROM rejects the image as "no valid user
+ * code". lpc21isp patches this slot during ISP flashing, but raw SWD
+ * programmers (pyocd/jlink/cmsis-dap) do not — so the checksum must be
+ * baked into the image itself. Only the linker can sum these relocatable
+ * symbols, so it is computed here and emitted at vector offset 0x1C by
+ * `.word _isr_vector_checksum` in startup_lpc804.S.
+ *
+ * The `+ 1` terms add the thumb bit: in linker-script expressions a
+ * function symbol resolves to its raw (even) address, whereas the boot
+ * ROM sums the table as written, where thumb entries carry bit 0 set
+ * (the assembler's `.word Reset_Handler` emits Reset_Handler|1). Reserved
+ * vectors at 0x10/0x14/0x18 are zero and drop out of the sum.
+ */
+_isr_vector_checksum =
+    0 - (_estack + (Reset_Handler + 1) + (NMI_Handler + 1) + (HardFault_Handler + 1));
+
 SECTIONS
 {
     .isr_vector :

--- a/crates/fbuild-build/src/nxplpc/assets/lpc845.ld
+++ b/crates/fbuild-build/src/nxplpc/assets/lpc845.ld
@@ -22,6 +22,24 @@ MEMORY
 /* Top of RAM — initial stack pointer. */
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
+/*
+ * LPC8xx boot-ROM validity check: the first 8 vector words must sum to
+ * zero (mod 2^32) or the boot ROM rejects the image as "no valid user
+ * code". lpc21isp patches this slot during ISP flashing, but raw SWD
+ * programmers (pyocd/jlink/cmsis-dap) do not — so the checksum must be
+ * baked into the image itself. Only the linker can sum these relocatable
+ * symbols, so it is computed here and emitted at vector offset 0x1C by
+ * `.word _isr_vector_checksum` in startup_lpc845.S.
+ *
+ * The `+ 1` terms add the thumb bit: in linker-script expressions a
+ * function symbol resolves to its raw (even) address, whereas the boot
+ * ROM sums the table as written, where thumb entries carry bit 0 set
+ * (the assembler's `.word Reset_Handler` emits Reset_Handler|1). Reserved
+ * vectors at 0x10/0x14/0x18 are zero and drop out of the sum.
+ */
+_isr_vector_checksum =
+    0 - (_estack + (Reset_Handler + 1) + (NMI_Handler + 1) + (HardFault_Handler + 1));
+
 SECTIONS
 {
     .isr_vector :

--- a/crates/fbuild-build/src/nxplpc/assets/startup_lpc804.S
+++ b/crates/fbuild-build/src/nxplpc/assets/startup_lpc804.S
@@ -50,6 +50,8 @@
     .extern _sbss
     .extern _ebss
     .extern main
+    /* Boot-ROM vector checksum, computed by the linker script (see lpc804.ld). */
+    .extern _isr_vector_checksum
 
 /* ---------------------------------------------------------------------------
  * Vector table — placed in flash at 0x00000000 via .isr_vector.
@@ -71,7 +73,7 @@ g_pfnVectors:
     .word 0                    /* 0x10 reserved */
     .word 0                    /* 0x14 reserved */
     .word 0                    /* 0x18 reserved */
-    .word 0                    /* 0x1C reserved (boot code App CRC slot) */
+    .word _isr_vector_checksum /* 0x1C boot-ROM checksum (vectors 0..7 sum to 0) */
     .word 0                    /* 0x20 reserved */
     .word 0                    /* 0x24 reserved */
     .word 0                    /* 0x28 reserved */

--- a/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S
+++ b/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S
@@ -37,6 +37,8 @@
     .extern _sbss
     .extern _ebss
     .extern main
+    /* Boot-ROM vector checksum, computed by the linker script (see lpc845.ld). */
+    .extern _isr_vector_checksum
 
 /* ---------------------------------------------------------------------------
  * Vector table — placed in flash at 0x00000000 via .isr_vector.
@@ -58,7 +60,7 @@ g_pfnVectors:
     .word 0                    /* 0x10 reserved */
     .word 0                    /* 0x14 reserved */
     .word 0                    /* 0x18 reserved */
-    .word 0                    /* 0x1C reserved (boot code App CRC slot) */
+    .word _isr_vector_checksum /* 0x1C boot-ROM checksum (vectors 0..7 sum to 0) */
     .word 0                    /* 0x20 reserved */
     .word 0                    /* 0x24 reserved */
     .word 0                    /* 0x28 reserved */

--- a/crates/fbuild-build/src/nxplpc/orchestrator.rs
+++ b/crates/fbuild-build/src/nxplpc/orchestrator.rs
@@ -354,6 +354,39 @@ mod tests {
     }
 
     #[test]
+    fn boot_checksum_is_baked_into_assets() {
+        // The LPC8xx boot ROM rejects an image unless the first 8 vector
+        // words sum to zero (mod 2^32). The linker script computes the slot
+        // value and the startup table emits it at 0x1C. If either half is
+        // dropped, raw SWD flashing produces a non-booting image — guard
+        // both halves for every supported MCU.
+        for mcu in ["lpc845", "lpc804"] {
+            let assets = mcu_assets(mcu).expect("mcu must be supported");
+            assert!(
+                assets.linker_script.contains("_isr_vector_checksum ="),
+                "{mcu}.ld must define the boot checksum symbol"
+            );
+            assert!(
+                assets.linker_script.contains(
+                    "0 - (_estack + (Reset_Handler + 1) + (NMI_Handler + 1) + (HardFault_Handler + 1))"
+                ),
+                "{mcu}.ld checksum formula must include the thumb-bit (+1) terms"
+            );
+            assert!(
+                assets.startup_asm.contains(".word _isr_vector_checksum"),
+                "startup_{mcu}.S must emit the checksum at the 0x1C vector slot"
+            );
+            // The old placeholder that left the slot zero must be gone.
+            assert!(
+                !assets
+                    .startup_asm
+                    .contains(".word 0                    /* 0x1C"),
+                "startup_{mcu}.S must not leave the 0x1C boot-checksum slot zero"
+            );
+        }
+    }
+
+    #[test]
     fn write_asset_round_trips_through_disk() {
         let dir = tempfile::tempdir().expect("tempdir");
         let written = write_asset(dir.path(), "demo.txt", "hello\nworld\n").unwrap();


### PR DESCRIPTION
## Summary

The LPC8xx boot ROM only executes an image whose first 8 vector words sum to zero (mod 2³²); the word at offset `0x1C` is reserved for the two's-complement that closes the sum. `lpc21isp` patches this slot during ISP-over-UART flashing, but **raw SWD programmers (pyocd / J-Link / CMSIS-DAP) do not** — so fbuild's linked image was non-bootable over SWD because the slot was left zero.

This bakes the checksum into the image itself so **no external linker script or `board_build.ldscript` declaration is required anywhere** for the firmware to boot:

- `lpc845.ld` / `lpc804.ld`: compute `_isr_vector_checksum = 0 - (_estack + (Reset_Handler+1) + (NMI_Handler+1) + (HardFault_Handler+1))`. Only the linker can sum these relocatable vector symbols; the `+1` terms add the thumb bit that the assembler's `.word <Handler>` carries in the emitted table.
- `startup_lpc845.S` / `startup_lpc804.S`: emit `.word _isr_vector_checksum` at the `0x1C` vector slot (was `.word 0`).
- New unit test `boot_checksum_is_baked_into_assets` guards both halves (linker formula + startup emission) for both MCUs.
- README documents the boot-ROM checksum requirement.

Part of the LPC8xx end-to-end effort (#487 / #479).

## Verification

End-to-end build of the `lpc845` fixture (`arm-none-eabi-gcc 15.2.1`) links cleanly, and the produced `firmware.bin`'s first 8 vector words sum to exactly zero:

```
0x00: 0x10004000   (_estack)
0x04: 0x00000105   (Reset_Handler | thumb)
0x08: 0x00000135   (NMI_Handler   | thumb)
0x0C: 0x00000135   (HardFault     | thumb)
0x10..0x18: 0
0x1C: 0xEFFFBC91   (computed checksum)
sum mod 2^32 = 0x00000000  => BOOTABLE
```

## Test plan

- [x] `soldr cargo test -p fbuild-build --lib nxplpc` (20/20 pass, incl. new checksum guard)
- [x] `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings` clean
- [x] Real lpc845 fixture build + `firmware.bin` checksum inspection (sum = 0)
- [ ] On-hardware SWD boot confirmation (no LPC845 board on hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)