### PR TITLE
chore(release): bump Cargo.toml workspace version 2.2.27 -> 2.2.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "async-trait",
  "blake3",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "blake3",
  "clap",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "libc",
  "running-process",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "async-trait",
  "axum",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "criterion",
  "rayon",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "bincode",
  "blake3",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "axum",
  "bzip2",
@@ -1116,14 +1116,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "async-trait",
  "base64",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.27"
+version = "2.2.28"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.27"
+version = "2.2.28"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Unjam the Autonomous Release pipeline. PR #572 (managed-zccache) bumped \`pyproject.toml\` from 2.2.27 → 2.2.28 but did not touch \`Cargo.toml\`'s \`[workspace.package].version\`. The \`release-auto.yml\` workflow hard-requires both to match in its preflight, and has been exit-1'ing on every push to main since 2026-06-13T22:04:22Z with:

\`\`\`
Cargo.toml version (2.2.27) does not match pyproject.toml version (2.2.28)
\`\`\`

## Why now

13 PRs of unreleased fixes are stacked behind that mismatch. Most visibly, the **LPC845 F_CPU correction (PR #568)** — main now correctly ships \`f_cpu = 24 MHz\` for \`lpc845\` / \`lpc845brk\` / \`lpcxpresso845max\` (via the FRO-direct SystemInit), but the latest PyPI wheel (\`v2.2.27\`) still ships \`f_cpu = 30 MHz\` which is wrong on the real silicon. LPC AutoResearch and driver development can't use a clean release wheel until v2.2.28 ships.

Other unreleased delta (highlights): #569 libc init, #570 ArduinoCore vendoring, #573 managed-zccache HTTP timeouts, #576 nxplpc RELEASE defines + ACLPC#29 pin bump, #577 + #580 ESP32 ROM-download-mode hard-reset recovery (#532), #581 / #583 / #585 lite-SCons retire-MockEnv (#553), #588 nxplpc build_flags propagation (#587), #589 validate_boards reconcile (#456).

## Diff

\`\`\`
Cargo.toml     1 line  (workspace.package.version 2.2.27 -> 2.2.28)
Cargo.lock    14 internal-crate version lines (regenerated by \`cargo check\`)
\`\`\`

No source code changes; the lock-file delta is just the workspace crates picking up the bumped version.

## After merge

The next push to main triggers \`release-auto.yml\`, the preflight passes, and v2.2.28 publishes to PyPI with the 13-PR backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.2.28

<!-- end of auto-generated comment: release notes by coderabbit.ai -->