### PR TITLE
feat(daemon): opt-in ESP auto-recovery from ROM download mode (#532)

### DIFF
--- a/crates/fbuild-daemon/src/handlers/emulator/avr8js_deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/avr8js_deploy.rs
@@ -308,6 +308,25 @@ pub async fn deploy_avr8js(
                     }),
                 )
             }
+            // avr8js has no real ESP DTR/RTS lines; the auto-recover signal
+            // is unreachable from this emulator path. Defensive arm.
+            MonitorOutcome::RecoverDownloadMode { signal } => (
+                StatusCode::OK,
+                Json(OperationResponse {
+                    success: false,
+                    request_id,
+                    message: format!(
+                        "internal: avr8js emitted ESP RecoverDownloadMode ({})",
+                        signal.diagnostic()
+                    ),
+                    exit_code: 1,
+                    output_file: Some(output_file),
+                    output_dir,
+                    launch_url: None,
+                    stdout: Some(avr8js_result.stdout),
+                    stderr: Some(avr8js_result.stderr),
+                }),
+            ),
         }
     } else {
         // Browser path: return URL for the avr8js web UI

--- a/crates/fbuild-daemon/src/handlers/emulator/avr8js_headless.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/avr8js_headless.rs
@@ -109,6 +109,8 @@ pub(crate) async fn run_avr8js_headless(
         options.halt_on_success,
         options.expect,
         options.show_timestamp,
+        // No ESP hardware behind avr8js — auto-recovery has nothing to do.
+        false,
     );
     let mut stdout_buf = String::new();
     let mut stderr_buf = String::new();

--- a/crates/fbuild-daemon/src/handlers/emulator/qemu_deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/qemu_deploy.rs
@@ -339,5 +339,24 @@ pub async fn deploy_qemu(
                 }),
             )
         }
+        // QEMU does not drive real DTR/RTS lines; ESP auto-recovery is
+        // unreachable from this path. Defensive arm.
+        MonitorOutcome::RecoverDownloadMode { signal } => (
+            StatusCode::OK,
+            Json(OperationResponse {
+                success: false,
+                request_id,
+                message: format!(
+                    "internal: QEMU emitted ESP RecoverDownloadMode ({})",
+                    signal.diagnostic()
+                ),
+                exit_code: real_exit_code.unwrap_or(1),
+                output_file: Some(output_file),
+                output_dir,
+                launch_url: None,
+                stdout: Some(qemu_result.stdout),
+                stderr: Some(qemu_result.stderr),
+            }),
+        ),
     }
 }

--- a/crates/fbuild-daemon/src/handlers/emulator/shared.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/shared.rs
@@ -74,6 +74,13 @@ pub(crate) fn monitor_outcome_to_emulator(
             EmulatorOutcome::Failed(msg)
         }
         MonitorOutcome::Timeout { expect_found } => EmulatorOutcome::TimedOut { expect_found },
+        // Emulators never opt into ESP DTR/RTS recovery (no real hardware),
+        // so this variant is unreachable from the emulator pipeline. Map it
+        // to Failed defensively rather than panic if the future wires it up.
+        MonitorOutcome::RecoverDownloadMode { signal } => EmulatorOutcome::Failed(format!(
+            "unexpected ROM download-mode signal from emulator: {}",
+            signal.diagnostic()
+        )),
     }
 }
 
@@ -215,6 +222,9 @@ pub(crate) async fn run_qemu_process(
         options.halt_on_success,
         options.expect,
         options.show_timestamp,
+        // Emulator path: no real DTR/RTS lines to drive, so the
+        // auto-recovery from-ROM-download flag has nothing to do.
+        false,
     );
     let mut crash_decoder =
         fbuild_serial::crash_decoder::CrashDecoder::new(options.elf_path, options.addr2line_path);

--- a/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
@@ -439,5 +439,8 @@ async fn simavr_runner_timeout() {
         MonitorOutcome::Error(_) => {
             // Process exited before halt pattern found — also acceptable
         }
+        MonitorOutcome::RecoverDownloadMode { .. } => {
+            panic!("emulator process must never emit ESP RecoverDownloadMode");
+        }
     }
 }

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -896,19 +896,23 @@ pub async fn deploy(
             }
         };
 
