### PR TITLE
feat(build): default extra_scripts backend to lite-SCons (#553 step 3)

### DIFF
--- a/crates/fbuild-build/README.md
+++ b/crates/fbuild-build/README.md
@@ -15,40 +15,61 @@ Build orchestration, compilation, linking for all platforms (AVR, ESP32, RP2040,
 
 ## Native `extra_scripts` Boundary
 
-Native mode intentionally supports only a narrow subset of PlatformIO `extra_scripts`.
-The goal is to preserve ordinary flag and path mutations without trying to emulate all of SCons.
+fbuild evaluates PlatformIO `extra_scripts` in a Python subprocess sidecar. As of [#553](https://github.com/FastLED/fbuild/issues/553) step 3, two backends coexist:
 
-Supported in native mode:
+| Backend | When it runs | What it covers |
+|---|---|---|
+| **lite-SCons** (`lite_scons_harness.py`) — **default** | `FBUILD_LITE_SCONS` unset, or any value other than `0`/`false`/`no`/`off` | Everything MockEnv covered + effectful `env.Execute(...)`, `env.AddPreAction`/`AddPostAction`, `env.AddBuildMiddleware`, `env.AddCustomTarget`, recursive `env.SConscript`, `env.AddMethod`, `env.ParseFlagsExtended` (both `-Ipath` and `-I path`) |
+| **MockEnv** (`script_runtime_harness.py`) — legacy | `FBUILD_LITE_SCONS=0` / `false` / `no` / `off` | The pre-#553 surface: flag/path mutations only, with hard-fail on `Execute` / `SConscript` / middleware |
+
+The lite backend is a functional superset of MockEnv: every script that worked under MockEnv continues to work, and four additional clusters of scripts (generator scripts, Marlin-class middleware, OTA `merge_bin` post-actions, recursive `SConscript` chains) now native-build instead of falling back to `--platformio`.
+
+MockEnv is on the retirement track defined in the [#553 plan](https://github.com/FastLED/fbuild/issues/553); step 4 will delete it. Until then `FBUILD_LITE_SCONS=0` is the emergency opt-out if the lite backend ever produces a wrong overlay for a real-world project.
+
+### Lite-SCons-only primitives
+
+These are what the lite backend adds on top of MockEnv:
+
+- `env.Execute(env.Action(callable_or_cmd))` — the callable runs in the same subprocess (PlatformIO's working directory), command-strings run via shell with `env.subst` applied first. Generated files materialise on disk and surface in the `lite_scons_records.generated_files` manifest fbuild reads on the Rust side.
+- `env.AddPreAction(target, action)` / `env.AddPostAction(target, action)` — recorded with the **unresolved** target template (e.g. `$BUILD_DIR/$PROGNAME$PROGSUFFIX`) so fbuild can `subst` it at deploy time when the values are known.
+- `env.AddBuildMiddleware(callback, regex=None)` — recorded with the callback name and glob; fbuild's native compile pipeline can invoke it per matching source.
+- `env.AddCustomTarget(name, dependencies=None, actions=None, ...)` — recorded as a custom target.
+- `env.SConscript("child.py", exports=None)` — recursively execs the child against the same env. Paths resolve relative to the calling script's directory (matching real SCons), not the project root.
+- `env.AddMethod(callable, name=None)` — installs as `env.<name>(...)` for script-defined helpers.
+- `env.ParseFlagsExtended("-Ipath -I sep/inc -DK=V -lname -Wl,…")` — routes tokens into the right scopes; handles both joined (`-Ipath`) and space-separated (`-I path`) forms for `-I`/`-L`/`-l`.
+
+### Always-supported (both backends)
 
 - `pre:` and `post:` script entries
-- `Import("env")` in PRE/POST scripts
-- `Import("projenv")` in POST scripts only
-- `from SCons.Script import DefaultEnvironment` followed by `DefaultEnvironment()` (returns the same mock env as `Import("env")`)
+- `Import("env")` in PRE/POST scripts; `Import("projenv")` in POST scripts only
+- `from SCons.Script import DefaultEnvironment` followed by `DefaultEnvironment()`
 - `Append`, `AppendUnique`, `Prepend`, and `Replace` over `CPPDEFINES`, `CPPPATH`, `CCFLAGS`, `CFLAGS`, `CXXFLAGS`, `ASFLAGS`, `LINKFLAGS`, `LIBPATH`, and `LIBS`
-- `BUILD_FLAGS` (PlatformIO's aggregate compile-flag list) — mutations fold into the common compile flags on export
+- `BUILD_FLAGS` mutations fold into the common compile flags on export
 - tuple-shaped `CPPDEFINES` appended in place (`env["CPPDEFINES"].append(("NAME", value))`) export as `-DNAME=value`
 - project introspection: `GetBuildType`, `GetProjectOptions`, `GetProjectOption`, and `env.get(key, default)` (falls through env vars → project options → default)
-- helper shims such as `Dump`, `BoardConfig`, `PioPlatform`, `Flatten`, `VerboseAction`, and `Execute`
-- non-flag tool/output scopes (e.g. `MKSPIFFSTOOL`, `PROGNAME`, `UPLOAD_PROTOCOL`) are **recorded as notes** rather than failing, so tool-path scripts no longer abort the native build
+- helper shims: `Dump`, `BoardConfig`, `PioPlatform`, `Flatten`, `VerboseAction`
+- non-flag tool/output scopes (e.g. `MKSPIFFSTOOL`, `PROGNAME`, `UPLOAD_PROTOCOL`) — recorded; tool-path scripts don't abort the native build
 
-Rejected or out of scope:
+### Architectural boundaries (neither backend crosses these)
 
-- unsupported script prefixes
-- PRE scripts that request `projenv`
-- mutations on genuinely unknown SCons scopes (anything outside the supported flag scopes and the known-ignored tool scopes)
-- unsupported `Import(...)` targets
-- builders, middleware, upload/package hooks, and other arbitrary Python-driven build behavior
+Three categories deliberately fall through to `--platformio`:
 
-Unsupported `extra_scripts` behavior fails the native build early with a recommendation to use `--platformio`.
+1. **Real DAG / incremental rebuilds.** Both backends do a single-pass resolve-then-return. Generated sources must be regenerated each clean build.
+2. **Scanner-driven header dep discovery.** fbuild has its own `fbuild-header-scan`; neither harness replicates SCons `CScanner`.
+3. **PlatformIO-defined chip-family builders** (`env.MergeFlashImage` for ESP32, `env.PackageJsonFirmware` for OTA, etc.) — lite-SCons records these as `builder_calls` entries; fbuild maps known names to native `fbuild-deploy` ops, otherwise fails fast with a targeted "needs `--platformio` for builder X" message.
 
-### Structural limitations of the mock
+### MockEnv-only failure modes (legacy backend)
 
-The shim runs scripts against a mock SCons `env`; it does **not** run real SCons. As a result:
+These are why MockEnv is being retired. The lite backend covers all four:
 
-1. **Mock scopes start empty.** The mock does not seed `CCFLAGS`/`LINKFLAGS`/etc. with the platform's existing flags. Scripts that read-transform-and-rewrite (e.g. remove a flag the toolchain injected) see an empty list, so removals are no-ops.
-2. **No real SCons graph.** Builders, node dependencies, and the SConscript hierarchy do not exist; `SConscript(...)` bails to `--platformio`.
-3. **Effectful `Execute` is a no-op.** `env.Execute(...)` / `VerboseAction` do not run external commands — they are recorded as notes. Scripts that generate headers or download artifacts at build time will not have those side effects.
-4. **`build_flags = !python ...` stdout-capture pattern is out of scope.** Only `extra_scripts` entries are interpreted, not flag-emitting shell substitutions in `build_flags`.
+- `env.Execute(...)` is a no-op — generator scripts that should produce headers at build time silently don't.
+- `env.SConscript(...)` hard-fails — recursive build fragments can't compose.
+- `env.AddBuildMiddleware(...)` hard-fails — Marlin-class per-source flag tweaks have no path through.
+- `env.AddPostAction(...)` is recorded as a note but never fires — OTA `merge_bin` style packagers don't run.
+
+### `build_flags = !python ...` stdout-capture pattern
+
+Out of scope for both backends — only `extra_scripts` entries are interpreted.
 
 ## Compile Database (compile_commands.json)
 

--- a/crates/fbuild-build/src/script_runtime.rs
+++ b/crates/fbuild-build/src/script_runtime.rs
@@ -1,9 +1,29 @@
-//! Native compatibility layer for a constrained subset of PlatformIO `extra_scripts`.
+//! Native compatibility layer for PlatformIO `extra_scripts`.
 //!
-//! Supported shapes are intentionally narrow: `pre:`/`post:` entries, `Import("env")`
-//! in PRE/POST scripts, `Import("projenv")` in POST scripts only, and flag/path
-//! mutations over the known compiler/linker scopes. Unsupported behavior fails fast
-//! with a recommendation to use `--platformio`.
+//! Two harness backends ship side-by-side:
+//!
+//! * **lite-SCons** (`lite_scons_harness.py`) — the **default** as of #553
+//!   step 3. Covers effectful `Execute`, `AddPreAction`/`AddPostAction`,
+//!   `AddBuildMiddleware`, `SConscript` recursion, `ParseFlagsExtended`
+//!   (joined + space forms), `AddCustomTarget`, `AddMethod`, and the read-
+//!   only `BoardConfig`/`PioPlatform`/`GetProjectConfig`/`GetBuildType`
+//!   helpers — plus everything MockEnv handled.
+//! * **MockEnv** (`script_runtime_harness.py`) — the legacy shim, available
+//!   as the emergency opt-out via `FBUILD_LITE_SCONS=0` / `false` / `no` /
+//!   `off`. Tracks an explicit retirement schedule per the
+//!   [#553 retirement plan](https://github.com/FastLED/fbuild/issues/553).
+//!
+//! The default backend selection is governed by [`use_lite_scons`]; callers
+//! that need deterministic pinning (e.g. unit tests across the parallel
+//! runner) use [`resolve_extra_script_overlay_with_mode`] directly. Both
+//! harnesses produce the same flag-scope contract on the output side, plus
+//! the lite path optionally emits `lite_scons_records` for the effectful /
+//! deferred ops MockEnv can't model.
+//!
+//! Anything that neither backend can model (real DAG / incremental
+//! rebuilds, scanner-driven dep discovery, PlatformIO-defined chip-family
+//! builders without a native fbuild equivalent) falls through to the
+//! `--platformio` passthrough.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -21,14 +41,24 @@ const HARNESS: &str = include_str!("script_runtime_harness.py");
 /// `SConscript` recursion, and `ParseFlagsExtended` (joined + space forms).
 const LITE_HARNESS: &str = include_str!("lite_scons_harness.py");
 
-/// Returns `true` when the FBUILD_LITE_SCONS env var requests the lite
-/// harness instead of MockEnv. Accepts `"1"`, `"true"`, `"yes"` (case
-/// insensitive). Anything else — including unset — keeps the legacy
-/// MockEnv behaviour the existing call sites depend on.
-fn lite_scons_requested() -> bool {
-    matches!(
-        std::env::var("FBUILD_LITE_SCONS").as_deref().map(str::trim),
-        Ok("1" | "true" | "TRUE" | "True" | "yes" | "YES")
+/// Returns `true` when the lite-SCons harness should be used (the
+/// post-#553-step-3 **default**), `false` only when `FBUILD_LITE_SCONS`
+/// explicitly opts out to the legacy MockEnv shim.
+///
+/// Opt-out values (case-insensitive, leading/trailing whitespace
+/// tolerated): `"0"`, `"false"`, `"no"`, `"off"`. Anything else —
+/// including unset, empty, the legacy opt-in values `"1"`/`"true"`,
+/// or unrecognised text — keeps the lite-SCons default. This makes the
+/// opt-in→opt-out semantics symmetric and means `FBUILD_LITE_SCONS=1`
+/// remains a valid (now redundant) request for the lite path during
+/// the migration window.
+fn use_lite_scons() -> bool {
+    let Ok(raw) = std::env::var("FBUILD_LITE_SCONS") else {
+        return true; // unset → default lite
+    };
+    !matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
     )
 }
 
@@ -48,7 +78,7 @@ pub fn resolve_extra_script_overlay(
     env_name: &str,
     config: &fbuild_config::PlatformIOConfig,
 ) -> fbuild_core::Result<BuildOverlay> {
-    resolve_extra_script_overlay_with_mode(project_dir, env_name, config, lite_scons_requested())
+    resolve_extra_script_overlay_with_mode(project_dir, env_name, config, use_lite_scons())
 }
 
 /// Same as [`resolve_extra_script_overlay`], but with the harness choice

--- a/crates/fbuild-build/src/script_runtime_tests.rs
+++ b/crates/fbuild-build/src/script_runtime_tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use crate::flag_overlay::ScriptScopeState;
 use std::fs;
@@ -31,7 +30,10 @@ extra_scripts = {}
 fn resolve_runtime_error(project_dir: &Path) -> String {
     let config =
         fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini")).unwrap();
-    resolve_extra_script_overlay(project_dir, "demo", &config)
+    // Pin to MockEnv (FBUILD_LITE_SCONS off) — these tests assert on
+    // MockEnv's hard-fail semantics (Execute / SConscript / unsupported
+    // scopes) that the lite-SCons default (#553 step 3) diverges from.
+    resolve_extra_script_overlay_with_mode(project_dir, "demo", &config, false)
         .unwrap_err()
         .to_string()
 }
@@ -158,7 +160,9 @@ env.Append(CPPDEFINES=[\"DUMP_SHIM_OK\"])
 
     let config =
         fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini")).unwrap();
-    let overlay = resolve_extra_script_overlay(project_dir, "demo", &config).unwrap();
+    // Pinned to MockEnv (see resolve_runtime_overlay note).
+    let overlay =
+        resolve_extra_script_overlay_with_mode(project_dir, "demo", &config, false).unwrap();
     assert!(overlay
         .global_compile
         .common
@@ -203,7 +207,9 @@ env.Append(CPPDEFINES=[\"HELPERS_SHIM_OK\"])
 
     let config =
         fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini")).unwrap();
-    let overlay = resolve_extra_script_overlay(project_dir, "demo", &config).unwrap();
+    // Pinned to MockEnv (see resolve_runtime_overlay note).
+    let overlay =
+        resolve_extra_script_overlay_with_mode(project_dir, "demo", &config, false).unwrap();
     assert!(overlay
         .global_compile
         .common
@@ -245,7 +251,9 @@ env.Append(CPPDEFINES=[\"BOARD_CONFIG_SHIM_OK\"])
 
     let config =
         fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini")).unwrap();
-    let overlay = resolve_extra_script_overlay(project_dir, "demo", &config).unwrap();
+    // Pinned to MockEnv (see resolve_runtime_overlay note).
+    let overlay =
+        resolve_extra_script_overlay_with_mode(project_dir, "demo", &config, false).unwrap();
     assert!(overlay
         .global_compile
         .common
@@ -290,7 +298,9 @@ env.Append(CPPDEFINES=[\"PIO_PLATFORM_SHIM_OK\"])
 
     let config =
         fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini")).unwrap();
-    let overlay = resolve_extra_script_overlay(project_dir, "demo", &config).unwrap();
+    // Pinned to MockEnv (see resolve_runtime_overlay note).
+    let overlay =
+        resolve_extra_script_overlay_with_mode(project_dir, "demo", &config, false).unwrap();
     assert!(overlay
         .global_compile
         .common
@@ -409,7 +419,8 @@ framework = arduino
 fn resolve_runtime_overlay(project_dir: &Path) -> BuildOverlay {
     let config =
         fbuild_config::PlatformIOConfig::from_path(&project_dir.join("platformio.ini")).unwrap();
-    resolve_extra_script_overlay(project_dir, "demo", &config).unwrap()
+    // Pinned to MockEnv (see resolve_runtime_error note above).
+    resolve_extra_script_overlay_with_mode(project_dir, "demo", &config, false).unwrap()
 }
 
 // ---- SIMPLE tier ------------------------------------------------------
@@ -627,4 +638,43 @@ env.SConscript(\"feature.py\", exports=\"env\")
     let err = resolve_runtime_error(temp.path());
     assert!(err.contains("SConscript is not supported"), "{err}");
     assert!(err.contains("Recommendation: use --platformio"), "{err}");
+}
+
+/// Locks down the post-#553-step-3 flip. The env var name + opt-out
+/// vocabulary is the user-facing contract; the lite-vs-MockEnv default
+/// is the semantic change. Don't rely on the rest of the test suite
+/// to catch a future regression on either dimension — that suite
+/// pins through `_with_mode(..., false)` and won't notice if the
+/// default silently reverts.
+#[test]
+fn use_lite_scons_default_and_opt_out_vocabulary() {
+    use std::sync::Mutex;
+    // env vars are process-global; serialise just this one test.
+    static GUARD: Mutex<()> = Mutex::new(());
+    let _g = GUARD.lock().unwrap();
+    let prev = std::env::var("FBUILD_LITE_SCONS").ok();
+
+    std::env::remove_var("FBUILD_LITE_SCONS");
+    assert!(use_lite_scons(), "unset → default lite (#553 step 3 flip)");
+
+    for opt_in_or_unrecognised in ["", "1", "true", "yes", "wat"] {
+        std::env::set_var("FBUILD_LITE_SCONS", opt_in_or_unrecognised);
+        assert!(
+            use_lite_scons(),
+            "FBUILD_LITE_SCONS={opt_in_or_unrecognised:?} keeps the lite default"
+        );
+    }
+
+    for opt_out in ["0", "false", "FALSE", "no", "Off", "  0  "] {
+        std::env::set_var("FBUILD_LITE_SCONS", opt_out);
+        assert!(
+            !use_lite_scons(),
+            "FBUILD_LITE_SCONS={opt_out:?} opts out to legacy MockEnv"
+        );
+    }
+
+    match prev {
+        Some(v) => std::env::set_var("FBUILD_LITE_SCONS", v),
+        None => std::env::remove_var("FBUILD_LITE_SCONS"),
+    }
 }


### PR DESCRIPTION
## Summary

Step 3 of the [#553 retirement plan](https://github.com/FastLED/fbuild/issues/553#issuecomment-4702780584): flips the default `extra_scripts` backend from the legacy MockEnv shim to the lite-SCons harness that shipped in #581. MockEnv stays available as the emergency opt-out via `FBUILD_LITE_SCONS=0` until #553 step 4 retires it for good.

> **Stacked on #581** — the base branch is `feat/lite-scons-harness-553` rather than `main`. Rebase to `main` once #581 merges.

## Semantic change

| Before | After |
|---|---|
| `FBUILD_LITE_SCONS=1` opted INTO lite-SCons; default was MockEnv | `FBUILD_LITE_SCONS=0` opts OUT of lite-SCons; default is lite |

Recognised opt-out values (case-insensitive, whitespace-tolerant): `0`, `false`, `no`, `off`. Anything else — unset, empty, `1`/`true`/`yes`, or unrecognised — keeps the lite default. So `FBUILD_LITE_SCONS=1` is still valid (just redundant) during the migration window.

## Rationale

The lite harness is a functional superset of MockEnv:
- Every MockEnv method works identically
- PLUS effectful `Execute`, `AddPreAction` / `AddPostAction`, `AddBuildMiddleware`, recursive `SConscript`, `AddCustomTarget`, `AddMethod`, `ParseFlagsExtended` (joined + space forms)
- PLUS the three bugs the spike caught and fixed (`env.get` → `project_options` fallthrough, `ParseFlagsExtended` space-form, `SConscript` caller-relative path resolution)

The three architectural boundaries lite-SCons deliberately keeps (real DAG / incremental rebuilds, scanner-driven dep discovery, PlatformIO-defined chip-family builders) MockEnv had no chance of crossing either. Anything in those categories still falls through to `--platformio`.

## Changes

- **`use_lite_scons()`** (renamed from `lite_scons_requested`) — returns `true` on unset / empty / unrecognised / `1`/`true`/`yes`; only `false` for explicit opt-out values.
- **Module docstring** — rewritten to reflect "lite-SCons by default, MockEnv via FBUILD_LITE_SCONS=0" plus the #553 retirement plan.
- **`crates/fbuild-build/README.md`** "Native extra_scripts Boundary" section — fully rewritten with the lite-vs-MockEnv comparison table, lite-only primitives, always-supported (both backends), architectural boundaries, MockEnv-only failure modes.
- **Existing MockEnv-targeted tests pinned via `_with_mode(..., false)`** — the two test helpers (`resolve_runtime_overlay`, `resolve_runtime_error`) plus four direct call sites now route through the explicit-MockEnv entry point so they keep covering the legacy code path until #553 step 4. The `lite_scons_acceptance.rs` integration tests already pin to lite and stay unchanged.
- **New unit test `use_lite_scons_default_and_opt_out_vocabulary`** — locks down the env var contract. Serialised via a static `Mutex` (env vars are process-global) and walks unset/empty + the five opt-in/recognised values + six opt-out spellings.

## Why pin the existing tests instead of rewriting?

The existing 705+ tests under `#[cfg(test)] mod tests` were written against MockEnv's hard-fail semantics — many of them explicitly assert that `Execute` / `SConscript` / `AddBuildMiddleware` produce a "not supported" error. Those tests stay load-bearing as long as MockEnv exists as the opt-out: they document what *would* happen if a user opts out. Step 4 (MockEnv retirement) will delete them and we'll port their setups to lite-SCons assertions where the behaviour differs meaningfully.

## Verification

- [x] `soldr cargo check --workspace --all-targets` — clean
- [x] `soldr cargo clippy -p fbuild-build --all-targets` — clean
- [x] `soldr cargo test -p fbuild-build --lib` — 710/710 pass (709 existing + 1 new vocabulary test)
- [x] `soldr cargo test -p fbuild-build --test lite_scons_acceptance` — 5/5 pass

Refs #553
