### PR TITLE
chore(deps): bump managed zccache 1.12.4 -> 1.12.7

### DIFF
--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -20,12 +20,12 @@ use fbuild_core::{FbuildError, Result};
 
 /// The zccache release fbuild pins. Bump in lockstep with the floor that
 /// the rest of the toolchain expects.
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.4";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.7";
 
 /// GitHub release tag for [`MANAGED_ZCCACHE_VERSION`]. The zccache release
 /// workflow tags without a `v` prefix, while the per-asset filenames carry
 /// `v<version>` — keep both spellings in sync when bumping.
-const RELEASE_TAG: &str = "1.12.4";
+const RELEASE_TAG: &str = "1.12.7";
 
 /// Source repository for managed downloads.
 const REPO: &str = "zackees/zccache";


### PR DESCRIPTION
Picks up [zackees/zccache#763](https://github.com/zackees/zccache/pull/763) (version-namespaced cache root, closes zackees/zccache#762) plus 1.12.5/1.12.6 fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated managed zccache version from 1.12.4 to 1.12.7, incorporating latest improvements and fixes from the upstream release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->