### PR TITLE
refactor(test-support): consolidate BoardConfig::from_board_id test sites (#519)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "fbuild-core",
  "fbuild-paths",
  "fbuild-serial",
+ "fbuild-test-support",
  "md-5 0.10.6",
  "object 0.36.7",
  "serde",
@@ -1167,6 +1168,7 @@ dependencies = [
 name = "fbuild-test-support"
 version = "2.2.27"
 dependencies = [
+ "fbuild-config",
  "fbuild-header-scan",
  "fbuild-library-select",
  "fbuild-packages",

--- a/crates/fbuild-build/src/nxplpc/orchestrator.rs
+++ b/crates/fbuild-build/src/nxplpc/orchestrator.rs
@@ -297,11 +297,7 @@ mod tests {
             ("lpcxpresso845max", "lpc845"),
         ];
         for (board_id, expected) in cases {
-            let board = fbuild_config::BoardConfig::from_board_id(
-                board_id,
-                &std::collections::HashMap::new(),
-            )
-            .unwrap();
+            let board = fbuild_test_support::board_for_test(board_id);
             assert_eq!(board_lpc_family(&board).unwrap(), expected);
         }
     }

--- a/crates/fbuild-build/src/rp2040/orchestrator.rs
+++ b/crates/fbuild-build/src/rp2040/orchestrator.rs
@@ -823,8 +823,7 @@ mod tests {
         let build_dir = tmp.path().join("build");
         std::fs::create_dir_all(&build_dir).unwrap();
         let framework = fbuild_packages::library::Rp2040Cores::new(tmp.path());
-        let mut board =
-            fbuild_config::BoardConfig::from_board_id("rpipico", &HashMap::new()).unwrap();
+        let mut board = fbuild_test_support::board_for_test("rpipico");
         board.variant = "fbuild-test-rpipico".to_string();
         board.max_flash = Some(2_097_152);
         board.max_ram = Some(262_144);

--- a/crates/fbuild-build/src/teensy/mcu_config.rs
+++ b/crates/fbuild-build/src/teensy/mcu_config.rs
@@ -220,8 +220,7 @@ mod tests {
             ("teensylc", "arm_cortexM0l_math"),
         ];
         for (board_id, expected) in expectations {
-            let board = fbuild_config::BoardConfig::from_board_id(board_id, &HashMap::new())
-                .unwrap_or_else(|_| panic!("BoardConfig should load for {}", board_id));
+            let board = fbuild_test_support::board_for_test(board_id);
             assert_eq!(
                 board.cmsis_dsp_lib.as_deref(),
                 Some(*expected),
@@ -485,8 +484,7 @@ mod tests {
         for (board_id, mcu, ref_json) in reference_configs {
             let reference: serde_json::Value =
                 serde_json::from_str(ref_json).expect("reference JSON should parse");
-            let board_config = fbuild_config::BoardConfig::from_board_id(board_id, &HashMap::new())
-                .unwrap_or_else(|_| panic!("BoardConfig should load for {}", board_id));
+            let board_config = fbuild_test_support::board_for_test(board_id);
             let mcu_config = get_teensy_config_for_mcu(mcu)
                 .unwrap_or_else(|_| panic!("MCU config should load for {}", mcu));
             let mut actual_defines = board_config.get_defines();

--- a/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
@@ -158,9 +158,7 @@ fn run_real_esp32s3_fixture_in_qemu() {
         .expect("should produce firmware.bin");
     let elf_path = build_result.elf_path.clone();
 
-    let board =
-        fbuild_config::BoardConfig::from_board_id("esp32-s3-devkitc-1", &Default::default())
-            .unwrap();
+    let board = fbuild_test_support::board_for_test("esp32-s3-devkitc-1");
     let mcu_config = fbuild_build::esp32::mcu_config::get_mcu_config("esp32s3").unwrap();
     let flash_size_bytes = fbuild_deploy::esp32::resolve_qemu_flash_size_bytes(
         &board,

--- a/crates/fbuild-daemon/src/handlers/emulator/tests_select_runner.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/tests_select_runner.rs
@@ -130,8 +130,7 @@ fn select_runner_auto_detects_avr8js_for_uno() {
 #[test]
 fn select_runner_simavr_name_matches() {
     use super::runners::EmulatorRunner;
-    let board =
-        fbuild_config::BoardConfig::from_board_id("megaatmega2560", &HashMap::new()).unwrap();
+    let board = fbuild_test_support::board_for_test("megaatmega2560");
     let runner = SimavrRunner::new(board);
     assert_eq!(runner.name(), "simavr");
 }

--- a/crates/fbuild-deploy/Cargo.toml
+++ b/crates/fbuild-deploy/Cargo.toml
@@ -38,3 +38,4 @@ md-5 = { version = "0.10", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+fbuild-test-support = { path = "../fbuild-test-support" }

--- a/crates/fbuild-deploy/src/avr.rs
+++ b/crates/fbuild-deploy/src/avr.rs
@@ -166,9 +166,7 @@ mod tests {
 
     #[test]
     fn test_avr_deployer_from_board_config() {
-        let board =
-            fbuild_config::BoardConfig::from_board_id("uno", &std::collections::HashMap::new())
-                .unwrap();
+        let board = fbuild_test_support::board_for_test("uno");
         let params = AvrdudeParams {
             default_programmer: "arduino".to_string(),
             default_baud: "115200".to_string(),

--- a/crates/fbuild-deploy/src/esp32/README.md
+++ b/crates/fbuild-deploy/src/esp32/README.md
@@ -1,0 +1,22 @@
+# ESP32 deployer
+
+Espressif chip family deployer for `fbuild deploy -e esp32*` (UART/USB-CDC
+bootloader path).
+
+Module layout:
+
+- `mod.rs` — `Esp32Deployer` orchestration entry point and `Deployer` trait
+  implementation.
+- `deployer.rs` — esptool/native-flasher invocation, stub upload, reset-after-
+  flash handshake.
+- `image.rs` — bootloader / partition-table / firmware region layout helpers
+  (offsets, padding, MD5 derivation).
+- `qemu.rs` — QEMU flash-image assembly path (`fbuild test-emu` against the
+  `esp32-qemu` emulator runner).
+- `verify.rs` — post-flash verification: native `FLASH_MD5SUM` round-trip with
+  esptool subprocess as the runtime fallback (PR #66 / `espflash-native`
+  feature).
+- `parse.rs` — esptool stdout / stderr parsers that surface progress events and
+  bootloader handshake errors to the daemon's WebSocket clients.
+- `tests.rs` — unit tests for the ESP32-S3 QEMU flash sizing, deployer
+  construction from `BoardConfig`, and parse helpers.

--- a/crates/fbuild-deploy/src/esp32/tests.rs
+++ b/crates/fbuild-deploy/src/esp32/tests.rs
@@ -50,9 +50,7 @@ fn test_esp32_deployer_creation() {
 
 #[test]
 fn qemu_flash_size_resolution_accepts_supported_sizes() {
-    let mut board =
-        fbuild_config::BoardConfig::from_board_id("esp32-s3-devkitc-1", &Default::default())
-            .unwrap();
+    let mut board = fbuild_test_support::board_for_test("esp32-s3-devkitc-1");
     board.max_flash = Some(8 * 1024 * 1024);
     assert_eq!(
         resolve_qemu_flash_size_bytes(&board, "4MB").unwrap(),
@@ -62,9 +60,7 @@ fn qemu_flash_size_resolution_accepts_supported_sizes() {
 
 #[test]
 fn qemu_flash_size_resolution_rejects_unsupported_size() {
-    let mut board =
-        fbuild_config::BoardConfig::from_board_id("esp32-s3-devkitc-1", &Default::default())
-            .unwrap();
+    let mut board = fbuild_test_support::board_for_test("esp32-s3-devkitc-1");
     board.max_flash = Some(32 * 1024 * 1024);
     let err = resolve_qemu_flash_size_bytes(&board, "4MB").unwrap_err();
     assert!(err
@@ -252,9 +248,7 @@ fn qemu_command_builder_adds_psram_args_when_requested() {
 
 #[test]
 fn test_esp32_deployer_from_board_config() {
-    let board =
-        fbuild_config::BoardConfig::from_board_id("esp32c6", &std::collections::HashMap::new())
-            .unwrap();
+    let board = fbuild_test_support::board_for_test("esp32c6");
     let params = test_esptool_params();
     let deployer =
         Esp32Deployer::from_board_config(&board, "0x0", "0x8000", "0x10000", &params, false);
@@ -267,7 +261,7 @@ fn test_esp32_deployer_from_board_config_honors_flash_size_override() {
     let mut overrides = std::collections::HashMap::new();
     overrides.insert("flash_size".to_string(), "4MB".to_string());
     let board =
-        fbuild_config::BoardConfig::from_board_id("esp32-c6-devkitc-1", &overrides).unwrap();
+        fbuild_test_support::board_for_test_with_overrides("esp32-c6-devkitc-1", &overrides);
     let params = test_esptool_params();
 
     let deployer =

--- a/crates/fbuild-deploy/src/teensy/mod.rs
+++ b/crates/fbuild-deploy/src/teensy/mod.rs
@@ -341,11 +341,7 @@ mod tests {
 
     #[test]
     fn test_teensy_deployer_from_board_config() {
-        let board = fbuild_config::BoardConfig::from_board_id(
-            "teensy41",
-            &std::collections::HashMap::new(),
-        )
-        .unwrap();
+        let board = fbuild_test_support::board_for_test("teensy41");
         let deployer =
             TeensyDeployer::from_board_config(&board, &TeensyLoaderParams::default(), false);
         assert_eq!(deployer.mcu_name, "TEENSY41");
@@ -353,11 +349,7 @@ mod tests {
 
     #[test]
     fn test_teensy_deployer_teensy40() {
-        let board = fbuild_config::BoardConfig::from_board_id(
-            "teensy40",
-            &std::collections::HashMap::new(),
-        )
-        .unwrap();
+        let board = fbuild_test_support::board_for_test("teensy40");
         let deployer =
             TeensyDeployer::from_board_config(&board, &TeensyLoaderParams::default(), false);
         assert_eq!(deployer.mcu_name, "TEENSY40");

--- a/crates/fbuild-test-support/Cargo.toml
+++ b/crates/fbuild-test-support/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
+fbuild-config = { path = "../fbuild-config" }
 fbuild-packages = { path = "../fbuild-packages" }
 fbuild-header-scan = { path = "../fbuild-header-scan" }
 fbuild-library-select = { path = "../fbuild-library-select" }

--- a/crates/fbuild-test-support/src/board.rs
+++ b/crates/fbuild-test-support/src/board.rs
@@ -1,0 +1,49 @@
+//! Shared board-config helper for unit tests across the workspace.
+//!
+//! `BoardConfig::from_board_id` is the legacy entry point that
+//! `BoardConfig::from_board_id_in_project` superseded when `project_dir`
+//! threading landed (#516 / #518). Every production caller routes through
+//! `fbuild_build::resolution::resolve_board` now (#519 → #543/#544/#545/
+//! #546/#552/#562/#564/#567), but per-test fixtures still need an ergonomic
+//! way to materialise a stock `BoardConfig` without each test rebuilding the
+//! `(board_id, &HashMap::new())` boilerplate by hand.
+//!
+//! This helper is the **one** sanctioned test-side call site to
+//! `BoardConfig::from_board_id`, completing the #519 acceptance criterion
+//! ("≤2 call sites outside `fbuild-config`: the new entry points + one test
+//! helper").
+
+use std::collections::HashMap;
+
+use fbuild_config::BoardConfig;
+
+/// Resolve a stock built-in `BoardConfig` for a test fixture (no overrides).
+///
+/// Panics on lookup failure — tests treat a missing built-in board as a
+/// hard configuration error, not a recoverable miss. Pass the canonical
+/// `board_id` from the relevant manifest (e.g. `"uno"`, `"teensy41"`,
+/// `"rpipico"`, `"lpc845brk"`).
+///
+/// This is one of the **two** sanctioned test-side callers of
+/// `BoardConfig::from_board_id`; the other is
+/// [`board_for_test_with_overrides`] for tests that exercise override
+/// behaviour. Production code routes through
+/// `fbuild_build::resolution::resolve_board` per #519.
+#[track_caller]
+pub fn board_for_test(board_id: &str) -> BoardConfig {
+    board_for_test_with_overrides(board_id, &HashMap::new())
+}
+
+/// Resolve a built-in `BoardConfig` for a test fixture, with PlatformIO
+/// `[env]` overrides applied. Used by tests that need to verify
+/// override-driven behaviour (e.g. `flash_size`, `f_cpu`).
+///
+/// Same panic semantics as [`board_for_test`].
+#[track_caller]
+pub fn board_for_test_with_overrides(
+    board_id: &str,
+    overrides: &HashMap<String, String>,
+) -> BoardConfig {
+    BoardConfig::from_board_id(board_id, overrides)
+        .unwrap_or_else(|e| panic!("BoardConfig should load for built-in board {board_id:?}: {e}"))
+}

--- a/crates/fbuild-test-support/src/lib.rs
+++ b/crates/fbuild-test-support/src/lib.rs
@@ -1,9 +1,11 @@
 //! Test utilities and fixtures for fbuild.
 
+pub mod board;
 pub mod compile_db;
 pub mod elf_probe;
 pub mod mini_framework;
 
+pub use board::{board_for_test, board_for_test_with_overrides};
 pub use compile_db::{CompileDb, CompileDbError, CompileEntry};
 pub use elf_probe::{ElfProbe, ElfProbeError, SectionInfo, SymbolInfo};
 pub use mini_framework::{LibraryBuilder, MiniFramework};


### PR DESCRIPTION
## Summary
Finishes the #519 audit on the test side. Production audit landed earlier (#543/#544/#545/#546/#552/#562/#564/#567) — every runtime caller now routes through \`fbuild_build::resolution::resolve_board\`, which threads \`project_dir\` for free. The remaining gap was the test fixtures: **11 unit-test call sites** across \`fbuild-build\` (nxplpc, rp2040, teensy×2), \`fbuild-deploy\` (avr, teensy×2, esp32×4) and \`fbuild-daemon\` (emulator×2) each open-coded the same \`(board_id, &HashMap::new()).unwrap()\` boilerplate.

Add \`fbuild_test_support::board_for_test\` (and a \`board_for_test_with_overrides\` variant for the one ESP32 flash_size-override test) as the **single sanctioned test-side caller** of \`BoardConfig::from_board_id\`, and migrate every site.

## Acceptance — \"≤2 call sites outside fbuild-config (the new entry points + one test helper)\"

After this PR:
\`\`\`
$ rg 'BoardConfig::from_board_id\b' crates/ | grep -v fbuild-config/
crates/fbuild-test-support/src/board.rs:47   ← the sanctioned helper
\`\`\`
**One** actual call site outside \`fbuild-config\` (well under the ≤2 target). Plus a single non-call comment reference in \`deploy.rs:448\`. Production audit + test audit both done — #519 ready to close.

## Why two helper variants
\`board_for_test(\"esp32-c6-devkitc-1\")\` covers the common case (no overrides) — 10 of the 11 sites. \`board_for_test_with_overrides(id, &overrides)\` keeps \`test_esp32_deployer_from_board_config_honors_flash_size_override\` honest: that test specifically exercises that an \`[env]\` override flows through into the loaded \`BoardConfig\`, so it must keep the overrides input. One helper, one override variant — simpler than a builder.

## Drive-by
\`crates/fbuild-deploy/src/esp32/\` was missing a \`README.md\` (caught by the \`readme_guard.py\` PreToolUse hook on the first edit). Added a layout/module README.

## Test plan
- [x] \`soldr cargo check --workspace --all-targets\` — clean
- [x] \`soldr cargo test -p fbuild-test-support\` — 37 pass
- [x] \`soldr cargo test -p fbuild-deploy --lib\` — 86 pass
- [x] \`soldr cargo test -p fbuild-daemon --lib emulator\` — 43 pass
- [x] \`soldr cargo clippy\` on touched crates — no new warnings
- Pre-existing flake \`script_runtime::tests::test_resolve_extra_script_overlay_supports_pio_platform_shim\` (passes in isolation, fails with full suite) is unrelated.

Closes #519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests across multiple modules to use new board configuration helper functions for improved test setup.

* **Documentation**
  * Added ESP32 deployer module documentation.

* **Chores**
  * Added test infrastructure helpers for constructing board configurations in tests with optional overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->