### PR TITLE
fix(nxplpc): run C++ global ctors in startup (__libc_init_array)

### DIFF
--- a/crates/fbuild-build/src/nxplpc/assets/startup_lpc804.S
+++ b/crates/fbuild-build/src/nxplpc/assets/startup_lpc804.S
@@ -154,6 +154,13 @@ Reset_Handler:
 4:
     /* SystemInit explicitly leaves FRO at 15 MHz default. */
     bl      SystemInit
+    /*
+     * Run C++ static/global constructors (.init_array) before main. Without
+     * this, vtable pointers of polymorphic globals are left uninitialised and
+     * the first virtual call HardFaults. See startup_lpc845.S for the full
+     * rationale.
+     */
+    bl      __libc_init_array
     bl      main
 LoopForever:
     b       LoopForever
@@ -167,6 +174,25 @@ LoopForever:
 Default_Handler:
     b       Default_Handler
     .size Default_Handler, . - Default_Handler
+
+/* ---------------------------------------------------------------------------
+ * _init / _fini — no-op stubs (see startup_lpc845.S for rationale). Needed
+ * because __libc_init_array references _init, normally from crti.o/crtn.o
+ * which a -nostartfiles bare-metal link omits.
+ * --------------------------------------------------------------------------- */
+    .thumb_func
+    .weak _init
+    .type _init, %function
+_init:
+    bx      lr
+    .size _init, . - _init
+
+    .thumb_func
+    .weak _fini
+    .type _fini, %function
+_fini:
+    bx      lr
+    .size _fini, . - _fini
 
 /* ---------------------------------------------------------------------------
  * SystemInit — minimal clock setup for LPC804 @ 15 MHz IRC default.

--- a/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S
+++ b/crates/fbuild-build/src/nxplpc/assets/startup_lpc845.S
@@ -141,6 +141,17 @@ Reset_Handler:
 4:
     /* SystemInit configures clocks + flash wait states. */
     bl      SystemInit
+    /*
+     * Run C++ static/global constructors (.init_array). Without this the
+     * vtable pointers of polymorphic globals (e.g. fl's default
+     * memory_resource singleton) are left as uninitialised RAM, so the first
+     * virtual call through one — the first heap allocation on the JSON-RPC
+     * path — dereferences a garbage vtable and HardFaults. newlib provides
+     * __libc_init_array; the .init_array section is emitted by the linker
+     * script. (Serial/FL_WARN survive without it because they touch no
+     * constructor-initialised global.)
+     */
+    bl      __libc_init_array
     bl      main
 LoopForever:
     b       LoopForever
@@ -154,6 +165,29 @@ LoopForever:
 Default_Handler:
     b       Default_Handler
     .size Default_Handler, . - Default_Handler
+
+/* ---------------------------------------------------------------------------
+ * _init / _fini — no-op stubs.
+ *
+ * newlib's __libc_init_array (which Reset_Handler now calls) ends with a call
+ * to _init; the matching __libc_fini_array calls _fini. These are normally
+ * supplied by crti.o/crtn.o, which a -nostartfiles bare-metal link does not
+ * pull in, leaving an undefined reference. We run constructors purely via the
+ * .init_array section, so empty stubs are sufficient.
+ * --------------------------------------------------------------------------- */
+    .thumb_func
+    .weak _init
+    .type _init, %function
+_init:
+    bx      lr
+    .size _init, . - _init
+
+    .thumb_func
+    .weak _fini
+    .type _fini, %function
+_fini:
+    bx      lr
+    .size _fini, . - _fini
 
 /* ---------------------------------------------------------------------------
  * SystemInit — clock + flash setup for LPC845 @ 24 MHz from FRO (FRO direct).


### PR DESCRIPTION
## Summary
- `Reset_Handler` (LPC845 & LPC804 startup) called `SystemInit` then jumped straight to `main`, never running `__libc_init_array`. So `.init_array` — every C++ static/global constructor — never executed.
- The casualty: `fl`'s default `memory_resource` singleton was left with an **uninitialised vtable pointer**. The first virtual dispatch through it (the first heap allocation on the JSON-RPC path) loaded a garbage vtable from RAM and **HardFaulted**, trapping in the weak `Default_Handler` infinite loop. Plain `Serial.println` / `FL_WARN` survived because they touch no constructor-initialised global, which is why earlier bringup looked healthy.
- Fix: add `bl __libc_init_array` between `SystemInit` and `main`, plus no-op `_init`/`_fini` stubs (normally provided by `crti.o`/`crtn.o`, absent in the `-nostartfiles` bare-metal link) that `__libc_init_array`/`__libc_fini_array` reference.

## Verification (LPC845-BRK hardware)
- Before: 8/8 PC samples pinned at `Default_Handler` (`b .`); stacked exception frame showed faulting PC in `fl::memory_resource::allocate` with a garbage vtable pointer (`0x84991d6e`); IPSR=3 (HardFault).
- After: firmware boots through constructors and runs the RPC stack in `loop()` — PC samples land in `fl::variant<fl::json>::destroy_current`, `main`, `memcpy`; xPSR IPSR=0 (Thread mode, no fault). Flash 63.56 KB / 64 KB.

## Test plan
- [x] Firmware links (`__libc_init_array` resolved via the new `_init`/`_fini` stubs) and fits flash
- [x] On-device PC sampling confirms no HardFault and live execution in the JSON-RPC stack
- [ ] Full live VCOM echo round-trip — hardware-gated on a physical USB replug to clear the shared CMSIS-DAP VCOM wedge (separate, known issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)