### PR TITLE
fix(config): split board tests under LOC gate (#519 follow-up)

### DIFF
--- a/crates/fbuild-config/src/board/tests.rs
+++ b/crates/fbuild-config/src/board/tests.rs
@@ -127,32 +127,6 @@ fn test_from_board_id_or_default_carries_overrides_into_fallback() {
 }
 
 #[test]
-fn test_from_board_id_or_default_resolves_project_local_board() {
-    // A board id absent from the built-in DB but present as
-    // <project>/boards/<id>.json must resolve via the project_dir path
-    // instead of silently falling back to the platform default (#519).
-    let dir = tempfile::tempdir().unwrap();
-    let boards = dir.path().join("boards");
-    std::fs::create_dir(&boards).unwrap();
-    std::fs::write(
-        boards.join("widget123.json"),
-        r#"{"mcu":"atmega328p","f_cpu":"16000000L","core":"arduino","variant":"standard"}"#,
-    )
-    .unwrap();
-    let config = BoardConfig::from_board_id_or_default(
-        "widget123",
-        "uno",
-        &HashMap::new(),
-        Some(dir.path()),
-    );
-    assert!(
-        config.board.eq_ignore_ascii_case("widget123"),
-        "expected project-local board, got '{}'",
-        config.board
-    );
-}
-
-#[test]
 fn test_from_board_id_with_override_fallback_known() {
     let board = BoardConfig::from_board_id_with_override_fallback("uno", &HashMap::new(), None);
     assert_eq!(board.unwrap().mcu, "atmega328p");
@@ -174,29 +148,6 @@ fn test_from_board_id_with_override_fallback_applies_overrides() {
     overrides.insert("f_cpu".to_string(), "8000000L".to_string());
     let board = BoardConfig::from_board_id_with_override_fallback("uno", &overrides, None);
     assert_eq!(board.unwrap().f_cpu, "8000000L");
-}
-
-#[test]
-fn test_from_board_id_with_override_fallback_resolves_project_local_board() {
-    let dir = tempfile::tempdir().unwrap();
-    let boards = dir.path().join("boards");
-    std::fs::create_dir(&boards).unwrap();
-    std::fs::write(
-        boards.join("widget456.json"),
-        r#"{"mcu":"atmega328p","f_cpu":"16000000L","core":"arduino","variant":"standard"}"#,
-    )
-    .unwrap();
-    let board = BoardConfig::from_board_id_with_override_fallback(
-        "widget456",
-        &HashMap::new(),
-        Some(dir.path()),
-    );
-    let board = board.expect("project-local board must resolve");
-    assert!(
-        board.board.eq_ignore_ascii_case("widget456"),
-        "expected project-local board, got '{}'",
-        board.board
-    );
 }
 
 #[test]

--- a/crates/fbuild-config/src/board/tests_project_local.rs
+++ b/crates/fbuild-config/src/board/tests_project_local.rs
@@ -138,3 +138,48 @@ fn from_board_id_is_equivalent_to_in_project_with_none() {
     assert_eq!(a.max_flash, b.max_flash);
     assert_eq!(a.max_ram, b.max_ram);
 }
+
+/// A board id absent from the built-in DB but present as
+/// `<project>/boards/<id>.json` must resolve via the project_dir path
+/// instead of silently falling back to the platform default (#519).
+#[test]
+fn from_board_id_or_default_resolves_project_local_board() {
+    let dir = tempfile::tempdir().unwrap();
+    write_project_board(
+        &dir,
+        "widget123",
+        r#"{"mcu":"atmega328p","f_cpu":"16000000L","core":"arduino","variant":"standard"}"#,
+    );
+    let config = BoardConfig::from_board_id_or_default(
+        "widget123",
+        "uno",
+        &HashMap::new(),
+        Some(dir.path()),
+    );
+    assert!(
+        config.board.eq_ignore_ascii_case("widget123"),
+        "expected project-local board, got '{}'",
+        config.board
+    );
+}
+
+#[test]
+fn from_board_id_with_override_fallback_resolves_project_local_board() {
+    let dir = tempfile::tempdir().unwrap();
+    write_project_board(
+        &dir,
+        "widget456",
+        r#"{"mcu":"atmega328p","f_cpu":"16000000L","core":"arduino","variant":"standard"}"#,
+    );
+    let board = BoardConfig::from_board_id_with_override_fallback(
+        "widget456",
+        &HashMap::new(),
+        Some(dir.path()),
+    )
+    .expect("project-local board must resolve");
+    assert!(
+        board.board.eq_ignore_ascii_case("widget456"),
+        "expected project-local board, got '{}'",
+        board.board
+    );
+}


### PR DESCRIPTION
## Summary
- Fixes the **LOC Gate** failure on `main` (regression from #564): `board/tests.rs` hit 1025 LOC, over the 1000-line limit.
- Moves the two project-local resolution tests added in #564 into `tests_project_local.rs`, their natural home. `tests.rs` is now 976 LOC.
- No behavior change — pure test relocation. All 8 `tests_project_local` tests pass.

Closes #566
Refs #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test coverage for board configuration override and fallback behavior
  * Reorganized project-local board resolution tests to improve test structure and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->