### PR TITLE
chore(deps): bump managed zccache 1.12.3 -> 1.12.4

### DIFF
--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -20,12 +20,12 @@ use fbuild_core::{FbuildError, Result};
 
 /// The zccache release fbuild pins. Bump in lockstep with the floor that
 /// the rest of the toolchain expects.
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.3";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.4";
 
 /// GitHub release tag for [`MANAGED_ZCCACHE_VERSION`]. The zccache release
 /// workflow tags without a `v` prefix, while the per-asset filenames carry
 /// `v<version>` — keep both spellings in sync when bumping.
-const RELEASE_TAG: &str = "1.12.3";
+const RELEASE_TAG: &str = "1.12.4";
 
 /// Source repository for managed downloads.
 const REPO: &str = "zackees/zccache";

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -908,9 +908,10 @@ pub async fn deploy(
         )
         .await
         {
-            MonitorOutcome::RecoverDownloadMode { signal } => MonitorOutcome::Error(
-                format!("internal: RecoverDownloadMode without opt-in ({})", signal.diagnostic()),
-            ),
+            MonitorOutcome::RecoverDownloadMode { signal } => MonitorOutcome::Error(format!(
+                "internal: RecoverDownloadMode without opt-in ({})",
+                signal.diagnostic()
+            )),
             other => other,
         };
 


### PR DESCRIPTION
## Summary

Bumps `MANAGED_ZCCACHE_VERSION` and `RELEASE_TAG` from 1.12.3 to [1.12.4](https://github.com/zackees/zccache/releases/tag/1.12.4).

## Changes in zccache 1.12.4 (since 1.12.3)

- feat(daemon): auto-install ServiceDefinition at startup ([#720](https://github.com/zackees/zccache/issues/720))
- feat(cli): add `zccache cache list` subcommand ([#695](https://github.com/zackees/zccache/issues/695))
- feat(cli): add `zccache release-handles --path X` ([#694](https://github.com/zackees/zccache/issues/694))
- feat(cli): add `zccache cache size` subcommand ([#695](https://github.com/zackees/zccache/issues/695))
- refactor(wire_frame): port FrameV1 encode/decode onto running-process backend_sdk codecs ([#718](https://github.com/zackees/zccache/issues/718))
- docs(wire): add wire-stability commitment + CI guard ([#693](https://github.com/zackees/zccache/issues/693))
- test(daemon): synthetic spawn-storm reproducer for [#691](https://github.com/zackees/zccache/issues/691)

No wire-breaking changes.

## Test plan

- [ ] CI green (managed_zccache download path fetches new release archive + SHA256SUMS at runtime; no hard-coded SHAs to update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)