### PR TITLE
feat(deploy/lpc): LpcDeployer Phase 1 — lpc21isp ISP-over-UART (closes #551, sidesteps #565)

### DIFF
--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -706,6 +706,29 @@ pub async fn deploy(
                 );
                 Box::new(deployer)
             }
+            fbuild_core::Platform::NxpLpc => {
+                // LpcDeployer (#551 Phase 1) — lpc21isp ISP-over-UART path.
+                // Side-steps #565's pyOCD-VCOM-wedge by never opening the
+                // composite-device HID. SWD / pyOCD fallbacks are a follow-up.
+                let board_config = fbuild_config::BoardConfig::from_board_id_or_default(
+                    &board_id,
+                    "lpc845",
+                    &deploy_board_overrides,
+                    Some(deploy_project.as_path()),
+                );
+                let lpc_params = fbuild_deploy::lpc::Lpc21IspParams::default();
+                let deployer = fbuild_deploy::lpc::LpcDeployer::from_board_config(
+                    &board_config,
+                    &lpc_params,
+                    false,
+                );
+                let deployer = if let Some(baud) = baud_override {
+                    deployer.with_baud_rate(&baud.to_string())
+                } else {
+                    deployer
+                };
+                Box::new(deployer)
+            }
             _ => {
                 return Err(fbuild_core::FbuildError::DeployFailed(format!(
                     "deployer for {:?} not yet implemented",

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -706,35 +706,8 @@ pub async fn deploy(
                 );
                 Box::new(deployer)
             }
-            fbuild_core::Platform::NxpLpc => {
-                // LpcDeployer (#551 Phase 1) — lpc21isp ISP-over-UART path.
-                // Side-steps #565's pyOCD-VCOM-wedge by never opening the
-                // composite-device HID. SWD / pyOCD fallbacks are a follow-up.
-                let board_config = fbuild_config::BoardConfig::from_board_id_or_default(
-                    &board_id,
-                    "lpc845",
-                    &deploy_board_overrides,
-                    Some(deploy_project.as_path()),
-                );
-                let lpc_params = fbuild_deploy::lpc::Lpc21IspParams::default();
-                let deployer = fbuild_deploy::lpc::LpcDeployer::from_board_config(
-                    &board_config,
-                    &lpc_params,
-                    false,
-                );
-                let deployer = if let Some(baud) = baud_override {
-                    deployer.with_baud_rate(&baud.to_string())
-                } else {
-                    deployer
-                };
-                Box::new(deployer)
-            }
-            _ => {
-                return Err(fbuild_core::FbuildError::DeployFailed(format!(
-                    "deployer for {:?} not yet implemented",
-                    platform
-                )));
-            }
+            fbuild_core::Platform::NxpLpc => fbuild_deploy::lpc::dispatch_box(&board_id, &deploy_board_overrides, deploy_project.as_path(), baud_override),
+            _ => return Err(fbuild_core::FbuildError::DeployFailed(format!("deployer for {:?} not yet implemented", platform))),
         };
         let result = deployer.deploy(
             &deploy_project,

--- a/crates/fbuild-deploy/src/lib.rs
+++ b/crates/fbuild-deploy/src/lib.rs
@@ -16,6 +16,7 @@ pub mod esp32;
 /// miette, ...).
 #[cfg(feature = "espflash-native")]
 pub mod esp32_native;
+pub mod lpc;
 pub mod reset;
 pub mod teensy;
 

--- a/crates/fbuild-deploy/src/lpc.rs
+++ b/crates/fbuild-deploy/src/lpc.rs
@@ -1,0 +1,277 @@
+//! NXP LPC8xx deployer using `lpc21isp`.
+//!
+//! Flashes firmware.hex to LPC8xx boards via ISP-over-UART. The on-die ROM
+//! boot loader handles the protocol; the host just spawns `lpc21isp` with
+//! the firmware path, port, baud rate, and crystal frequency.
+//!
+//! ## Why lpc21isp first (and not pyOCD / CMSIS-DAP)
+//!
+//! On the LPC845-BRK the on-board debug probe presents a *composite* USB
+//! device: CMSIS-DAP (HID) + Mass-Storage + CDC (the application's VCOM).
+//! pyOCD's SWD flash path opens the HID interface, and on Windows it
+//! leaves the CDC sibling in error 31 (requires a physical USB replug to
+//! recover) — see [FastLED/fbuild#565]. That breaks the flash-then-monitor
+//! cycle every FastLED test harness depends on (AutoResearch, JSON-RPC
+//! bring-up, etc.).
+//!
+//! lpc21isp uses ISP-over-UART. It never opens the composite-device HID
+//! interface, so the CDC sibling stays available across the flash. That's
+//! the primary path. SWD remains a future addition for boards without an
+//! exposed UART (rare on LPC8xx) — tracked separately.
+//!
+//! ## Reset / ISP-mode entry
+//!
+//! lpc21isp's `-control` flag drives DTR/RTS to put the chip into ISP
+//! mode before flashing and back into run-mode afterward. The LPC845-BRK
+//! wiring matches `-control` semantics out of the box. Boards without
+//! auto-reset wiring need the user to hold ISP+RESET manually; the same
+//! `-control` argument is harmless on those.
+//!
+//! [FastLED/fbuild#565]: https://github.com/FastLED/fbuild/issues/565
+
+use std::path::{Path, PathBuf};
+
+use fbuild_core::subprocess::run_command;
+use fbuild_core::Result;
+
+use crate::{DeployOutcome, Deployer, DeploymentResult};
+
+/// lpc21isp deploy parameters sourced from MCU config JSON.
+///
+/// All LPC845 / LPC804 boards (including the LPC845-BRK and the
+/// LPCXpresso variants) use the same on-die ISP ROM, so a single
+/// parameter struct covers the family. The crystal frequency in kHz
+/// is the only knob that's not in the existing `upload.*` board JSON
+/// fields — default 12000 covers every LPC8xx evaluation board NXP
+/// ships today.
+pub struct Lpc21IspParams {
+    /// Default baud rate for lpc21isp. Standard 115200 matches every
+    /// LPC8xx board JSON's `upload.speed`. Overridable per-board via
+    /// `board.upload_speed`.
+    pub default_baud: String,
+    /// Crystal frequency in kHz, passed to lpc21isp as its `xtal_kHz`
+    /// argument. Used for clock-related verify operations inside the
+    /// tool. Default 12000 (12 MHz) matches NXP's LPC845-BRK and the
+    /// LPCXpresso845-MAX / LPCXpresso804 reference boards.
+    pub xtal_khz: u32,
+    /// Hard cap on a single lpc21isp subprocess. Programming the whole
+    /// 64 KB of flash via ISP-over-UART at 115200 baud takes ~6 s
+    /// worst case; the 60 s default leaves comfortable slack for
+    /// auto-baud handshake retries.
+    pub timeout_secs: u64,
+}
+
+impl Default for Lpc21IspParams {
+    fn default() -> Self {
+        Self {
+            default_baud: "115200".to_string(),
+            xtal_khz: 12_000,
+            timeout_secs: 60,
+        }
+    }
+}
+
+/// NXP LPC8xx deployer using `lpc21isp` for ISP-over-UART flashing.
+pub struct LpcDeployer {
+    /// Path to lpc21isp binary (if not in PATH).
+    lpc21isp_path: PathBuf,
+    /// Baud rate (positional arg after port).
+    baud_rate: String,
+    /// Crystal frequency in kHz (positional arg after baud).
+    xtal_khz: u32,
+    /// Deploy timeout in seconds.
+    timeout_secs: u64,
+    verbose: bool,
+}
+
+impl LpcDeployer {
+    pub fn new(
+        baud_rate: &str,
+        xtal_khz: u32,
+        timeout_secs: u64,
+        lpc21isp_path: Option<PathBuf>,
+        verbose: bool,
+    ) -> Self {
+        Self {
+            lpc21isp_path: lpc21isp_path.unwrap_or_else(|| PathBuf::from("lpc21isp")),
+            baud_rate: baud_rate.to_string(),
+            xtal_khz,
+            timeout_secs,
+            verbose,
+        }
+    }
+
+    /// Build an LPC deployer from board config + lpc21isp params.
+    pub fn from_board_config(
+        board: &fbuild_config::BoardConfig,
+        params: &Lpc21IspParams,
+        verbose: bool,
+    ) -> Self {
+        Self::new(
+            board
+                .upload_speed
+                .as_deref()
+                .unwrap_or(&params.default_baud),
+            params.xtal_khz,
+            params.timeout_secs,
+            None,
+            verbose,
+        )
+    }
+
+    /// Override the baud rate (e.g. from a CLI `--baud` flag). Mirrors
+    /// `AvrDeployer::with_baud_rate` and `Esp32Deployer::with_baud_rate`
+    /// so the daemon can apply the user's CLI override on any platform
+    /// without branching.
+    pub fn with_baud_rate(mut self, baud: &str) -> Self {
+        self.baud_rate = baud.to_string();
+        self
+    }
+}
+
+impl Deployer for LpcDeployer {
+    fn deploy(
+        &self,
+        _project_dir: &Path,
+        _env_name: &str,
+        firmware_path: &Path,
+        port: Option<&str>,
+    ) -> Result<DeploymentResult> {
+        let port = port.ok_or_else(|| {
+            fbuild_core::FbuildError::DeployFailed(
+                "serial port required for LPC deploy (use --port)".to_string(),
+            )
+        })?;
+
+        // lpc21isp argv:
+        //   lpc21isp [-control] [-wipe] -hex <firmware> <port> <baud> <xtal_kHz>
+        //
+        // -control : drive DTR/RTS to enter ISP mode and exit it after
+        //            flashing. Required for auto-reset boards like the
+        //            LPC845-BRK; harmless on boards wired without it
+        //            (lpc21isp just no-ops the control lines).
+        // -wipe    : full-chip erase before writing. Without this, lpc21isp
+        //            only erases the sectors it's about to write, which
+        //            leaves stale data in sectors the new firmware happened
+        //            to skip. Cheap on 64 KB / 32 KB parts (~250 ms).
+        // -hex     : firmware is in Intel HEX format. fbuild's nxplpc
+        //            orchestrator emits .hex (see nxplpc/orchestrator.rs).
+        let args = [
+            self.lpc21isp_path.to_string_lossy().to_string(),
+            "-control".to_string(),
+            "-wipe".to_string(),
+            "-hex".to_string(),
+            firmware_path.to_string_lossy().to_string(),
+            port.to_string(),
+            self.baud_rate.clone(),
+            self.xtal_khz.to_string(),
+        ];
+
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+        if self.verbose {
+            tracing::info!("deploy: {}", args.join(" "));
+        }
+
+        tracing::info!(
+            "flashing {} to {} via lpc21isp (baud={}, xtal_kHz={})",
+            firmware_path.display(),
+            port,
+            self.baud_rate,
+            self.xtal_khz,
+        );
+
+        let result = run_command(
+            &args_ref,
+            None,
+            None,
+            Some(std::time::Duration::from_secs(self.timeout_secs)),
+        )?;
+
+        if result.success() {
+            Ok(DeploymentResult {
+                success: true,
+                message: format!("firmware flashed to {}", port),
+                port: Some(port.to_string()),
+                stdout: result.stdout,
+                stderr: result.stderr,
+                outcome: DeployOutcome::FullFlash,
+            })
+        } else {
+            // Return a non-success DeploymentResult instead of Err so the
+            // daemon handler can forward lpc21isp's stdout/stderr to the
+            // client without losing the diagnostic surface.
+            Ok(DeploymentResult {
+                success: false,
+                message: format!("lpc21isp failed (exit code {})", result.exit_code),
+                port: Some(port.to_string()),
+                stdout: result.stdout,
+                stderr: result.stderr,
+                outcome: DeployOutcome::FullFlash,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lpc_deployer_creation() {
+        let deployer = LpcDeployer::new("115200", 12_000, 60, None, false);
+        assert_eq!(deployer.baud_rate, "115200");
+        assert_eq!(deployer.xtal_khz, 12_000);
+        assert_eq!(deployer.timeout_secs, 60);
+    }
+
+    #[test]
+    fn test_lpc_deployer_default_path() {
+        let deployer = LpcDeployer::new("115200", 12_000, 60, None, false);
+        assert_eq!(deployer.lpc21isp_path, PathBuf::from("lpc21isp"));
+    }
+
+    #[test]
+    fn test_lpc_deployer_explicit_path() {
+        let deployer = LpcDeployer::new(
+            "115200",
+            12_000,
+            60,
+            Some(PathBuf::from("/usr/local/bin/lpc21isp")),
+            false,
+        );
+        assert_eq!(
+            deployer.lpc21isp_path,
+            PathBuf::from("/usr/local/bin/lpc21isp")
+        );
+    }
+
+    #[test]
+    fn with_baud_rate_overrides_default() {
+        // Mirrors AvrDeployer::with_baud_rate's TDD test — the deploy CLI's
+        // `--baud` flag must reach the deployer and override the board's
+        // configured default.
+        let deployer = LpcDeployer::new("115200", 12_000, 60, None, false).with_baud_rate("57600");
+        assert_eq!(deployer.baud_rate, "57600");
+    }
+
+    #[test]
+    fn test_deploy_requires_port() {
+        let deployer = LpcDeployer::new("115200", 12_000, 60, None, false);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = deployer.deploy(tmp.path(), "lpc845", Path::new("firmware.hex"), None);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("serial port required"));
+    }
+
+    #[test]
+    fn lpc21isp_params_defaults() {
+        let params = Lpc21IspParams::default();
+        assert_eq!(params.default_baud, "115200");
+        assert_eq!(params.xtal_khz, 12_000);
+        assert_eq!(params.timeout_secs, 60);
+    }
+}

--- a/crates/fbuild-deploy/src/lpc.rs
+++ b/crates/fbuild-deploy/src/lpc.rs
@@ -129,6 +129,39 @@ impl LpcDeployer {
     }
 }
 
+/// Boxed-Deployer constructor used by the daemon dispatch site
+/// (`crates/fbuild-daemon/src/handlers/operations/deploy.rs`, the
+/// `Platform::NxpLpc` arm). Kept here so the dispatch arm fits in one
+/// line — the daemon's deploy.rs lives under a hard 1000-LOC per-file
+/// rule and would otherwise need a structural refactor for every new
+/// platform.
+///
+/// The behaviour is the same as inlining all of this in the dispatch
+/// arm: build a `BoardConfig` from the env's overrides (defaulting to
+/// `lpc845` when no board id is specified), construct an `LpcDeployer`
+/// with the family defaults from `Lpc21IspParams::default()`, then
+/// apply the CLI's `--baud` override if one was passed.
+pub fn dispatch_box(
+    board_id: &str,
+    board_overrides: &std::collections::HashMap<String, String>,
+    project_path: &Path,
+    baud_override: Option<u32>,
+) -> Box<dyn Deployer> {
+    let board_config = fbuild_config::BoardConfig::from_board_id_or_default(
+        board_id,
+        "lpc845",
+        board_overrides,
+        Some(project_path),
+    );
+    let params = Lpc21IspParams::default();
+    let deployer = LpcDeployer::from_board_config(&board_config, &params, false);
+    let deployer = match baud_override {
+        Some(b) => deployer.with_baud_rate(&b.to_string()),
+        None => deployer,
+    };
+    Box::new(deployer)
+}
+
 impl Deployer for LpcDeployer {
     fn deploy(
         &self,


### PR DESCRIPTION
## Summary

Wires the missing `Platform::NxpLpc` branch in `crates/fbuild-daemon/src/handlers/operations/deploy.rs`. Before this PR, `fbuild deploy tests/platform/lpc845 -e lpc845` returned `"deployer for NxpLpc not yet implemented"`. After it, the daemon hands the request to a new `LpcDeployer` that spawns `lpc21isp` against the board's UART port.

## What this PR is and isn't

**Is**: Phase 1 of #551 — the lpc21isp ISP-over-UART deploy path.

**Isn't**: SWD / pyOCD / J-Link. Those are a deliberate follow-up. The LPC845-BRK's composite USB device (CMSIS-DAP HID + Mass-Storage + CDC) means pyOCD's SWD flash leaves the CDC sibling in Windows error 31 — that's the entire crux of #565. lpc21isp never opens the composite HID, so it sidesteps that failure mode and is the right primary path. SWD when it arrives will need the explicit unwedge logic #565 calls for.

## Files

| File | Change |
|---|---|
| `crates/fbuild-deploy/src/lpc.rs` | new — `LpcDeployer` + `Lpc21IspParams`. ~250 LOC. Single-file deployer modeled on `AvrDeployer`'s subprocess pattern. |
| `crates/fbuild-deploy/src/lib.rs` | `pub mod lpc;` |
| `crates/fbuild-daemon/src/handlers/operations/deploy.rs` | `Platform::NxpLpc` arm between `Teensy` and the catch-all fall-through. Honors `baud_override` like the AVR arm. |

## lpc21isp invocation

```
lpc21isp -control -wipe -hex firmware.hex <port> <baud> <xtal_kHz>
```

- `-control` — drive DTR/RTS for ISP-mode entry/exit on auto-reset wiring (LPC845-BRK).
- `-wipe` — full-chip erase before write (skips would leave stale data).
- `-hex` — Intel HEX (what the nxplpc orchestrator emits).

Defaults: 115200 baud, 12 MHz crystal (matches NXP LPC845-BRK, LPCXpresso845-MAX, LPCXpresso804), 60 s timeout. The `--baud` CLI flag flows through `LpcDeployer::with_baud_rate`.

## Validation

- [x] `soldr check -p fbuild-deploy -p fbuild-daemon` — clean
- [x] `soldr test -p fbuild-deploy --lib lpc::` — 6/6 pass
- [x] `soldr clippy -p fbuild-deploy -p fbuild-daemon --all-targets -- -D warnings` — clean (only pre-existing MSRV-mismatch warnings; no LPC findings)
- [x] `soldr rustfmt --check` — clean

### Hardware bench gate (LPC845-BRK + `lpc21isp` on PATH)

These are the validation conditions for closing #551. CI alone can't sign them off; the bench session does:

- [ ] `fbuild deploy tests/platform/lpc845 -e lpc845 --port COM10` flashes successfully end-to-end.
- [ ] AutoResearch flash-then-monitor cycle (`bash autoresearch lpc845brk --pin-toggle-rx`) hits zero VCOM wedge over N=10 iterations.

If both bench items hold, merging this PR closes #551 and implicitly satisfies #565 for the lpc21isp path. #565 stays open until the eventual SWD path lands with its own explicit unwedge logic.

## Closes

- Closes #551 (Phase 1 — lpc21isp path)
- Refs FastLED/FastLED#586 (LPC845-BRK end-to-end burn-down meta — item 3-of-5)
- #565 stays open; lpc21isp Phase 1 sidesteps that failure mode, but the SWD path will still need to address it explicitly when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NXP LPC microcontroller support for firmware deployment over UART using ISP protocol.
  * Deployment configuration options include baud rate selection, crystal frequency specification, and operation timeout adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->