### PR TITLE
chore(deps): bump managed zccache 1.12.0 -> 1.12.1

### DIFF
--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -20,12 +20,12 @@ use fbuild_core::{FbuildError, Result};
 
 /// The zccache release fbuild pins. Bump in lockstep with the floor that
 /// the rest of the toolchain expects.
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.0";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.1";
 
 /// GitHub release tag for [`MANAGED_ZCCACHE_VERSION`]. The zccache release
 /// workflow tags without a `v` prefix, while the per-asset filenames carry
 /// `v<version>` — keep both spellings in sync when bumping.
-const RELEASE_TAG: &str = "1.12.0";
+const RELEASE_TAG: &str = "1.12.1";
 
 /// Source repository for managed downloads.
 const REPO: &str = "zackees/zccache";


### PR DESCRIPTION
## Summary

Picks up [zccache#724](https://github.com/zackees/zccache/issues/724) fix shipped in [zccache#725](https://github.com/zackees/zccache/pull/725) (zccache 1.12.1): `FingerprintManager::on_batch` no longer holds DashMap shard locks across canonicalize + full-file blake3 hashing.

Before this, ESP32/LPC builds with ~400 watch roots wedged the daemon under burst load — fbuild's compile path tripped `zccache[err][R]: lost connection to daemon (no response)`.

`SHA256SUMS` is fetched from the GitHub release at runtime, so no hash table updates are needed — only `MANAGED_ZCCACHE_VERSION` and `RELEASE_TAG`.

## Test plan

- [x] Both version constants bumped in lockstep
- [ ] CI green once zccache 1.12.1 GitHub release assets are published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated managed zccache binary to version 1.12.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->