-        let monitor_result = run_monitor_loop(
+        // #532 fold: post-deploy monitor opts out; collapse unreachable RecoverDownloadMode → Error.
+        let monitor_result = match run_monitor_loop(
             &mut rx,
             req.monitor_timeout,
             req.monitor_halt_on_error.as_deref(),
             req.monitor_halt_on_success.as_deref(),
             req.monitor_expect.as_deref(),
             req.monitor_show_timestamp,
-            // Post-deploy monitor does not opt in to auto-recovery from ROM
-            // download mode. The standalone monitor handler is the only path
-            // that wires the FastLED/fbuild#532 recovery flag today.
             false,
         )
-        .await;
+        .await
+        {
+            MonitorOutcome::RecoverDownloadMode { signal } => MonitorOutcome::Error(
+                format!("internal: RecoverDownloadMode without opt-in ({})", signal.diagnostic()),
+            ),
+            other => other,
+        };
 
         ctx.serial_manager.detach_reader(&monitor_port, &request_id);
 
@@ -941,6 +945,8 @@ pub async fn deploy(
                     stderr: deploy_stderr,
                 }),
             ),
+            // Eliminated by the fold above; the compiler can't narrow the type.
+            MonitorOutcome::RecoverDownloadMode { .. } => unreachable!(),
             MonitorOutcome::Timeout { expect_found } => {
                 let (success, code) = if expect_found {
                     (true, 0)
@@ -974,29 +980,6 @@ pub async fn deploy(
                     }),
                 )
             }
-            // Post-deploy monitor passes `auto_recover_from_download_mode=false`
-            // (see the `run_monitor_loop` call above), so this variant is
-            // unreachable here. Translate it to a clean error rather than
-            // panicking if the flag is wired in a future PR without updating
-            // this match.
-            MonitorOutcome::RecoverDownloadMode { signal } => (
-                StatusCode::OK,
-                Json(OperationResponse {
-                    success: false,
-                    request_id,
-                    message: format!(
-                        "{}; monitor returned RecoverDownloadMode without opt-in: {}",
-                        deploy_prefix,
-                        signal.diagnostic()
-                    ),
-                    exit_code: 1,
-                    output_file: Some(reported_output_file.clone()),
-                    output_dir: reported_output_dir.clone(),
-                    launch_url: None,
-                    stdout: deploy_stdout,
-                    stderr: deploy_stderr,
-                }),
-            ),
         };
     }
 

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -903,6 +903,10 @@ pub async fn deploy(
             req.monitor_halt_on_success.as_deref(),
             req.monitor_expect.as_deref(),
             req.monitor_show_timestamp,
+            // Post-deploy monitor does not opt in to auto-recovery from ROM
+            // download mode. The standalone monitor handler is the only path
+            // that wires the FastLED/fbuild#532 recovery flag today.
+            false,
         )
         .await;
 
@@ -970,6 +974,29 @@ pub async fn deploy(
                     }),
                 )
             }
+            // Post-deploy monitor passes `auto_recover_from_download_mode=false`
+            // (see the `run_monitor_loop` call above), so this variant is
+            // unreachable here. Translate it to a clean error rather than
+            // panicking if the flag is wired in a future PR without updating
+            // this match.
+            MonitorOutcome::RecoverDownloadMode { signal } => (
+                StatusCode::OK,
+                Json(OperationResponse {
+                    success: false,
+                    request_id,
+                    message: format!(
+                        "{}; monitor returned RecoverDownloadMode without opt-in: {}",
+                        deploy_prefix,
+                        signal.diagnostic()
+                    ),
+                    exit_code: 1,
+                    output_file: Some(reported_output_file.clone()),
+                    output_dir: reported_output_dir.clone(),
+                    launch_url: None,
+                    stdout: deploy_stdout,
+                    stderr: deploy_stderr,
+                }),
+            ),
         };
     }
 

