### PR TITLE
ci(crate-gate): run monocrate check via uv --script (fix soldr build failure)

### DIFF
--- a/.github/workflows/crate-gate.yml
+++ b/.github/workflows/crate-gate.yml
@@ -17,4 +17,8 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Check workspace members against the approved allowlist
-        run: uv run python ci/check_workspace_crates.py
+        # `--script` runs the standalone PEP-723 script in isolation. Plain
+        # `uv run python ...` would first build the `fbuild` project package,
+        # which requires `soldr` (absent in this job) and fails the gate for an
+        # unrelated reason. The script declares its own inline metadata.
+        run: uv run --script ci/check_workspace_crates.py


### PR DESCRIPTION
## Summary

The Crate Gate workflow added in #561 fails on **every** PR with `ERROR: soldr is required to build fbuild from source`. Root cause: `uv run python ci/check_workspace_crates.py` makes uv build the `fbuild` editable package before running, and that build backend requires `soldr`, which isn't installed in the crate-gate job.

`ci/check_workspace_crates.py` is a standalone PEP-723 script (`# /// script` inline metadata, no third-party deps), so `uv run --script` runs it in isolation — no project build, no soldr.

## Test plan

- [x] `uv run --script ci/check_workspace_crates.py` → `OK: 14 approved workspace members, no new crates.`
- [x] No project build is triggered (the failing path is avoided entirely)

Regression from #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow execution to improve process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->