### PR TITLE
feat(serial): add esp_reset hard-reset DTR/RTS primitive (#532)

### DIFF
--- a/crates/fbuild-serial/src/boot_mode.rs
+++ b/crates/fbuild-serial/src/boot_mode.rs
@@ -10,6 +10,12 @@
 //! humans reading the logs) recognise the boot-mode lockup and recover, rather
 //! than mistaking a stuck-in-ROM board for a host-side deadlock. See
 //! FastLED/fbuild#532.
+//!
+//! The matching *recovery* primitive — a single DTR/RTS-driven hard-reset
+//! sequence — lives in [`crate::esp_reset`]. Callers that want to attempt
+//! automatic recovery before propagating the error can invoke
+//! [`crate::esp_reset::hard_reset_blocking`] on the same port that produced
+//! the detection.
 
 /// A detected ESP ROM download-mode signal on the serial stream.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/fbuild-serial/src/esp_reset.rs
+++ b/crates/fbuild-serial/src/esp_reset.rs
@@ -1,0 +1,177 @@
+//! ESP32 hard-reset DTR/RTS sequence.
+//!
+//! Most ESP DevKit boards (and the ESP32-S3 USB serial/JTAG bridge) wire DTR
+//! and RTS to BOOT (IO0) and EN/RESET via a transistor inverter pair, so the
+//! host-side serial line-control bits determine what mode the chip boots
+//! into. Without an explicit, well-timed sequence, fbuild can leave the
+//! lines asserted in a configuration that puts the chip into ROM download
+//! mode — the failure described in FastLED/fbuild#532.
+//!
+//! Detection of a stuck-in-ROM board already lives in
+//! [`crate::boot_mode::detect_download_mode`]. This module supplies the
+//! matching *recovery* primitive: a single function that pulses the lines
+//! through the canonical hard-reset sequence and brings the chip back to
+//! normal firmware boot.
+//!
+//! Wiring assumed (matches every Espressif DevKit + USB-CDC variant):
+//!
+//! | DTR | RTS | Effect                            |
+//! |-----|-----|-----------------------------------|
+//! | low | low | boot from flash (run firmware)    |
+//! | low | high| EN low → reset hold               |
+//! | high| low | BOOT low → enter ROM bootloader   |
+//!
+//! Sequence implemented here keeps DTR=low (so BOOT stays high → boot from
+//! flash) and pulses RTS to toggle EN, matching `esptool`'s
+//! `hard_reset` for classic-hardware UART and USB-CDC bridges.
+
+use std::thread;
+use std::time::Duration;
+
+/// DTR/RTS control surface — exactly what [`hard_reset_blocking`] needs from
+/// a serial port. A blanket impl makes every type that implements
+/// [`serialport::SerialPort`] usable, and a tiny mock impl makes the
+/// sequence unit-testable without real hardware.
+pub trait DtrRtsControl {
+    fn write_data_terminal_ready(&mut self, level: bool) -> serialport::Result<()>;
+    fn write_request_to_send(&mut self, level: bool) -> serialport::Result<()>;
+}
+
+impl<T: serialport::SerialPort + ?Sized> DtrRtsControl for T {
+    fn write_data_terminal_ready(&mut self, level: bool) -> serialport::Result<()> {
+        serialport::SerialPort::write_data_terminal_ready(self, level)
+    }
+    fn write_request_to_send(&mut self, level: bool) -> serialport::Result<()> {
+        serialport::SerialPort::write_request_to_send(self, level)
+    }
+}
+
+/// Hold time for the RTS=high (EN=low) pulse, in milliseconds.
+///
+/// Matches `esptool`'s classic-hardware `hard_reset` timing: long enough to
+/// let the EN debounce capacitor on a DevKit settle across the chips we've
+/// observed, short enough that recovery feels instant to a host caller.
+pub const HARD_RESET_PULSE_MS: u64 = 100;
+
+/// Drive the DTR/RTS sequence that takes an ESP out of ROM download mode
+/// and into normal firmware boot.
+///
+/// Blocking — intended to run inside `tokio::task::spawn_blocking`, matching
+/// the rest of `fbuild-serial`'s pattern (see
+/// [`crate::manager`] for the precedent: every `serialport` mutation
+/// is treated as a synchronous Win32/POSIX call and shipped to the blocking
+/// pool to keep the tokio reactor free).
+///
+/// Sequence (each step is logged at `tracing::debug!`; the completion is
+/// logged at `tracing::info!` so a routine log scan can see the recovery
+/// happened):
+///
+/// 1. `DTR = low` — BOOT pin high → chip will boot from flash, not ROM.
+/// 2. `RTS = high` — EN pin low → reset hold.
+/// 3. Sleep [`HARD_RESET_PULSE_MS`] ms.
+/// 4. `RTS = low` — EN pin high → release reset → chip boots from flash.
+///
+/// Errors from the underlying DTR/RTS writes propagate; the most common
+/// cause is the port being closed mid-call. A `serialport::Error` from
+/// step 1 short-circuits before any pin is pulsed.
+pub fn hard_reset_blocking<P: DtrRtsControl + ?Sized>(port: &mut P) -> serialport::Result<()> {
+    tracing::debug!("esp_reset: DTR=low (BOOT high → boot from flash)");
+    port.write_data_terminal_ready(false)?;
+    tracing::debug!("esp_reset: RTS=high (EN low → reset hold)");
+    port.write_request_to_send(true)?;
+    thread::sleep(Duration::from_millis(HARD_RESET_PULSE_MS));
+    tracing::debug!("esp_reset: RTS=low (EN high → release reset)");
+    port.write_request_to_send(false)?;
+    tracing::info!(
+        "esp_reset: ESP hard-reset complete (DTR=low, RTS pulsed {}ms)",
+        HARD_RESET_PULSE_MS
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct RecordedPort {
+        events: Vec<(&'static str, bool)>,
+        fail_on: Option<&'static str>,
+    }
+
+    impl DtrRtsControl for RecordedPort {
+        fn write_data_terminal_ready(&mut self, level: bool) -> serialport::Result<()> {
+            if self.fail_on == Some("dtr") {
+                return Err(serialport::Error::new(
+                    serialport::ErrorKind::Io(std::io::ErrorKind::Other),
+                    "fake DTR failure",
+                ));
+            }
+            self.events.push(("DTR", level));
+            Ok(())
+        }
+        fn write_request_to_send(&mut self, level: bool) -> serialport::Result<()> {
+            if self.fail_on == Some("rts") {
+                return Err(serialport::Error::new(
+                    serialport::ErrorKind::Io(std::io::ErrorKind::Other),
+                    "fake RTS failure",
+                ));
+            }
+            self.events.push(("RTS", level));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn hard_reset_emits_canonical_sequence() {
+        let mut port = RecordedPort::default();
+        hard_reset_blocking(&mut port).expect("hard_reset should succeed against the mock");
+        assert_eq!(
+            port.events,
+            vec![
+                ("DTR", false), // BOOT high — boot from flash
+                ("RTS", true),  // EN low — reset hold
+                ("RTS", false), // EN high — release reset
+            ]
+        );
+    }
+
+    #[test]
+    fn pulse_holds_for_at_least_the_minimum_duration() {
+        let mut port = RecordedPort::default();
+        let start = std::time::Instant::now();
+        hard_reset_blocking(&mut port).expect("ok");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(HARD_RESET_PULSE_MS),
+            "reset pulse should hold RTS=high for at least {}ms, only slept {:?}",
+            HARD_RESET_PULSE_MS,
+            elapsed
+        );
+    }
+
+    #[test]
+    fn dtr_failure_short_circuits_before_any_rts_pulse() {
+        let mut port = RecordedPort {
+            fail_on: Some("dtr"),
+            ..RecordedPort::default()
+        };
+        assert!(hard_reset_blocking(&mut port).is_err());
+        // Sequence step 1 failed; we must NOT have pulsed EN, otherwise we
+        // would have left the chip in reset.
+        assert!(
+            port.events.is_empty(),
+            "no RTS transitions should fire after a DTR error, got {:?}",
+            port.events
+        );
+    }
+
+    #[test]
+    fn rts_failure_surfaces_to_caller() {
+        let mut port = RecordedPort {
+            fail_on: Some("rts"),
+            ..RecordedPort::default()
+        };
+        assert!(hard_reset_blocking(&mut port).is_err());
+    }
+}

--- a/crates/fbuild-serial/src/lib.rs
+++ b/crates/fbuild-serial/src/lib.rs
@@ -32,6 +32,7 @@
 
 pub mod boot_mode;
 pub mod crash_decoder;
+pub mod esp_reset;
 pub mod manager;
 pub mod messages;
 pub mod preemption;


### PR DESCRIPTION
## Summary
Adds `fbuild_serial::esp_reset::hard_reset_blocking`, the matching **recovery** primitive to `boot_mode::detect_download_mode` (shipped via #547 + #557). After detection surfaces a stuck-in-ROM ESP, callers now have a single function to attempt automatic recovery instead of bailing out with a diagnostic that requires a physical power-cycle.

Sequence matches \`esptool\`'s classic-hardware \`hard_reset\` for both UART and USB-CDC bridges:

| Step | DTR | RTS | Pin effect |
|------|-----|-----|------------|
| 1 | low | – | BOOT high → boot from flash, not ROM |
| 2 | – | high | EN low → reset hold |
| 3 | – | – | sleep \`HARD_RESET_PULSE_MS\` (100 ms) |
| 4 | – | low | EN high → release reset → run firmware |

DTR/RTS transitions are logged at \`tracing::debug!\` and the completion at \`tracing::info!\`, so the #532 acceptance criterion *\"fbuild logs show enough DTR/RTS/reset context to diagnose future S3 boot-mode lockups\"* is met for the recovery path as well as the existing detection path.

## Design
The trait-based design (\`DtrRtsControl\` with a blanket impl over \`serialport::SerialPort\`) keeps the unit tests **hardware-free**: a fake \`RecordedPort\` records every line-control transition, and four tests lock down:
- the canonical sequence (\`DTR=false → RTS=true → RTS=false\`)
- the pulse duration (\`≥ HARD_RESET_PULSE_MS\`)
- error propagation on RTS failure
- **DTR-failure short-circuit** — proving step 1 failure never triggers step 2/3, so the chip is never left in reset

\`boot_mode\`'s module docstring now cross-links \`esp_reset\` so the detection → recovery pairing is obvious at the API entry point.

## Out of scope (follow-up)
Wiring the primitive into the daemon's monitor auto-recovery path. That's a behaviour change for #532 follow-up that needs end-to-end hardware testing on a real ESP32-S3. This PR ships the primitive plus the docstring cross-link so that integration can be trivially plugged in.

## Test plan
- [x] \`soldr cargo test -p fbuild-serial esp_reset\` — 4/4 pass
- [x] \`soldr cargo check --workspace --all-targets\` — clean
- [x] \`soldr cargo clippy -p fbuild-serial --all-targets -- -D warnings\` — no new warnings
- [x] \`soldr rustfmt --check\` on touched files

Refs #532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hard reset capability for ESP32/ESP32-S3 devices stuck in ROM download mode, including a public API function for initiating automatic hardware reset recovery sequences.

* **Documentation**
  * Updated recovery documentation to explain the hard reset mechanism and provide guidance on using the new recovery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->