### PR TITLE
fix(ci): list 3 more LPC8xx variants as fbuild-native (#456 item 3.8)

### DIFF
--- a/ci/validate_boards.py
+++ b/ci/validate_boards.py
@@ -67,9 +67,20 @@ FBUILD_NATIVE_BOARDS = frozenset(
     {
         # NXP LPC8xx bare-metal targets. PlatformIO's `nxplpc` platform
         # ships lpc11u68 / lpc1768 / lpc54114 / lpc546xx / lpcxpresso55s16
-        # / seeedArchPro, but not these two — they are fbuild-only.
+        # / seeedArchPro, but not these five — they are fbuild-only.
+        # The bare MCU ids (`lpc845`, `lpc804`) plus the three Arduino-style
+        # board variants ship under the vendored ArduinoCore-LPC8xx framework
+        # (FastLED/fbuild#456 item 3.8, #479, #487). Without listing the
+        # variants here, validate_boards.py silently skips them via the
+        # "platform not installed" code path (find_pio_board → None) even
+        # though the platform IS installed — the board just doesn't exist
+        # upstream. Listing them surfaces them in the fbuild-native tally
+        # and keeps future drift from being silently masked.
         "lpc845",
         "lpc804",
+        "lpc845brk",
+        "lpcxpresso804",
+        "lpcxpresso845max",
     }
 )
 


### PR DESCRIPTION
Closes #456 (item 3.8).

## Summary

- The status survey on #456 declared the \`validate_boards.py\` reconciliation done, but \`FBUILD_NATIVE_BOARDS\` only listed the bare MCU ids (\`lpc845\`, \`lpc804\`). The three Arduino-style variants that ship under the vendored ArduinoCore-LPC8xx framework (#479 / #487) — \`lpc845brk\`, \`lpcxpresso804\`, \`lpcxpresso845max\` — were silently falling into the "platform not installed, skip" branch of \`validate_board()\` via \`find_pio_board → None\`. That masked the fact that they have no PlatformIO upstream at all and would have hidden any future drift in their JSON definitions.
- Listing them in \`FBUILD_NATIVE_BOARDS\` surfaces them in the fbuild-native tally (2 → 5) and keeps the silent-skip path from masking drift.

## Verification

\`uv run python ci/validate_boards.py\` now reports:

\`\`\`
Results: 1640 total, 1519 checked, 1269 passed, 250 failed, 116 skipped, 5 fbuild-native
  fbuild-native (intentional skip, no PlatformIO upstream — see FastLED/FastLED#2845):
    lpc804, lpc845, lpc845brk, lpcxpresso804, lpcxpresso845max
\`\`\`

(The 250 unrelated failures are pre-existing drift on main, out of scope for this change.)

## Why the status survey missed it

Cross-checked the three variants with \`uv run python ci/board_sources.py --search\` — all three return \`[fbuild]\` only with zero Arduino / Zephyr / PlatformIO matches, so they are unambiguously fbuild-native. The previous reconciliation captured the MCU ids but not the board-variant ids; this PR closes that gap.

## Refs

- #456 — Meta: LPC port completion (Stage 3 item 3.8)
- FastLED/FastLED#2845 — original cross-repo roadmap
- #479 / #487 — ArduinoCore-LPC8xx vendoring (the work that introduced the three variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)