### PR TITLE
fix(build): add HTTP timeouts to managed-zccache download client

### DIFF
--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -178,6 +178,8 @@ fn host_triple() -> Result<&'static str> {
 fn http_client() -> Result<reqwest::blocking::Client> {
     reqwest::blocking::Client::builder()
         .user_agent(concat!("fbuild/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(120))
         .build()
         .map_err(|e| FbuildError::Other(format!("failed to build http client: {e}")))
 }


### PR DESCRIPTION
## Summary
- Adds an explicit 10s connect timeout and 120s overall request timeout to the `reqwest::blocking` client used by the managed-zccache downloader (`crates/fbuild-build/src/managed_zccache.rs`).
- Without these, a stalled network path could block `ensure()` indefinitely and hang an fbuild build.

Follow-up to #572: CodeRabbit flagged this (Major) but the comment landed after #572 was squash-merged, so the fix is not on `main`.

## Test plan
- [x] `soldr cargo check -p fbuild-build`
- [ ] CI green