### PR TITLE
chore: replace zccache kvstore dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,30 +495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crash-context"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
-dependencies = [
- "cfg-if",
- "libc",
- "mach2",
-]
-
-[[package]]
-name = "crash-handler"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2066907075af649bcb8bcb1b9b986329b243677e6918b2d920aa64b0aac5ace3"
-dependencies = [
- "cfg-if",
- "crash-context",
- "libc",
- "mach2",
- "parking_lot",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,7 +883,6 @@ dependencies = [
  "fbuild-test-support",
  "serde_json",
  "tempfile",
- "zccache-artifact",
 ]
 
 [[package]]
@@ -937,7 +912,6 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
- "zccache-artifact",
  "zip",
 ]
 
@@ -1081,12 +1055,13 @@ dependencies = [
  "fbuild-header-scan",
  "fbuild-packages",
  "fbuild-test-support",
+ "prost",
  "serde",
  "tempfile",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-test",
  "walkdir",
- "zccache-artifact",
 ]
 
 [[package]]
@@ -2004,15 +1979,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memmap2"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,16 +2201,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
 
 [[package]]
 name = "parking_lot_core"
@@ -2708,15 +2664,6 @@ name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
-
-[[package]]
-name = "redb"
-version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -4376,53 +4323,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zccache-artifact"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3524099f64acc4188c166d2f3981b7302e0b1622d7bf7172c69218cac31ca067"
-dependencies = [
- "bincode",
- "blake3",
- "dashmap",
- "rayon",
- "redb",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
- "zccache-core",
- "zccache-hash",
-]
-
-[[package]]
-name = "zccache-core"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8364d5db80125bce99cdb7c1ba487478c2a8124754314e79fdac1b22ca0192b8"
-dependencies = [
- "crash-handler",
- "libc",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "zccache-hash"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbfcaf7a4932a267846108df3a250023706c601f6ba341d51b96812f76b9c1"
-dependencies = [
- "blake3",
- "memmap2",
- "serde",
- "zccache-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ prost = "0.14"
 # fbuild-daemon binds the running-process backend endpoint directly so the
 # broker can verify and route to versioned daemon processes.
 interprocess = "2.4.2"
-zccache-artifact = "1.9"
 rayon = "1"
 tracing-test = "0.2"
 # Terminal coloring for `fbuild build --shrink` reporting (FastLED/fbuild#493).

--- a/bench/fastled-examples/Cargo.toml
+++ b/bench/fastled-examples/Cargo.toml
@@ -15,6 +15,5 @@ path = "src/main.rs"
 fbuild-library-select = { path = "../../crates/fbuild-library-select" }
 fbuild-packages = { path = "../../crates/fbuild-packages" }
 fbuild-test-support = { path = "../../crates/fbuild-test-support" }
-zccache-artifact = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }

--- a/bench/fastled-examples/README.md
+++ b/bench/fastled-examples/README.md
@@ -8,7 +8,7 @@ matrix. This is the AC#5 / P-01 measurement for
 
 For each example sketch under `$FASTLED_DIR/examples/`, runs the
 `fbuild_library_select::cache::resolve_cached` resolver twice against a
-fresh `KvStore`:
+fresh `FileKvStore`:
 
 - **Cold** — empty cache. Wall-clock includes the scanner walk over the
   FastLED `src/` tree (~1000 files), the 2-pass LDF reconciliation, and
@@ -46,7 +46,7 @@ FASTLED_DIR=/path/to/fastled \
   -- --max-warm-ms 50
 ```
 
-If any example fails to measure (missing sketch, KvStore error, warm
+If any example fails to measure (missing sketch, cache error, warm
 miss) the binary exits non-zero rather than skipping the row. CI must
 treat a partial matrix as a failure, not a pass.
 
@@ -85,7 +85,7 @@ release build:
 
 The warm path comfortably clears AC#5 (≤ +50 ms over current fbuild) at
 ~11 ms per example. The ~75x speedup reflects the cost asymmetry between
-walking the FastLED `src/` tree (~1000 files) and a `KvStore`
+walking the FastLED `src/` tree (~1000 files) and a `FileKvStore`
 get + bincode decode of a serialized `Selection`.
 
 ## Curated example set

--- a/bench/fastled-examples/src/main.rs
+++ b/bench/fastled-examples/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the AC#5 / P-01 measurement for FastLED/fbuild#205: for each
 //! example sketch under `$FASTLED_DIR/examples/`, runs the resolver cold
-//! (empty `KvStore`) and warm (cache pre-populated by the cold call) and
+//! (empty `FileKvStore`) and warm (cache pre-populated by the cold call) and
 //! reports the timings as a Markdown table.
 //!
 //! ## Inputs
@@ -17,9 +17,9 @@
 //!
 //! For each `(example, framework_lib_set)` pair:
 //!
-//! - **Cold**: open a fresh `KvStore`, call `resolve_cached(...)`. Wall-clock
+//! - **Cold**: open a fresh `FileKvStore`, call `resolve_cached(...)`. Wall-clock
 //!   includes scanner walk, LDF reconciliation, and cache write.
-//! - **Warm**: call `resolve_cached(...)` again against the same `KvStore`.
+//! - **Warm**: call `resolve_cached(...)` again against the same `FileKvStore`.
 //!   Wall-clock includes cache-key compute (sorted seed/header hashing —
 //!   bounded by `cache_key` itself) and bincode decode of the cached
 //!   `Selection`. Asserts `from_cache = true` so silent re-misses surface
@@ -49,12 +49,11 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use fbuild_library_select::cache::{resolve_cached, CacheKeyInputs};
+use fbuild_library_select::cache::{resolve_cached, CacheKeyInputs, FileKvStore};
 use fbuild_library_select::CachedSelection;
 use fbuild_packages::library::framework_library::discover_framework_libraries;
 use fbuild_packages::library::FrameworkLibrary;
 use fbuild_test_support::MiniFramework;
-use zccache_artifact::KvStore;
 
 /// Curated subset that spans the simple/complex spectrum without dragging
 /// in every one of the ~80 FastLED examples. Bench iteration time at six
@@ -208,7 +207,7 @@ fn measure_example(
     let search_paths = vec![stage_src, fastled_src.to_path_buf()];
 
     let kv_dir = tempfile::tempdir()?;
-    let kv = KvStore::open(kv_dir.path().join("kv"))?;
+    let kv = FileKvStore::open(kv_dir.path().join("kv"))?;
 
     let inputs = CacheKeyInputs {
         toolchain_triple: "teensy-arm-none-eabi",

--- a/crates/fbuild-build/Cargo.toml
+++ b/crates/fbuild-build/Cargo.toml
@@ -12,7 +12,6 @@ fbuild-config = { path = "../fbuild-config" }
 fbuild-paths = { path = "../fbuild-paths" }
 fbuild-packages = { path = "../fbuild-packages" }
 fbuild-library-select = { path = "../fbuild-library-select" }
-zccache-artifact = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/fbuild-build/src/framework_libs.rs
+++ b/crates/fbuild-build/src/framework_libs.rs
@@ -16,11 +16,10 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use fbuild_library_select::cache::{resolve_cached, CacheKeyInputs};
+use fbuild_library_select::cache::{resolve_cached, CacheKeyInputs, FileKvStore};
 use fbuild_library_select::resolve as resolve_library_selection;
 use fbuild_packages::library::FrameworkLibrary;
 use walkdir::{DirEntry, WalkDir};
-use zccache_artifact::KvStore;
 
 /// Resolve framework library source files needed by a project.
 pub fn resolve_framework_library_sources(
@@ -195,7 +194,7 @@ pub fn resolve_framework_library_sources_from_libraries(
 ///
 /// Routes the same `(libraries, project_dir, src_dir)` resolution through
 /// `fbuild_library_select::cache::resolve_cached` using the supplied
-/// `KvStore`. On a backend failure (open, read, write) we log a warning and
+/// `FileKvStore`. On a backend failure (open, read, write) we log a warning and
 /// fall back to the uncached `resolve(...)` so a degraded cache can never
 /// poison a build — same philosophy as the corrupt-entry handling already
 /// inside `cache.rs`.
@@ -204,7 +203,7 @@ pub fn resolve_framework_library_sources_cached(
     project_dir: &Path,
     src_dir: &Path,
     key_inputs: &CacheKeyInputs<'_>,
-    store: &KvStore,
+    store: &FileKvStore,
 ) -> Vec<PathBuf> {
     let (sources, _hit) = resolve_framework_library_sources_cached_with_hit(
         libraries,
@@ -225,7 +224,7 @@ pub(crate) fn resolve_framework_library_sources_cached_with_hit(
     project_dir: &Path,
     src_dir: &Path,
     key_inputs: &CacheKeyInputs<'_>,
-    store: &KvStore,
+    store: &FileKvStore,
 ) -> (Vec<PathBuf>, bool) {
     let roots = framework_include_scan_roots(project_dir, src_dir);
     if libraries.is_empty() {
@@ -274,21 +273,21 @@ pub(crate) fn resolve_framework_library_sources_cached_with_hit(
     }
 }
 
-/// Process-shared `KvStore` for the library-selection cache.
+/// Process-shared file store for the library-selection cache.
 ///
 /// Opens lazily on first call and caches the handle for the rest of the
 /// process. Returns `None` on open failure — callers must skip caching
 /// (and route through the uncached resolver) rather than crash.
-pub fn library_select_kv_store() -> Option<&'static KvStore> {
-    static STORE: OnceLock<Option<KvStore>> = OnceLock::new();
+pub fn library_select_kv_store() -> Option<&'static FileKvStore> {
+    static STORE: OnceLock<Option<FileKvStore>> = OnceLock::new();
     STORE
         .get_or_init(|| {
             let dir = library_select_cache_dir();
-            match KvStore::open(&dir) {
+            match FileKvStore::open(&dir) {
                 Ok(store) => {
                     tracing::info!(
                         path = %dir.display(),
-                        "library-select cache: opened KvStore"
+                        "library-select cache: opened file store"
                     );
                     Some(store)
                 }
@@ -296,7 +295,7 @@ pub fn library_select_kv_store() -> Option<&'static KvStore> {
                     tracing::warn!(
                         path = %dir.display(),
                         error = %err,
-                        "library-select cache: failed to open KvStore; \
+                        "library-select cache: failed to open file store; \
                          resolution will run uncached"
                     );
                     None
@@ -306,7 +305,7 @@ pub fn library_select_kv_store() -> Option<&'static KvStore> {
         .as_ref()
 }
 
-/// Filesystem location of the library-selection KvStore.
+/// Filesystem location of the library-selection file store.
 ///
 /// Routes through `fbuild_paths::get_cache_root()` so the cache obeys the
 /// dev/prod isolation contract (`FBUILD_DEV_MODE=1` → `~/.fbuild/dev/cache`)
@@ -798,7 +797,7 @@ mod tests {
     }
 
     #[test]
-    fn cached_resolution_round_trips_through_kvstore() {
+    fn cached_resolution_round_trips_through_file_store() {
         let tmp = tempfile::TempDir::new().unwrap();
         let project_dir = tmp.path().join("project");
         let src_dir = project_dir.join("src");
@@ -824,7 +823,7 @@ mod tests {
             framework_version: "0.0.0-test",
         };
 
-        let kv = KvStore::open(tmp.path().join("kv")).unwrap();
+        let kv = FileKvStore::open(tmp.path().join("kv")).unwrap();
 
         let (first, hit_first) = resolve_framework_library_sources_cached_with_hit(
             &libraries,

--- a/crates/fbuild-library-select/Cargo.toml
+++ b/crates/fbuild-library-select/Cargo.toml
@@ -10,11 +10,12 @@ license.workspace = true
 fbuild-header-scan = { path = "../fbuild-header-scan" }
 fbuild-packages = { path = "../fbuild-packages" }
 tracing = { workspace = true }
+thiserror = { workspace = true }
 walkdir = { workspace = true }
 serde = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
-zccache-artifact = { workspace = true }
+prost = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/fbuild-library-select/benches/README.md
+++ b/crates/fbuild-library-select/benches/README.md
@@ -26,7 +26,7 @@ soldr cargo bench -p fbuild-library-select --bench resolve_cold
 
 Warm cache-hit path through `resolve_cached()` against the same synthetic
 ~30-library `MiniFramework` tree. The bench builds the fixture once, opens a
-`KvStore` in a tempdir, primes the cache with one untimed `resolve_cached`
+`FileKvStore` in a tempdir, primes the cache with one untimed `resolve_cached`
 call (which misses), then times only the second invocation. Each iteration
 asserts `from_cache == true` and panics otherwise — that way we can never
 silently regress to measuring miss work.

--- a/crates/fbuild-library-select/benches/resolve_warm.rs
+++ b/crates/fbuild-library-select/benches/resolve_warm.rs
@@ -1,7 +1,7 @@
 //! P-01 (mini) warm-resolver benchmark.
 //!
 //! Phase 4 of <https://github.com/FastLED/fbuild/issues/205> shipped
-//! [`fbuild_library_select::cache::resolve_cached`], a `KvStore`-backed memo
+//! [`fbuild_library_select::cache::resolve_cached`], a file-backed memo
 //! in front of [`fbuild_library_select::resolve`]. AC#5 / P-01 of #205 sets
 //! a "warm library-selection ≤ current fbuild + 50 ms" goal; the real
 //! per-board matrix lives under `bench/fastled-examples/` and waits on a
@@ -11,7 +11,7 @@
 //! hit code path independent of the larger matrix.
 //!
 //! Structure mirrors `resolve_cold.rs`: build the ~30-library tree once,
-//! open a `KvStore` once, prime the cache with one untimed `resolve_cached`
+//! open a `FileKvStore` once, prime the cache with one untimed `resolve_cached`
 //! call, then time only the second invocation (the hit path).
 //!
 //! Run with:
@@ -25,11 +25,10 @@
 use std::path::PathBuf;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use fbuild_library_select::cache::{resolve_cached, CacheKeyInputs};
+use fbuild_library_select::cache::{resolve_cached, CacheKeyInputs, FileKvStore};
 use fbuild_packages::library::framework_library::discover_framework_libraries;
 use fbuild_packages::library::FrameworkLibrary;
 use fbuild_test_support::MiniFramework;
-use zccache_artifact::KvStore;
 
 const LIB_COUNT: usize = 30;
 const CHAIN_LEN: usize = 5;
@@ -67,7 +66,8 @@ fn build_fixture() -> (
 fn bench_resolve_warm(c: &mut Criterion) {
     let (mf, seeds, search_paths, libs) = build_fixture();
     let kv_dir = tempfile::tempdir().expect("resolve_warm: failed to create kv tempdir");
-    let kv = KvStore::open(kv_dir.path().join("kv")).expect("resolve_warm: KvStore::open failed");
+    let kv = FileKvStore::open(kv_dir.path().join("kv"))
+        .expect("resolve_warm: FileKvStore::open failed");
 
     let framework_root = mf.framework_root().to_path_buf();
     let inputs = CacheKeyInputs {

--- a/crates/fbuild-library-select/src/cache.rs
+++ b/crates/fbuild-library-select/src/cache.rs
@@ -3,8 +3,8 @@
 //! The resolver is a pure function of (project sources, search paths, library
 //! set, toolchain triple, framework version, scanner/LDF semantics). Computing
 //! it costs ~tens of ms cold; restoring from a cache hit is sub-ms. On a warm
-//! CI build this should round-trip through `zccache_artifact::KvStore` instead
-//! of re-walking the framework `libraries/` tree.
+//! CI build this should round-trip through a small fbuild-owned file cache
+//! instead of re-walking the framework `libraries/` tree.
 //!
 //! ## Cache key (Q9 from #205)
 //!
@@ -27,7 +27,7 @@
 use std::path::{Path, PathBuf};
 
 use fbuild_packages::library::FrameworkLibrary;
-use zccache_artifact::{Key, KvError, KvStore};
+use prost::Message;
 
 use crate::{resolve, Selection};
 
@@ -39,8 +39,136 @@ pub const SCANNER_VERSION: u32 = 1;
 /// attribution, convergence rule, etc.).
 pub const LDF_MODE_VERSION: u32 = 1;
 
-/// zccache namespace for this cache. Reserved per the zccache#130 design note.
+/// Namespace for the library-selection file cache.
 pub const NAMESPACE: &str = "library-selection";
+
+const CACHE_ENVELOPE_VERSION: u32 = 1;
+
+/// Content-addressed cache key for library-selection memoization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CacheKey([u8; 32]);
+
+impl CacheKey {
+    fn from_hash(hash: blake3::Hash) -> Self {
+        Self(*hash.as_bytes())
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub fn to_hex(&self) -> String {
+        let mut out = String::with_capacity(64);
+        for byte in self.0 {
+            use std::fmt::Write as _;
+            let _ = write!(&mut out, "{byte:02x}");
+        }
+        out
+    }
+}
+
+/// Minimal file-backed K/V cache for best-effort memoized resolver output.
+///
+/// This deliberately avoids a database engine. Values are deterministic and
+/// disposable: corrupt, missing, or stale entries are treated as cache misses.
+#[derive(Debug, Clone)]
+pub struct FileKvStore {
+    root: PathBuf,
+}
+
+impl FileKvStore {
+    pub fn open<P: AsRef<Path>>(root: P) -> CacheResult<Self> {
+        let root = root.as_ref().to_path_buf();
+        std::fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    pub fn get(&self, namespace: &str, key: &CacheKey) -> CacheResult<Option<Vec<u8>>> {
+        validate_namespace(namespace)?;
+        let path = self.entry_path(namespace, key);
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+        let envelope = match CacheEnvelope::decode(bytes.as_slice()) {
+            Ok(envelope) => envelope,
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "library-select cache: corrupt protobuf envelope; treating as miss"
+                );
+                return Ok(None);
+            }
+        };
+        if envelope.schema_version != CACHE_ENVELOPE_VERSION {
+            return Ok(None);
+        }
+        Ok(Some(envelope.payload))
+    }
+
+    pub fn put(&self, namespace: &str, key: &CacheKey, value: &[u8]) -> CacheResult<usize> {
+        validate_namespace(namespace)?;
+        let path = self.entry_path(namespace, key);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let envelope = CacheEnvelope {
+            schema_version: CACHE_ENVELOPE_VERSION,
+            payload: value.to_vec(),
+        };
+        let bytes = envelope.encode_to_vec();
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), nonce));
+        std::fs::write(&tmp, bytes)?;
+        std::fs::rename(&tmp, &path).or_else(|err| {
+            let _ = std::fs::remove_file(&path);
+            std::fs::rename(&tmp, &path).map_err(|_| err)
+        })?;
+        Ok(value.len())
+    }
+
+    fn entry_path(&self, namespace: &str, key: &CacheKey) -> PathBuf {
+        self.root
+            .join(namespace)
+            .join(format!("{}.pb", key.to_hex()))
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct CacheEnvelope {
+    #[prost(uint32, tag = "1")]
+    schema_version: u32,
+    #[prost(bytes, tag = "2")]
+    payload: Vec<u8>,
+}
+
+pub type CacheResult<T> = Result<T, CacheError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CacheError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("bad cache namespace")]
+    BadNamespace,
+}
+
+fn validate_namespace(namespace: &str) -> CacheResult<()> {
+    if !namespace.is_empty()
+        && namespace
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        Ok(())
+    } else {
+        Err(CacheError::BadNamespace)
+    }
+}
 
 /// Inputs that vary independently of the (seeds, search_paths, libraries)
 /// triple and must contribute to the cache key — toolchain + framework
@@ -63,7 +191,7 @@ pub struct CacheKeyInputs<'a> {
 #[derive(Debug, Clone)]
 pub struct CachedSelection {
     pub selection: Selection,
-    pub key: Key,
+    pub key: CacheKey,
     pub from_cache: bool,
 }
 
@@ -80,7 +208,7 @@ pub fn cache_key(
     search_paths: &[PathBuf],
     libraries: &[FrameworkLibrary],
     inputs: &CacheKeyInputs<'_>,
-) -> Key {
+) -> CacheKey {
     let mut h = blake3::Hasher::new();
 
     h.update(b"fbuild.library-select.v1\n");
@@ -148,7 +276,7 @@ pub fn cache_key(
         h.update(content);
     }
 
-    Key::from_hash(h.finalize())
+    CacheKey::from_hash(h.finalize())
 }
 
 fn canonical_header_hash(lib: &FrameworkLibrary) -> [u8; 32] {
@@ -174,16 +302,16 @@ fn canonical_header_hash(lib: &FrameworkLibrary) -> [u8; 32] {
 /// never poison a build. The tainted entry is overwritten by the fresh
 /// computation's `put`.
 ///
-/// Errors propagate only from the underlying [`KvStore`] backend
-/// (filesystem, redb commit). Construction-time validation of the
+/// Errors propagate only from the underlying [`FileKvStore`] backend
+/// (filesystem or protobuf decode). Construction-time validation of the
 /// namespace is impossible to fail because [`NAMESPACE`] is a const.
 pub fn resolve_cached(
     seeds: &[PathBuf],
     search_paths: &[PathBuf],
     libraries: &[FrameworkLibrary],
     inputs: &CacheKeyInputs<'_>,
-    store: &KvStore,
-) -> Result<CachedSelection, KvError> {
+    store: &FileKvStore,
+) -> CacheResult<CachedSelection> {
     let key = cache_key(seeds, search_paths, libraries, inputs);
 
     if let Some(bytes) = store.get(NAMESPACE, &key)? {
@@ -285,7 +413,7 @@ mod tests {
     #[test]
     fn c01_cache_miss_then_hit() {
         let (tmp, seeds, search_paths, libs) = build_simple_project();
-        let kv = KvStore::open(tmp.path().join("kv")).unwrap();
+        let kv = FileKvStore::open(tmp.path().join("kv")).unwrap();
         let inputs = fixture_inputs(tmp.path());
 
         let first = resolve_cached(&seeds, &search_paths, &libs, &inputs, &kv).unwrap();
@@ -399,7 +527,7 @@ mod tests {
     #[test]
     fn c07_corrupt_entry_falls_through_to_recompute() {
         let (tmp, seeds, search_paths, libs) = build_simple_project();
-        let kv = KvStore::open(tmp.path().join("kv")).unwrap();
+        let kv = FileKvStore::open(tmp.path().join("kv")).unwrap();
         let inputs = fixture_inputs(tmp.path());
 
         let key = cache_key(&seeds, &search_paths, &libs, &inputs);


### PR DESCRIPTION
## Summary
- replace `zccache_artifact::KvStore` with an fbuild-owned `FileKvStore` for library-selection memoization
- store entries as file-per-key protobuf envelopes and treat stale/corrupt entries as cache misses
- remove `zccache-artifact` from workspace/build/library-select/bench dependencies and update benchmark docs

## Tests
- cargo fmt --all
- cargo check -p fbuild-library-select -p fbuild-build -p fbuild-bench-fastled-examples
- cargo test -p fbuild-library-select cache
- cargo test -p fbuild-build framework_libs
- git diff --check
- cargo tree --invert zccache-artifact (now reports no such package)

Closes #600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Migrated cache backend to file-based storage. Cache entries are now persisted on disk with improved error handling and recovery mechanisms, enhancing reliability for library selection and framework resolution workflows across build sessions.

* **Documentation**
  * Updated benchmarking and configuration documentation to reflect the new file-backed cache storage implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->