### PR TITLE
chore(release): bump 2.2.28 -> 2.2.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "async-trait",
  "blake3",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "blake3",
  "clap",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "libc",
  "running-process",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "async-trait",
  "axum",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "criterion",
  "rayon",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "bincode",
  "blake3",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "axum",
  "bzip2",
@@ -1116,14 +1116,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "async-trait",
  "base64",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.28"
+version = "2.2.29"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.28"
+version = "2.2.29"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.28"
+version = "2.2.29"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Ships [#596](https://github.com/FastLED/fbuild/pull/596) (managed zccache 1.12.4 → 1.12.7).