### PR TITLE
chore(deps): bump managed zccache 1.12.1 -> 1.12.3

### DIFF
--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -20,12 +20,12 @@ use fbuild_core::{FbuildError, Result};
 
 /// The zccache release fbuild pins. Bump in lockstep with the floor that
 /// the rest of the toolchain expects.
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.1";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.3";
 
 /// GitHub release tag for [`MANAGED_ZCCACHE_VERSION`]. The zccache release
 /// workflow tags without a `v` prefix, while the per-asset filenames carry
 /// `v<version>` — keep both spellings in sync when bumping.
-const RELEASE_TAG: &str = "1.12.1";
+const RELEASE_TAG: &str = "1.12.3";
 
 /// Source repository for managed downloads.
 const REPO: &str = "zackees/zccache";


### PR DESCRIPTION
## Summary

Bumps managed zccache 1.12.1 -> 1.12.3 (skipping 1.12.2 — the consumer cascade never ran for 1.12.2; jumping to 1.12.3 picks up all fixes).

Issues addressed:

- **#710** — meson configure snapshot allowlist + `zccache clear` purges meson-configure (closes the stale-PCH poisoning class).
- **#726** — daemon wedge guard widened (90s -> 180s) + duplicate `died-shutdown` writes deduped under burst link load.
- **#728** — enriched persist `os error 2` WARN diagnostics for future Defender repros.

`SHA256SUMS` is fetched from the GitHub release at runtime, so no hash table updates are needed — only `MANAGED_ZCCACHE_VERSION` and `RELEASE_TAG`.

## Test plan

- [ ] CI green once zccache 1.12.3 GitHub release assets are published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated zccache dependency from version 1.12.1 to 1.12.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->