### PR TITLE
chore: require zccache>=1.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.2.27"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["zccache>=1.11.20"]
+dependencies = ["zccache>=1.12.0"]
 
 # Console script: `fbuild` on PATH after `pip install .` execs the native
 # binary that setup.py stages into ci/bin/fbuild[.exe]. See setup.py +


### PR DESCRIPTION
## Summary
- Raise the `zccache` floor from `>=1.11.20` to `>=1.12.0`.

1.12.0 is the release that adopts the running-process v1 broker (live-socket adoption via `into_backend_io` on Unix). Pinning the floor makes the dependency on that release explicit ahead of broker-lane work.

## Test plan
- [ ] CI green (fbuild installs zccache 1.12.0 from PyPI)