### PR TITLE
feat(daemon): install running-process fbuild.servicedef on startup (#592 prerequisite)

### DIFF
--- a/crates/fbuild-daemon/src/broker/mod.rs
+++ b/crates/fbuild-daemon/src/broker/mod.rs
@@ -31,7 +31,9 @@ pub use protocol::{
     BrokerRequest, BrokerResponse, DaemonOp, FBUILD_PAYLOAD_PROTOCOL, FBUILD_PROTOCOL_VERSION,
 };
 pub use service::{
-    fbuild_cache_manifest, fbuild_ci_service_definition, fbuild_service_definition, ServiceError,
+    fbuild_cache_manifest, fbuild_ci_service_definition, fbuild_service_definition,
+    install_fbuild_service_definition, install_fbuild_service_definition_in,
+    publish_fbuild_cache_manifest, publish_fbuild_cache_manifest_in, ServiceError,
 };
 pub use session::{AdoptOutcome, BrokerError, FbuildBrokerSession};
 

--- a/crates/fbuild-daemon/src/main.rs
+++ b/crates/fbuild-daemon/src/main.rs
@@ -164,6 +164,36 @@ async fn main() {
         tracing::warn!("failed to write port file: {}", e);
     }
 
+    // Install the running-process `fbuild.servicedef` so the broker can
+    // discover this daemon binary in subsequent fbuild invocations. Without
+    // this file the broker stays in `Mode: direct-fallback` even after
+    // FastLED/fbuild#510 lands `connect_to_backend`. Best-effort: any
+    // failure (read-only AppData, sandbox, etc.) is logged but does not
+    // block daemon startup. See FastLED/fbuild#592.
+    match std::env::current_exe() {
+        Ok(this_exe) => {
+            let daemon_binary = this_exe
+                .parent()
+                .map(|d| d.join(fbuild_paths::running_process::DAEMON_BINARY_NAME))
+                .unwrap_or(this_exe);
+            match fbuild_daemon::broker::install_fbuild_service_definition(&daemon_binary) {
+                Ok(written) => tracing::info!(
+                    "installed running-process service definition: {}",
+                    written.display()
+                ),
+                Err(e) => tracing::warn!(
+                    "failed to install running-process service definition for {}: {}",
+                    daemon_binary.display(),
+                    e
+                ),
+            }
+        }
+        Err(e) => tracing::warn!(
+            "cannot resolve current_exe() for servicedef install: {}",
+            e
+        ),
+    }
+
     // On Windows, `tokio::signal::ctrl_c()` catches CTRL_C_EVENT and
     // CTRL_BREAK_EVENT but NOT CTRL_CLOSE_EVENT (terminal window closed),
     // CTRL_LOGOFF_EVENT, or CTRL_SHUTDOWN_EVENT. Without a console ctrl

--- a/crates/fbuild-daemon/src/main.rs
+++ b/crates/fbuild-daemon/src/main.rs
@@ -188,10 +188,7 @@ async fn main() {
                 ),
             }
         }
-        Err(e) => tracing::warn!(
-            "cannot resolve current_exe() for servicedef install: {}",
-            e
-        ),
+        Err(e) => tracing::warn!("cannot resolve current_exe() for servicedef install: {}", e),
     }
 
     // On Windows, `tokio::signal::ctrl_c()` catches CTRL_C_EVENT and


### PR DESCRIPTION
## Summary

- Daemon now writes `fbuild.servicedef` on startup using the existing `broker::install_fbuild_service_definition`. Without this, the servicedef file was never created and every fbuild invocation silently fell back to direct mode.
- Re-exports `install_fbuild_service_definition*` and `publish_fbuild_cache_manifest*` from `broker::mod` so other crates can drive provisioning without reaching into `service`.

## Why

`fbuild daemon running-process` reported:

```
Service definition:   ...\running-process\services\fbuild.servicedef
Selected path:        broker
Mode:                 direct-fallback
```

…but the servicedef path was a dead reference. The broker had no way to discover this daemon binary. This PR is the prerequisite for the broker work tracked in FastLED/fbuild#510 and #592.

`Mode:` will stay `direct-fallback` after this PR because the actual broker client (`connect_to_backend`) is still stubbed — `RunningProcessDaemonMode::uses_direct_fallback()` returns `true` unconditionally. That switch flips in a follow-up. **This PR removes the file-not-on-disk blocker; #510 wires the runtime path that consumes it.**

## How it's wired

In `fbuild-daemon/src/main.rs`, right after PID/port files are written:

```rust
match std::env::current_exe() {
    Ok(this_exe) => {
        let daemon_binary = this_exe
            .parent()
            .map(|d| d.join(fbuild_paths::running_process::DAEMON_BINARY_NAME))
            .unwrap_or(this_exe);
        match fbuild_daemon::broker::install_fbuild_service_definition(&daemon_binary) {
            Ok(written) => tracing::info!(...),
            Err(e)      => tracing::warn!(...),
        }
    }
    Err(e) => tracing::warn!(...),
}
```

Best-effort: any IO failure (read-only AppData, sandbox, etc.) is logged but does not block startup.

## Verification

Verified on Windows 10:

1. Delete `%APPDATA%\running-process\services\fbuild.servicedef`.
2. Trigger any daemon-bearing fbuild op (e.g. `fbuild device list`).
3. File reappears (211 bytes, contains the validated `SharedBroker` definition pointing at the live `fbuild-daemon.exe`).
4. `fbuild daemon running-process` now resolves `Service definition:` to a real file.

## Test plan

- [x] Workspace check on `fbuild-daemon` (zero warnings introduced)
- [x] Existing `install_and_validate_roundtrip_in_temp_dir` test in `broker/service.rs` continues to pass
- [x] Manual: clean Windows reproducer (delete servicedef -> trigger fbuild op -> servicedef re-appears)
- [ ] CI

## Follow-ups (out of scope for this PR)

- FastLED/fbuild#510 — actually flip `Mode: direct-fallback` -> `Mode: broker` by wiring `connect_to_backend`.
- FastLED/fbuild#592 §3 — singleton `PortSession` + WebSocket fan-out + grace-window close.
- FastLED/fbuild#592 §3.3 — USB disconnect / re-enumeration events.
- FastLED/fbuild#592 §4.2 — lease-attribution columns on `device list` / `device status`.

Refs: FastLED/fbuild#510, FastLED/fbuild#592

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The daemon now automatically attempts to install the service definition on startup, with detailed logging of success and any issues encountered. Installation failures do not prevent daemon startup.

* **Style**
  * Improved formatting of broker module's re-export declarations for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->