### PR TITLE
refactor(config): thread project_dir through deploy board-resolution fallbacks (#519)

### DIFF
--- a/crates/fbuild-cli/src/cli/deploy.rs
+++ b/crates/fbuild-cli/src/cli/deploy.rs
@@ -45,6 +45,7 @@ pub fn infer_cli_default_emulator_kind(
     let board = fbuild_config::BoardConfig::from_board_id_with_override_fallback(
         &board_id,
         &board_overrides,
+        Some(project_dir),
     );
     Ok(
         match (platform, board.as_ref().map(|board| board.mcu.as_str())) {

--- a/crates/fbuild-config/src/board/loaders.rs
+++ b/crates/fbuild-config/src/board/loaders.rs
@@ -189,6 +189,12 @@ impl BoardConfig {
     /// (e.g. `"esp32dev"`, `"uno"`, `"teensy41"`) when the primary id is
     /// unknown, carrying the same `overrides` through to the fallback.
     ///
+    /// `project_dir` enables project-local `boards/<id>.json` discovery for
+    /// both the primary and the default lookup (pass `None` to disable). This
+    /// is threaded through [`Self::from_board_id_in_project`] so deploy-side
+    /// callers honor the same project-local boards as the build path
+    /// (FastLED/fbuild#519).
+    ///
     /// `default_board_id` is expected to be a compile-time platform default
     /// that always exists in the board database, so a failure to resolve it
     /// is a programming error and panics rather than being swallowed.
@@ -196,9 +202,10 @@ impl BoardConfig {
         board_id: &str,
         default_board_id: &str,
         overrides: &HashMap<String, String>,
+        project_dir: Option<&std::path::Path>,
     ) -> Self {
-        Self::from_board_id(board_id, overrides).unwrap_or_else(|_| {
-            Self::from_board_id(default_board_id, overrides)
+        Self::from_board_id_in_project(board_id, overrides, project_dir).unwrap_or_else(|_| {
+            Self::from_board_id_in_project(default_board_id, overrides, project_dir)
                 .unwrap_or_else(|e| panic!("default board '{default_board_id}' must resolve: {e}"))
         })
     }
@@ -207,15 +214,21 @@ impl BoardConfig {
     /// override-applied resolution fails. Returns `None` only when `board_id`
     /// is unknown even without overrides.
     ///
+    /// `project_dir` enables project-local `boards/<id>.json` discovery (pass
+    /// `None` to disable), threaded through [`Self::from_board_id_in_project`]
+    /// so this best-effort lookup honors the same project-local boards as the
+    /// build path (FastLED/fbuild#519).
+    ///
     /// Used by best-effort call sites (e.g. emulator-kind inference) that want
     /// a board for hints but must not hard-fail when a user override is
     /// malformed.
     pub fn from_board_id_with_override_fallback(
         board_id: &str,
         overrides: &HashMap<String, String>,
+        project_dir: Option<&std::path::Path>,
     ) -> Option<Self> {
-        Self::from_board_id(board_id, overrides)
-            .or_else(|_| Self::from_board_id(board_id, &HashMap::new()))
+        Self::from_board_id_in_project(board_id, overrides, project_dir)
+            .or_else(|_| Self::from_board_id_in_project(board_id, &HashMap::new(), project_dir))
             .ok()
     }
 

--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -105,13 +105,14 @@ fn test_from_board_id_unknown() {
 
 #[test]
 fn test_from_board_id_or_default_uses_primary_when_known() {
-    let config = BoardConfig::from_board_id_or_default("mega", "uno", &HashMap::new());
+    let config = BoardConfig::from_board_id_or_default("mega", "uno", &HashMap::new(), None);
     assert_eq!(config.mcu, "atmega2560");
 }
 
 #[test]
 fn test_from_board_id_or_default_falls_back_when_unknown() {
-    let config = BoardConfig::from_board_id_or_default("nonexistent_board", "uno", &HashMap::new());
+    let config =
+        BoardConfig::from_board_id_or_default("nonexistent_board", "uno", &HashMap::new(), None);
     assert_eq!(config.mcu, "atmega328p");
 }
 
@@ -119,21 +120,51 @@ fn test_from_board_id_or_default_falls_back_when_unknown() {
 fn test_from_board_id_or_default_carries_overrides_into_fallback() {
     let mut overrides = HashMap::new();
     overrides.insert("f_cpu".to_string(), "8000000L".to_string());
-    let config = BoardConfig::from_board_id_or_default("nonexistent_board", "uno", &overrides);
+    let config =
+        BoardConfig::from_board_id_or_default("nonexistent_board", "uno", &overrides, None);
     assert_eq!(config.f_cpu, "8000000L");
     assert_eq!(config.mcu, "atmega328p");
 }
 
 #[test]
+fn test_from_board_id_or_default_resolves_project_local_board() {
+    // A board id absent from the built-in DB but present as
+    // <project>/boards/<id>.json must resolve via the project_dir path
+    // instead of silently falling back to the platform default (#519).
+    let dir = tempfile::tempdir().unwrap();
+    let boards = dir.path().join("boards");
+    std::fs::create_dir(&boards).unwrap();
+    std::fs::write(
+        boards.join("widget123.json"),
+        r#"{"mcu":"atmega328p","f_cpu":"16000000L","core":"arduino","variant":"standard"}"#,
+    )
+    .unwrap();
+    let config = BoardConfig::from_board_id_or_default(
+        "widget123",
+        "uno",
+        &HashMap::new(),
+        Some(dir.path()),
+    );
+    assert!(
+        config.board.eq_ignore_ascii_case("widget123"),
+        "expected project-local board, got '{}'",
+        config.board
+    );
+}
+
+#[test]
 fn test_from_board_id_with_override_fallback_known() {
-    let board = BoardConfig::from_board_id_with_override_fallback("uno", &HashMap::new());
+    let board = BoardConfig::from_board_id_with_override_fallback("uno", &HashMap::new(), None);
     assert_eq!(board.unwrap().mcu, "atmega328p");
 }
 
 #[test]
 fn test_from_board_id_with_override_fallback_unknown_returns_none() {
-    let board =
-        BoardConfig::from_board_id_with_override_fallback("nonexistent_board", &HashMap::new());
+    let board = BoardConfig::from_board_id_with_override_fallback(
+        "nonexistent_board",
+        &HashMap::new(),
+        None,
+    );
     assert!(board.is_none());
 }
 
@@ -141,8 +172,31 @@ fn test_from_board_id_with_override_fallback_unknown_returns_none() {
 fn test_from_board_id_with_override_fallback_applies_overrides() {
     let mut overrides = HashMap::new();
     overrides.insert("f_cpu".to_string(), "8000000L".to_string());
-    let board = BoardConfig::from_board_id_with_override_fallback("uno", &overrides);
+    let board = BoardConfig::from_board_id_with_override_fallback("uno", &overrides, None);
     assert_eq!(board.unwrap().f_cpu, "8000000L");
+}
+
+#[test]
+fn test_from_board_id_with_override_fallback_resolves_project_local_board() {
+    let dir = tempfile::tempdir().unwrap();
+    let boards = dir.path().join("boards");
+    std::fs::create_dir(&boards).unwrap();
+    std::fs::write(
+        boards.join("widget456.json"),
+        r#"{"mcu":"atmega328p","f_cpu":"16000000L","core":"arduino","variant":"standard"}"#,
+    )
+    .unwrap();
+    let board = BoardConfig::from_board_id_with_override_fallback(
+        "widget456",
+        &HashMap::new(),
+        Some(dir.path()),
+    );
+    let board = board.expect("project-local board must resolve");
+    assert!(
+        board.board.eq_ignore_ascii_case("widget456"),
+        "expected project-local board, got '{}'",
+        board.board
+    );
 }
 
 #[test]

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -153,6 +153,7 @@ pub async fn deploy(
     let board = fbuild_config::BoardConfig::from_board_id_with_override_fallback(
         &board_id,
         &board_overrides,
+        Some(project_dir.as_path()),
     );
     let deploy_route = match parse_deploy_route(
         &req,
@@ -427,6 +428,7 @@ pub async fn deploy(
                     &board_id,
                     "esp32dev",
                     &deploy_board_overrides,
+                    Some(deploy_project.as_path()),
                 );
                 // Load MCU config to get flash offsets and esptool defaults.
                 // Fail loudly on an unknown MCU instead of silently falling
@@ -663,6 +665,7 @@ pub async fn deploy(
                     &board_id,
                     "uno",
                     &deploy_board_overrides,
+                    Some(deploy_project.as_path()),
                 );
                 let avr_config = fbuild_build::avr::mcu_config::get_avr_config().unwrap();
                 let avrdude_params = fbuild_deploy::avr::AvrdudeParams {
@@ -691,6 +694,7 @@ pub async fn deploy(
                     &board_id,
                     "teensy41",
                     &deploy_board_overrides,
+                    Some(deploy_project.as_path()),
                 );
                 let loader_params = fbuild_deploy::teensy::TeensyLoaderParams::default();
                 let loader_path = find_teensy_loader_cli();


### PR DESCRIPTION
## Summary
- Second slice of #519 (consolidate duplicated board/config resolution). Threads `project_dir` through the two deploy-side board-resolution fallback helpers so they honor project-local `boards/<id>.json`.
- `from_board_id_or_default` and `from_board_id_with_override_fallback` now take `project_dir: Option<&Path>` and route through `from_board_id_in_project`, closing the silent-drift gap where deploy paths dropped project-local board support.
- Updated all 5 production call sites (fbuild-cli `deploy.rs`, fbuild-daemon `operations/deploy.rs`) to pass the in-scope project dir, plus 6 existing test sites.

## Tests
- Added `test_from_board_id_or_default_resolves_project_local_board` and `test_from_board_id_with_override_fallback_resolves_project_local_board`: each creates a tempdir with `boards/widgetNNN.json` and asserts resolution honors the project-local def (case-insensitive — `board` is uppercase-normalized).
- All 86 fbuild-config board tests pass; clippy clean on fbuild-config/cli/daemon.

Refs #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Projects can now define custom board configurations that override platform defaults. The system intelligently discovers project-local board definitions first, enabling flexible per-project hardware customization across all deployment operations.

* **Improvements**
  * Board configuration resolution has been enhanced to provide layered configuration support, consistently prioritizing project-specific settings over platform-wide defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->