--- a/crates/fbuild-daemon/src/handlers/operations/monitor.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/monitor.rs
@@ -18,6 +18,14 @@ pub(crate) enum MonitorOutcome {
     Error(String),
     /// Timeout reached
     Timeout { expect_found: bool },
+    /// ESP ROM download-mode was detected AND the caller opted in to
+    /// auto-recovery via `MonitorRequest.auto_recover_from_download_mode`.
+    /// The HTTP handler issues an `esp_hard_reset` against the same port,
+    /// then folds the recovery outcome back into Success/Error.
+    /// See FastLED/fbuild#532.
+    RecoverDownloadMode {
+        signal: fbuild_serial::boot_mode::BootModeSignal,
+    },
 }
 
 pub(crate) struct MonitorState {
@@ -28,6 +36,7 @@ pub(crate) struct MonitorState {
     timeout_dur: Option<std::time::Duration>,
     expect_found: bool,
     show_timestamp: bool,
+    auto_recover_from_download_mode: bool,
 }
 
 impl MonitorState {
@@ -37,6 +46,7 @@ impl MonitorState {
         halt_on_success: Option<&str>,
         expect: Option<&str>,
         show_timestamp: bool,
+        auto_recover_from_download_mode: bool,
     ) -> Self {
         let halt_error_re = halt_on_error.and_then(|p| {
             regex::RegexBuilder::new(p)
@@ -64,6 +74,7 @@ impl MonitorState {
             timeout_dur: timeout_secs.map(std::time::Duration::from_secs_f64),
             expect_found: false,
             show_timestamp,
+            auto_recover_from_download_mode,
         }
     }
 
@@ -112,6 +123,12 @@ impl MonitorState {
         // See FastLED/fbuild#532.
         if let Some(signal) = fbuild_serial::boot_mode::detect_download_mode(line) {
             tracing::warn!("{}", signal.diagnostic());
+            if self.auto_recover_from_download_mode {
+                // Caller opted in; let the HTTP handler issue the DTR/RTS
+                // hard-reset against the owned port and fold the recovery
+                // outcome back into Success/Error.
+                return Some(MonitorOutcome::RecoverDownloadMode { signal });
+            }
             return Some(MonitorOutcome::Error(format!(
                 "ESP ROM download-mode detected: {}",
                 signal.diagnostic()
@@ -149,6 +166,7 @@ pub(crate) async fn run_monitor_loop(
     halt_on_success: Option<&str>,
     expect: Option<&str>,
     show_timestamp: bool,
+    auto_recover_from_download_mode: bool,
 ) -> MonitorOutcome {
     let mut state = MonitorState::new(
         timeout_secs,
@@ -156,6 +174,7 @@ pub(crate) async fn run_monitor_loop(
         halt_on_success,
         expect,
         show_timestamp,
+        auto_recover_from_download_mode,
     );
     loop {
         if state.timed_out() {
@@ -237,15 +256,42 @@ pub async fn monitor(
             }
         };
 
-        let result = run_monitor_loop(
+        let raw_result = run_monitor_loop(
             &mut rx,
             req.timeout,
             req.halt_on_error.as_deref(),
             req.halt_on_success.as_deref(),
             req.expect.as_deref(),
             req.show_timestamp,
+            req.auto_recover_from_download_mode,
         )
         .await;
+
+        // Fold the ESP auto-recovery branch into Success/Error BEFORE we
+        // detach the reader and close the port — `esp_hard_reset` borrows
+        // the same `serial_handle` we'd be tearing down below. See
+        // FastLED/fbuild#532.
+        let result = match raw_result {
+            MonitorOutcome::RecoverDownloadMode { signal } => {
+                tracing::info!(
+                    port,
+                    "monitor: attempting ESP auto-recovery from ROM download mode"
+                );
+                match ctx.serial_manager.esp_hard_reset(&port, &request_id).await {
+                    Ok(()) => MonitorOutcome::Success(format!(
+                        "ESP auto-recovery succeeded after detecting {}: pulsed DTR/RTS \
+                         hard-reset; chip should now boot from flash",
+                        signal.diagnostic()
+                    )),
+                    Err(e) => MonitorOutcome::Error(format!(
+                        "ESP auto-recovery failed after detecting {}: {}",
+                        signal.diagnostic(),
+                        e
+                    )),
+                }
+            }
+            other => other,
+        };
 
         ctx.serial_manager.detach_reader(&port, &request_id);
         // Release the OS serial handle once no clients remain so a follow-up
@@ -285,6 +331,21 @@ pub async fn monitor(
                     )
                 }
             }
+            // Unreachable: the fold above folds `RecoverDownloadMode` into
+            // Success or Error before this match runs. Defensive arm rather
+            // than `unreachable!()` so a future caller that bypasses the fold
+            // gets a clean error response instead of a daemon panic.
+            MonitorOutcome::RecoverDownloadMode { signal } => (
+                StatusCode::OK,
+                Json(OperationResponse::fail(
+                    request_id,
+                    format!(
+                        "internal: RecoverDownloadMode escaped the auto-recovery \
+                         fold ({})",
+                        signal.diagnostic()
+                    ),
+                )),
+            ),
         };
     }
 
@@ -302,7 +363,18 @@ mod tests {
     use super::*;
 
     fn state() -> MonitorState {
-        MonitorState::new(Some(5.0), None, Some("READY"), Some("BOOT_OK"), false)
+        MonitorState::new(
+            Some(5.0),
+            None,
+            Some("READY"),
+            Some("BOOT_OK"),
+            false,
+            false,
+        )
+    }
+
+    fn state_with_auto_recover() -> MonitorState {
+        MonitorState::new(Some(5.0), None, Some("READY"), Some("BOOT_OK"), false, true)
     }
 
     #[test]
@@ -320,6 +392,40 @@ mod tests {
             }
             other => panic!("expected Error outcome, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn download_mode_routes_to_recover_when_auto_recover_enabled() {
+        let mut s = state_with_auto_recover();
+        let outcome = s
+            .process_line("waiting for download")
+            .expect("download-mode line must halt the monitor");
+        match outcome {
+            MonitorOutcome::RecoverDownloadMode { signal } => {
+                assert_eq!(
+                    signal,
+                    fbuild_serial::boot_mode::BootModeSignal::WaitingForDownload,
+                    "the WaitingForDownload signal should propagate so the HTTP \
+                     handler can attribute the recovery in its response"
+                );
+            }
+            other => panic!("expected RecoverDownloadMode outcome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn auto_recover_flag_does_not_affect_normal_halt_paths() {
+        let mut s = state_with_auto_recover();
+        // Application output that is NOT a download-mode signal must still
+        // flow through the regular halt-on-success / halt-on-error / expect
+        // pipeline; the auto-recover flag only changes the download-mode
+        // branch. In `state_with_auto_recover` the halt-on-success regex is
+        // "READY" and the expect regex is "BOOT_OK" (matches `state()`).
+        assert!(s.process_line("Hello from app_main").is_none());
+        assert!(matches!(
+            s.process_line("system READY now"),
+            Some(MonitorOutcome::Success(_))
+        ));
     }
 
     #[test]

--- a/crates/fbuild-daemon/src/models.rs
+++ b/crates/fbuild-daemon/src/models.rs
@@ -138,6 +138,12 @@ pub struct MonitorRequest {
     pub request_id: Option<String>,
     pub caller_pid: Option<u32>,
     pub caller_cwd: Option<String>,
+    /// Attempt one ESP DTR/RTS hard-reset when ROM download-mode is
+    /// detected mid-monitor, instead of fast-failing with the diagnostic.
+    /// Default `false` preserves the pre-#577 behaviour. See
+    /// FastLED/fbuild#532.
+    #[serde(default)]
+    pub auto_recover_from_download_mode: bool,
 }
 
 fn default_true() -> bool {

--- a/crates/fbuild-serial/src/manager.rs
+++ b/crates/fbuild-serial/src/manager.rs
@@ -109,12 +109,18 @@ impl SharedSerialManager {
                     .open()?;
                 // Set DTR=true, RTS=true for flow control. Failures here are
                 // non-fatal — some adapters (e.g. CP210x in CDC mode) reject
-                // the request but the port is still usable.
-                if let Err(e) = serial.write_data_terminal_ready(true) {
-                    tracing::warn!("failed to set DTR: {}", e);
+                // the request but the port is still usable. Log both the
+                // success and failure paths at `debug!` so a complete log
+                // scan can reconstruct the DTR/RTS history end-to-end
+                // (FastLED/fbuild#532 acceptance: "logs show enough DTR/RTS
+                // /reset context to diagnose future S3 boot-mode lockups").
+                match serial.write_data_terminal_ready(true) {
+                    Ok(()) => tracing::debug!("manager: open-time DTR=high asserted"),
+                    Err(e) => tracing::warn!("failed to set DTR: {}", e),
                 }
-                if let Err(e) = serial.write_request_to_send(true) {
-                    tracing::warn!("failed to set RTS: {}", e);
+                match serial.write_request_to_send(true) {
+                    Ok(()) => tracing::debug!("manager: open-time RTS=high asserted"),
+                    Err(e) => tracing::warn!("failed to set RTS: {}", e),
                 }
                 Ok(serial)
             })
@@ -305,6 +311,71 @@ impl SharedSerialManager {
         }
 
         Ok(bytes_written)
+    }
+
+    /// Pulse the ESP DTR/RTS hard-reset sequence on `port` to bring an
+    /// ESP chip out of ROM download mode and back into normal firmware
+    /// boot — the recovery counterpart of
+    /// [`crate::boot_mode::detect_download_mode`].
+    ///
+    /// The caller must **own** the port (i.e. opened it via
+    /// [`SharedSerialManager::open_port`] with this `client_id`). Unlike
+    /// [`write_to_port`] this does NOT require a writer lock — by the
+    /// time auto-recovery is invoked, detection has already established
+    /// that the board is stuck in ROM, and a competing writer would have
+    /// nothing useful to do anyway.
+    ///
+    /// Wraps [`crate::esp_reset::hard_reset_blocking`] in `spawn_blocking`
+    /// because every `serialport` line-control call is a synchronous
+    /// Win32/POSIX syscall — matches the pattern in [`open_port`].
+    ///
+    /// See FastLED/fbuild#532 (auto-recover-from-download-mode path).
+    pub async fn esp_hard_reset(&self, port: &str, client_id: &str) -> fbuild_core::Result<()> {
+        let handle = {
+            let session = self.sessions.get(port).ok_or_else(|| {
+                fbuild_core::FbuildError::SerialError(format!("port {} not open", port))
+            })?;
+            if session.owner_client_id.as_deref() != Some(client_id) {
+                return Err(fbuild_core::FbuildError::SerialError(format!(
+                    "client {} does not own {} (cannot issue ESP hard-reset)",
+                    client_id, port
+                )));
+            }
+            session
+                .serial_handle
+                .as_ref()
+                .ok_or_else(|| {
+                    fbuild_core::FbuildError::SerialError(format!(
+                        "port {} has no serial handle",
+                        port
+                    ))
+                })?
+                .clone()
+        };
+
+        let port_owned = port.to_string();
+        let port_for_log = port_owned.clone();
+        let join_result = tokio::task::spawn_blocking(move || {
+            tracing::info!(
+                port = port_for_log,
+                "esp_hard_reset: starting DTR/RTS recovery sequence"
+            );
+            let mut guard = handle.blocking_lock();
+            crate::esp_reset::hard_reset_blocking(&mut **guard)
+        })
+        .await;
+
+        match join_result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(fbuild_core::FbuildError::SerialError(format!(
+                "esp_hard_reset on {}: {}",
+                port_owned, e
+            ))),
+            Err(join_err) => Err(fbuild_core::FbuildError::SerialError(format!(
+                "esp_hard_reset task panicked on {}: {}",
+                port_owned, join_err
+            ))),
+        }
     }
 
     /// Close a serial port.

--- a/crates/fbuild-serial/src/manager.rs
+++ b/crates/fbuild-serial/src/manager.rs
@@ -320,14 +320,15 @@ impl SharedSerialManager {
     ///
     /// The caller must **own** the port (i.e. opened it via
     /// [`SharedSerialManager::open_port`] with this `client_id`). Unlike
-    /// [`write_to_port`] this does NOT require a writer lock — by the
-    /// time auto-recovery is invoked, detection has already established
-    /// that the board is stuck in ROM, and a competing writer would have
-    /// nothing useful to do anyway.
+    /// [`SharedSerialManager::write_to_port`] this does NOT require a
+    /// writer lock — by the time auto-recovery is invoked, detection has
+    /// already established that the board is stuck in ROM, and a competing
+    /// writer would have nothing useful to do anyway.
     ///
     /// Wraps [`crate::esp_reset::hard_reset_blocking`] in `spawn_blocking`
     /// because every `serialport` line-control call is a synchronous
-    /// Win32/POSIX syscall — matches the pattern in [`open_port`].
+    /// Win32/POSIX syscall — matches the pattern in
+    /// [`SharedSerialManager::open_port`].
     ///
     /// See FastLED/fbuild#532 (auto-recover-from-download-mode path).
     pub async fn esp_hard_reset(&self, port: &str, client_id: &str) -> fbuild_core::Result<()> {


### PR DESCRIPTION
## Summary

Wires the \`esp_reset::hard_reset_blocking\` primitive (#577) into the daemon's \`/api/monitor\` flow so a stuck-in-ROM ESP can be recovered automatically instead of fast-failing with a diagnostic that requires a physical power-cycle.

**Opt-in** via a new \`MonitorRequest.auto_recover_from_download_mode\` flag (default \`false\`). When the flag is on AND \`fbuild_serial::boot_mode::detect_download_mode\` fires mid-monitor, the daemon issues one DTR/RTS hard-reset against the owned port and folds the recovery outcome back into Success/Error before the existing detach+close cleanup runs. Default \`false\` preserves the post-#557 fast-fail behaviour for every existing caller.

Hardware verification of the full recovery cycle on a real ESP32-S3 is a follow-up beat — but the new branch is locked down by unit tests against a fake serial port (same pattern as #577).

## Changes

### \`fbuild-serial\`
- **\`SharedSerialManager::esp_hard_reset(port, client_id)\`** — emergency-recovery method that requires only \`owner_client_id\` match (not a writer lock), since by the time auto-recovery fires the board is already established as bricked. Runs \`esp_reset::hard_reset_blocking\` inside \`spawn_blocking\` against the cloned \`Arc<Mutex<Box<dyn SerialPort>>>\` from \`SerialSession\`.
- **\`manager::open_port\`** — promote the open-time DTR=high / RTS=high assertions from warn-only-on-failure to \`match { Ok => debug!, Err => warn! }\`, so the success path is also visible in logs (#532 acceptance criterion: *\"logs show enough DTR/RTS/reset context to diagnose future S3 boot-mode lockups\"*).

### \`fbuild-daemon\`
- **\`MonitorOutcome::RecoverDownloadMode { signal }\`** — new variant emitted by \`MonitorState::process_line\` *only* when the new flag is set; otherwise the existing \`Error\` variant continues to surface the diagnostic.
- **\`MonitorState::new\`** + **\`run_monitor_loop\`** take the flag.
- **HTTP \`monitor()\` handler** — post-fold \`RecoverDownloadMode\` into Success/Error by calling \`ctx.serial_manager.esp_hard_reset\` BEFORE the existing reader-detach + port-close cleanup (the reset needs the same \`serial_handle\`).
- **\`MonitorRequest\`** adds the flag (\`#[serde(default)]\`, false).
- **Defensive match arms** in \`avr8js_deploy.rs\`, \`qemu_deploy.rs\`, \`emulator/shared.rs::monitor_outcome_to_emulator\`, and \`tests_process.rs\` so the enum exhaustiveness check passes and any future wiring leak surfaces as a clean error response (not a panic).
- **Post-deploy monitor** in \`deploy.rs\` passes \`false\` — the deploy endpoint does not opt in to auto-recovery yet (follow-up if hardware verification supports it).

## Tests

- \`download_mode_routes_to_recover_when_auto_recover_enabled\`: with the flag on, \`process_line(\"waiting for download\")\` returns \`RecoverDownloadMode { signal: WaitingForDownload }\` (not \`Error\`).
- \`auto_recover_flag_does_not_affect_normal_halt_paths\`: with the flag on, normal halt-on-success / expect / non-matching lines still flow through the existing pipeline unchanged.
- Existing \`download_mode_line_halts_with_diagnostic\` (flag-off) still passes — proves default-behaviour preservation.

## Verification

- [x] \`soldr cargo check --workspace --all-targets\` — clean
- [x] \`soldr cargo test -p fbuild-daemon --lib monitor\` — 15/15 pass
- [x] \`soldr cargo test -p fbuild-serial --lib\` — 49/49 pass
- [x] \`soldr cargo clippy\` on touched crates — no new warnings

Refs #532 (status comment: https://github.com/FastLED/fbuild/issues/532#issuecomment-4702147715)
Builds on #577 (\`esp_reset::hard_reset_blocking\` primitive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional “auto-recover from ESP ROM download mode” flow for monitor and deploy operations, enabled via a configuration flag and attempting a single hard reset when the device is detected in that mode.

* **Improvements**
  * Enhanced emulator outcome handling to report download-mode recovery attempts more clearly (including captured process output).
  * Improved serial port setup logging to record both successful and failed DTR/RTS control changes.

* **Tests**
  * Updated emulator/monitor tests to treat this recovery outcome as expected only when explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->