### PR TITLE
refactor(build): funnel board resolution through resolution::resolve_board (#519)

### DIFF
--- a/crates/fbuild-build/src/resolution.rs
+++ b/crates/fbuild-build/src/resolution.rs
@@ -51,7 +51,7 @@ impl<'a> ResolutionContext<'a> {
     pub fn resolve_board(&self) -> Result<BoardConfig> {
         let board_id = self.board_id()?;
         let overrides = self.config.get_board_overrides(self.env_name)?;
-        BoardConfig::from_board_id_in_project(&board_id, &overrides, Some(self.project_dir))
+        resolve_board(&board_id, &overrides, Some(self.project_dir))
     }
 
     /// Resolve the [`Platform`] for this env's board.
@@ -61,13 +61,26 @@ impl<'a> ResolutionContext<'a> {
     }
 }
 
+/// The single build-side funnel for board resolution. Every build-side site
+/// that needs a [`BoardConfig`] from a board id routes through here instead of
+/// calling [`BoardConfig::from_board_id_in_project`] directly, so a new
+/// resolution input (the next `project_dir`-style knob) is threaded in one
+/// place rather than re-plumbed into each consumer (FastLED/fbuild#519).
+pub fn resolve_board(
+    board_id: &str,
+    overrides: &HashMap<String, String>,
+    project_dir: Option<&Path>,
+) -> Result<BoardConfig> {
+    BoardConfig::from_board_id_in_project(board_id, overrides, project_dir)
+}
+
 /// Determine the [`Platform`] for a bare board id (no `[env]` overrides),
 /// honoring a project-local `boards/<id>.json`. This is the lookup used by
 /// sites that only know a board string — e.g. `compile_many`'s per-sketch
 /// dispatch — and shares the single "could not determine platform" error
 /// with [`ResolutionContext::resolve_platform`] (FastLED/fbuild#519).
 pub fn platform_for_board(board_id: &str, project_dir: Option<&Path>) -> Result<Platform> {
-    let board = BoardConfig::from_board_id_in_project(board_id, &HashMap::new(), project_dir)?;
+    let board = resolve_board(board_id, &HashMap::new(), project_dir)?;
     platform_of(&board, board_id)
 }
 
@@ -102,6 +115,20 @@ mod tests {
         assert_eq!(ctx.board_id().unwrap(), "uno");
         assert_eq!(ctx.resolve_board().unwrap().mcu, "atmega328p");
         assert_eq!(ctx.resolve_platform().unwrap(), Platform::AtmelAvr);
+    }
+
+    #[test]
+    fn resolve_board_free_fn_matches_context() {
+        let dir = write_project("[env:uno]\nplatform = atmelavr\nboard = uno\n");
+        let config = PlatformIOConfig::from_path(&dir.path().join("platformio.ini")).unwrap();
+        let ctx = ResolutionContext::new(dir.path(), "uno", &config);
+        let via_funnel = super::resolve_board("uno", &HashMap::new(), None).unwrap();
+        assert_eq!(via_funnel.mcu, ctx.resolve_board().unwrap().mcu);
+    }
+
+    #[test]
+    fn resolve_board_unknown_errors() {
+        assert!(super::resolve_board("nonexistent_board", &HashMap::new(), None).is_err());
     }
 
     #[test]

--- a/crates/fbuild-build/src/script_runtime.rs
+++ b/crates/fbuild-build/src/script_runtime.rs
@@ -300,12 +300,9 @@ fn build_script_runtime_board_config(
     // Shares the same project-local boards/*.json resolution as the
     // pipeline `BuildContext` and `compile_many::platform_for_board` so a
     // user's `<project>/boards/<id>.json` is the single source of truth
-    // for every build-side board lookup. See FastLED/fbuild#515.
-    let board = fbuild_config::BoardConfig::from_board_id_in_project(
-        board_id,
-        &HashMap::new(),
-        project_dir,
-    )?;
+    // for every build-side board lookup. Routes through the shared
+    // `resolution::resolve_board` funnel (FastLED/fbuild#515, #519).
+    let board = crate::resolution::resolve_board(board_id, &HashMap::new(), project_dir)?;
     result.insert("name".to_string(), board.name.clone());
     result.insert("build.mcu".to_string(), board.mcu.clone());
     result.insert("build.f_cpu".to_string(), board.f_cpu.clone());


### PR DESCRIPTION
## Summary

First consolidation step for #519. Adds a single build-side board-resolution funnel so a new resolution input (the next `project_dir`-style knob) is threaded in one place instead of re-plumbed into each consumer.

- New `resolution::resolve_board(board_id, overrides, project_dir)` free function — the one build-side wrapper over `BoardConfig::from_board_id_in_project`.
- `ResolutionContext::resolve_board` and `platform_for_board` now route through it.
- `script_runtime::build_script_runtime_board_config` was the last build-side straggler calling `from_board_id_in_project` directly; it now uses the funnel. That site was precisely the kind missed in #516 (caught up by #518), where a new param silently drops unless every call site is hand-updated.

Scope is intentionally limited to the `fbuild-build` build path. The daemon/CLI deploy fallback helpers (`from_board_id_or_default`, `from_board_id_with_override_fallback`) live in `fbuild-config` and already act as shared entry points; folding those in is a separate follow-up under #519.

## Test plan

- [x] `soldr cargo test -p fbuild-build --lib resolution` — 7 pass (adds `resolve_board_free_fn_matches_context`, `resolve_board_unknown_errors`)
- [x] `soldr cargo clippy -p fbuild-build --all-targets -- -D warnings` clean

Refs #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)