### PR TITLE
feat(serial): #605 Phase 0 — Deployer::post_deploy_recovery + SerialMonitor in_waiting/reset_input_buffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Custom Claude Code skills in `.claude/skills/`:
 - **HTTP API compatibility** — same endpoints and JSON schemas as the Python daemon
 - **Windows USB-CDC** — 30 retries, aggressive buffer drain, DTR/RTS toggling after flash
 - **Emulator CLI convention** — prefer `fbuild test-emu` for CI; `fbuild deploy --to emu [--emulator <kind>]` for interactive use; keep `--target` and `--qemu` only as compatibility aliases
+- **Serial recovery & client API** — post-deploy serial-port recovery is owned by `Deployer::post_deploy_recovery` (default: 3 s fast-poll; platform-specific deployers can override for e.g. LPC + CMSIS-DAP wedge recovery). Clients consume serial through `fbuild.api.SerialMonitor` exclusively — direct pyserial use by clients is deprecated and will be lint-enforced in a follow-up sweep (FastLED/fbuild#605 Phase 1).
 
 ## Reference Implementations
 

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -544,9 +544,7 @@ pub async fn deploy(
                                     port,
                                     "trusted-hash: session-trusted match; skipping verify-flash entirely"
                                 );
-                                // VerifySkip → no flash happened, no
-                                // recovery needed. Pass `None` so the
-                                // async caller skips the recovery hook.
+                                // VerifySkip → recovery skipped (#605).
                                 return Ok((None, fbuild_deploy::DeploymentResult {
                                     success: true,
                                     message: format!(
@@ -584,7 +582,7 @@ pub async fn deploy(
                                 port,
                                 "verify-flash: device already running this exact image; skipping write"
                             );
-                            // VerifySkip → no recovery needed. Pass `None`.
+                            // VerifySkip → recovery skipped (#605).
                             return Ok((None, fbuild_deploy::DeploymentResult {
                                 success: true,
                                 message: format!(
@@ -744,43 +742,28 @@ pub async fn deploy(
                 }
             }
         }
-        // Return the deployer alongside the result so the post-deploy
-        // recovery hook (FastLED/fbuild#605) can be invoked from the
-        // async caller after `clear_preemption().await`. The early-return
-        // verify-skip paths above pass `None` since recovery is a no-op
-        // when no flash actually happened.
+        // Return the deployer so the async caller can invoke
+        // `post_deploy_recovery` after `clear_preemption().await` (#605).
         result.map(|r| (Some(deployer), r))
     })
     .await;
 
-    // Split the deployer out of the spawn_blocking result so it can drive
-    // post-deploy recovery while `deploy_result` retains its original shape
-    // for the downstream match. The deployer is `None` for verify-skip
-    // early returns (no flash happened → no recovery needed), for
-    // unsupported-platform errors, and for spawn_blocking task failures.
+    // Split the deployer out so it can drive recovery while `deploy_result`
+    // retains its original shape for the downstream match. `None` covers
+    // verify-skip early returns, unsupported platforms, and join errors.
     let (deployer_for_recovery, deploy_result) = match deploy_result {
         Ok(Ok((d, r))) => (d, Ok(Ok(r))),
         Ok(Err(e)) => (None, Ok(Err(e))),
         Err(e) => (None, Err(e)),
     };
 
-    // Clear preemption then invoke the deployer's post-deploy recovery
-    // hook. The default `Deployer::post_deploy_recovery` impl is a 3-second
-    // 100ms fast-poll on the port (most ESP32-S3 boards with native USB
-    // re-enumerate in <500ms). Platform-specific deployers can override the
-    // hook to perform OS-level re-enumeration — see FastLED/fbuild#605.
-    //
-    // Skip the recovery entirely when the deploy didn't actually touch
-    // flash (VerifySkip): no reset happened, no USB re-enumeration is
-    // coming, and the poll's `open()` probe would conflict with any
-    // already-attached monitor and burn the full 3 s timeout. This is
-    // load-bearing for the < 4 s warm-trust-skip budget.
+    // Skip recovery when the deploy didn't touch flash (VerifySkip): no
+    // reset, no USB re-enumeration, and the poll's `open()` probe would
+    // conflict with any already-attached monitor — load-bearing for the
+    // <4 s warm-trust-skip budget.
     let deploy_skipped_bus_work = matches!(
         &deploy_result,
-        Ok(Ok(r)) if r.success && matches!(
-            r.outcome,
-            fbuild_deploy::DeployOutcome::VerifySkip
-        )
+        Ok(Ok(r)) if r.success && matches!(r.outcome, fbuild_deploy::DeployOutcome::VerifySkip)
     );
     if let Some(ref p) = deploy_port_str {
         ctx.serial_manager.clear_preemption(p).await;
@@ -789,11 +772,7 @@ pub async fn deploy(
                 let port_name = p.clone();
                 let _ = tokio::task::spawn_blocking(move || {
                     if let Err(e) = deployer.post_deploy_recovery(&port_name) {
-                        tracing::warn!(
-                            "post_deploy_recovery failed for {}: {}",
-                            port_name,
-                            e
-                        );
+                        tracing::warn!("post_deploy_recovery failed for {}: {}", port_name, e);
                     }
                 })
                 .await;

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -416,7 +416,7 @@ pub async fn deploy(
         ctx.device_manager
             .refresh_devices_if_stale(std::time::Duration::from_secs(2));
     }
-    let deploy_result = tokio::task::spawn_blocking(move || {
+    let deploy_result = tokio::task::spawn_blocking(move || -> fbuild_core::Result<(Option<Box<dyn fbuild_deploy::Deployer>>, fbuild_deploy::DeploymentResult)> {
         // Populated by the Espressif32 arm with (image_hash, port).
         // The tail of the closure consults it after `deployer.deploy`
         // returns to record or invalidate the daemon's trusted-hash
@@ -544,7 +544,10 @@ pub async fn deploy(
                                     port,
                                     "trusted-hash: session-trusted match; skipping verify-flash entirely"
                                 );
-                                return Ok(fbuild_deploy::DeploymentResult {
+                                // VerifySkip → no flash happened, no
+                                // recovery needed. Pass `None` so the
+                                // async caller skips the recovery hook.
+                                return Ok((None, fbuild_deploy::DeploymentResult {
                                     success: true,
                                     message: format!(
                                         "firmware already current on {} (skipped via session trust)",
@@ -554,7 +557,7 @@ pub async fn deploy(
                                     stdout: String::new(),
                                     stderr: String::new(),
                                     outcome: fbuild_deploy::DeployOutcome::VerifySkip,
-                                });
+                                }));
                             }
                         }
                     }
@@ -581,7 +584,8 @@ pub async fn deploy(
                                 port,
                                 "verify-flash: device already running this exact image; skipping write"
                             );
-                            return Ok(fbuild_deploy::DeploymentResult {
+                            // VerifySkip → no recovery needed. Pass `None`.
+                            return Ok((None, fbuild_deploy::DeploymentResult {
                                 success: true,
                                 message: format!(
                                     "firmware already current on {} (skipped via verify-flash)",
@@ -591,7 +595,7 @@ pub async fn deploy(
                                 stdout,
                                 stderr,
                                 outcome: fbuild_deploy::DeployOutcome::VerifySkip,
-                            });
+                            }));
                         }
                         Ok(fbuild_deploy::esp32::VerifyOutcome::Mismatch { regions, .. }) => {
                             // Pick only the regions that actually differ
@@ -644,7 +648,12 @@ pub async fn deploy(
                             }
                         }
                     }
-                    return result;
+                    // Selective flash did write to flash — return the
+                    // deployer so post-deploy recovery runs.
+                    return result.map(|r| {
+                        let boxed: Box<dyn fbuild_deploy::Deployer> = Box::new(deployer);
+                        (Some(boxed), r)
+                    });
                 }
 
                 // Capture the hash into the boxed deployer closure
@@ -735,19 +744,37 @@ pub async fn deploy(
                 }
             }
         }
-        result
+        // Return the deployer alongside the result so the post-deploy
+        // recovery hook (FastLED/fbuild#605) can be invoked from the
+        // async caller after `clear_preemption().await`. The early-return
+        // verify-skip paths above pass `None` since recovery is a no-op
+        // when no flash actually happened.
+        result.map(|r| (Some(deployer), r))
     })
     .await;
 
-    // Clear preemption then wait for USB re-enumeration.
-    // Fast-poll the serial port instead of a hard 2s sleep — most ESP32-S3
-    // boards with native USB re-enumerate in <500ms.
+    // Split the deployer out of the spawn_blocking result so it can drive
+    // post-deploy recovery while `deploy_result` retains its original shape
+    // for the downstream match. The deployer is `None` for verify-skip
+    // early returns (no flash happened → no recovery needed), for
+    // unsupported-platform errors, and for spawn_blocking task failures.
+    let (deployer_for_recovery, deploy_result) = match deploy_result {
+        Ok(Ok((d, r))) => (d, Ok(Ok(r))),
+        Ok(Err(e)) => (None, Ok(Err(e))),
+        Err(e) => (None, Err(e)),
+    };
+
+    // Clear preemption then invoke the deployer's post-deploy recovery
+    // hook. The default `Deployer::post_deploy_recovery` impl is a 3-second
+    // 100ms fast-poll on the port (most ESP32-S3 boards with native USB
+    // re-enumerate in <500ms). Platform-specific deployers can override the
+    // hook to perform OS-level re-enumeration — see FastLED/fbuild#605.
     //
-    // Skip the poll entirely when the deploy didn't actually touch
-    // flash (VerifySkip): no reset happened, no USB re-enumeration
-    // is coming, and the poll's `open()` probe would conflict with
-    // any already-attached monitor and burn the full 3 s timeout.
-    // This is load-bearing for the < 4 s warm-trust-skip budget.
+    // Skip the recovery entirely when the deploy didn't actually touch
+    // flash (VerifySkip): no reset happened, no USB re-enumeration is
+    // coming, and the poll's `open()` probe would conflict with any
+    // already-attached monitor and burn the full 3 s timeout. This is
+    // load-bearing for the < 4 s warm-trust-skip budget.
     let deploy_skipped_bus_work = matches!(
         &deploy_result,
         Ok(Ok(r)) if r.success && matches!(
@@ -758,25 +785,19 @@ pub async fn deploy(
     if let Some(ref p) = deploy_port_str {
         ctx.serial_manager.clear_preemption(p).await;
         if !deploy_skipped_bus_work {
-            let port_name = p.clone();
-            let _ = tokio::task::spawn_blocking(move || {
-                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-                while std::time::Instant::now() < deadline {
-                    if serialport::new(&port_name, 115200)
-                        .timeout(std::time::Duration::from_millis(50))
-                        .open()
-                        .is_ok()
-                    {
-                        return;
+            if let Some(deployer) = deployer_for_recovery {
+                let port_name = p.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    if let Err(e) = deployer.post_deploy_recovery(&port_name) {
+                        tracing::warn!(
+                            "post_deploy_recovery failed for {}: {}",
+                            port_name,
+                            e
+                        );
                     }
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                }
-                tracing::warn!(
-                    "USB re-enumeration: port {} not available after 3s",
-                    port_name
-                );
-            })
-            .await;
+                })
+                .await;
+            }
         }
     }
 

--- a/crates/fbuild-daemon/src/handlers/websockets.rs
+++ b/crates/fbuild-daemon/src/handlers/websockets.rs
@@ -263,6 +263,41 @@ async fn handle_serial_ws(mut socket: WebSocket, ctx: Arc<DaemonContext>) {
                             Ok(SerialClientMessage::Detach) => {
                                 break;
                             }
+                            Ok(SerialClientMessage::ClearBuffer) => {
+                                // FastLED/fbuild#605 — drop every line the
+                                // client's broadcast receiver has buffered
+                                // but not yet observed. Mirrors pyserial's
+                                // `Serial.reset_input_buffer()` semantic
+                                // (modulo bytes vs lines).
+                                let mut drained: usize = 0;
+                                while rx.try_recv().is_ok() {
+                                    drained += 1;
+                                }
+                                tracing::debug!(
+                                    client_id,
+                                    port,
+                                    drained,
+                                    "clear_buffer drained pending lines"
+                                );
+                            }
+                            Ok(SerialClientMessage::GetInWaiting) => {
+                                // FastLED/fbuild#605 — answer with the
+                                // current per-client broadcast queue depth
+                                // (lines buffered but not yet observed).
+                                // Distinct from pyserial's `in_waiting`
+                                // (bytes) — see the issue for the rationale.
+                                let count = rx.len();
+                                let reply = SerialServerMessage::InWaiting { count };
+                                if socket
+                                    .send(Message::Text(
+                                        serde_json::to_string(&reply).unwrap(),
+                                    ))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
                             Ok(_) => {}
                             Err(e) => {
                                 tracing::warn!(client_id, "invalid ws message: {}", e);

--- a/crates/fbuild-deploy/src/lib.rs
+++ b/crates/fbuild-deploy/src/lib.rs
@@ -98,6 +98,42 @@ pub trait Deployer: Send + Sync {
         firmware_path: &Path,
         port: Option<&str>,
     ) -> Result<DeploymentResult>;
+
+    /// Post-deploy serial-port recovery.
+    ///
+    /// Called by the daemon's deploy handler after `clear_preemption()`
+    /// and before serial monitors are notified to reconnect. The default
+    /// impl is a 3-second 100ms fast-poll on the port — most ESP32-S3
+    /// boards with native USB re-enumerate in <500ms, so polling returns
+    /// far faster than a hard sleep would. Platform-specific deployers
+    /// can override this to perform OS-level re-enumeration.
+    ///
+    /// FastLED/fbuild#605 — this hook is the seam where the LPC + CMSIS-DAP
+    /// composite-USB wedge recovery will land. The default fast-poll cannot
+    /// clear the Windows error-31 state on a composite USB device whose HID
+    /// interface was touched by pyocd; an LPC-specific override calling
+    /// `CM_Reenumerate_DevNode_Ex` on the parent hub devnode is the planned
+    /// Phase 1 follow-up.
+    ///
+    // TODO(#605 Phase 1): LPC + CMSIS-DAP wedge-recovery override.
+    fn post_deploy_recovery(&self, port: &str) -> Result<()> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while std::time::Instant::now() < deadline {
+            if serialport::new(port, 115200)
+                .timeout(std::time::Duration::from_millis(50))
+                .open()
+                .is_ok()
+            {
+                return Ok(());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        tracing::warn!(
+            "USB re-enumeration: port {} not available after 3s",
+            port
+        );
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -146,6 +182,112 @@ mod outcome_tests {
         assert_eq!(
             outcome.describe(),
             "selective flash: bootloader, partitions, firmware"
+        );
+    }
+}
+
+#[cfg(test)]
+mod post_deploy_recovery_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Test deployer whose `deploy()` is unimplemented (never invoked
+    /// here) but whose `post_deploy_recovery` is observable: it records
+    /// the port it saw and that it ran. FastLED/fbuild#605 acceptance
+    /// gate — verifies the trait method exists, is dispatched via
+    /// `Box<dyn Deployer>`, and that overrides win over the default.
+    struct ObservableDeployer {
+        called: Arc<AtomicBool>,
+        port_seen: Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    impl Deployer for ObservableDeployer {
+        fn deploy(
+            &self,
+            _project_dir: &Path,
+            _env_name: &str,
+            _firmware_path: &Path,
+            _port: Option<&str>,
+        ) -> Result<DeploymentResult> {
+            unreachable!("deploy not exercised by post_deploy_recovery tests")
+        }
+
+        fn post_deploy_recovery(&self, port: &str) -> Result<()> {
+            self.called.store(true, Ordering::SeqCst);
+            *self.port_seen.lock().unwrap() = Some(port.to_string());
+            Ok(())
+        }
+    }
+
+    /// A deployer that uses the default `post_deploy_recovery`. Counts
+    /// `deploy()` calls so the default-impl test can confirm it didn't
+    /// accidentally dispatch through `deploy()`.
+    struct DefaultRecoveryDeployer {
+        deploy_calls: Arc<AtomicUsize>,
+    }
+
+    impl Deployer for DefaultRecoveryDeployer {
+        fn deploy(
+            &self,
+            _project_dir: &Path,
+            _env_name: &str,
+            _firmware_path: &Path,
+            _port: Option<&str>,
+        ) -> Result<DeploymentResult> {
+            self.deploy_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(DeploymentResult {
+                success: true,
+                message: "ok".into(),
+                port: None,
+                stdout: String::new(),
+                stderr: String::new(),
+                outcome: DeployOutcome::FullFlash,
+            })
+        }
+    }
+
+    #[test]
+    fn override_is_dispatched_through_box_dyn() {
+        let called = Arc::new(AtomicBool::new(false));
+        let port_seen = Arc::new(std::sync::Mutex::new(None));
+        let dep: Box<dyn Deployer> = Box::new(ObservableDeployer {
+            called: Arc::clone(&called),
+            port_seen: Arc::clone(&port_seen),
+        });
+
+        dep.post_deploy_recovery("COM-fake").expect("override returns Ok");
+
+        assert!(called.load(Ordering::SeqCst), "override must run");
+        assert_eq!(
+            port_seen.lock().unwrap().as_deref(),
+            Some("COM-fake"),
+            "override receives the port verbatim"
+        );
+    }
+
+    #[test]
+    fn default_impl_returns_ok_for_nonexistent_port_within_budget() {
+        // The default impl polls the port for up to 3 seconds and then
+        // returns Ok regardless. Using a port name that cannot possibly
+        // exist exercises the slow path. Budget is 4s — the impl itself
+        // is bounded at 3s plus scheduling jitter.
+        let dep = DefaultRecoveryDeployer {
+            deploy_calls: Arc::new(AtomicUsize::new(0)),
+        };
+        let start = std::time::Instant::now();
+        let result = dep.post_deploy_recovery("a-port-that-does-not-exist-zzz");
+        let elapsed = start.elapsed();
+        assert!(result.is_ok(), "default impl returns Ok even on timeout");
+        assert!(
+            elapsed < std::time::Duration::from_secs(4),
+            "default impl bounded by ~3s, took {:?}",
+            elapsed
+        );
+        assert_eq!(
+            dep.deploy_calls.load(Ordering::SeqCst),
+            0,
+            "post_deploy_recovery must not invoke deploy()"
         );
     }
 }

--- a/crates/fbuild-deploy/src/lib.rs
+++ b/crates/fbuild-deploy/src/lib.rs
@@ -128,10 +128,7 @@ pub trait Deployer: Send + Sync {
             }
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
-        tracing::warn!(
-            "USB re-enumeration: port {} not available after 3s",
-            port
-        );
+        tracing::warn!("USB re-enumeration: port {} not available after 3s", port);
         Ok(())
     }
 }
@@ -256,7 +253,8 @@ mod post_deploy_recovery_tests {
             port_seen: Arc::clone(&port_seen),
         });
 
-        dep.post_deploy_recovery("COM-fake").expect("override returns Ok");
+        dep.post_deploy_recovery("COM-fake")
+            .expect("override returns Ok");
 
         assert!(called.load(Ordering::SeqCst), "override must run");
         assert_eq!(

--- a/crates/fbuild-python/src/messages.rs
+++ b/crates/fbuild-python/src/messages.rs
@@ -32,6 +32,12 @@ pub(crate) enum ServerMessage {
         #[allow(dead_code)]
         message: Option<String>,
     },
+    /// Reply to `ClientMessage::GetInWaiting` — the number of buffered
+    /// lines this client's broadcast receiver has not yet observed.
+    /// See FastLED/fbuild#605.
+    InWaiting {
+        count: usize,
+    },
     Preempted {
         #[allow(dead_code)]
         reason: String,
@@ -64,4 +70,11 @@ pub(crate) enum ClientMessage {
         data: String,
     },
     Detach,
+    /// Drop buffered serial-line data on the daemon side. Matches
+    /// pyserial's `Serial.reset_input_buffer()`. See FastLED/fbuild#605.
+    ClearBuffer,
+    /// Ask the daemon for the count of buffered lines this client has
+    /// not yet observed. Maps to pyserial's `Serial.in_waiting`. The
+    /// daemon replies with `ServerMessage::InWaiting`. See FastLED/fbuild#605.
+    GetInWaiting,
 }

--- a/crates/fbuild-python/src/serial_monitor.rs
+++ b/crates/fbuild-python/src/serial_monitor.rs
@@ -375,12 +375,10 @@ impl SerialMonitor {
         // in front of the reply; ignore them and keep waiting for the
         // typed answer until the 2s deadline expires.
         let mut read = ws_read.lock().unwrap();
-        let deadline =
-            std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         while std::time::Instant::now() < deadline {
             let remaining = deadline - std::time::Instant::now();
-            let result =
-                rt.block_on(async { tokio::time::timeout(remaining, read.next()).await });
+            let result = rt.block_on(async { tokio::time::timeout(remaining, read.next()).await });
             match result {
                 Ok(Some(Ok(tungstenite::Message::Text(text)))) => {
                     if let Ok(ServerMessage::InWaiting { count }) =

--- a/crates/fbuild-python/src/serial_monitor.rs
+++ b/crates/fbuild-python/src/serial_monitor.rs
@@ -341,6 +341,78 @@ impl SerialMonitor {
         )))
     }
 
+    /// Number of buffered serial lines the daemon has produced for this
+    /// session but the client has not yet drained via `read_lines()`.
+    ///
+    /// Maps to pyserial's `Serial.in_waiting`, modulo a units difference:
+    /// the daemon brokers serial data as already-split lines, not raw
+    /// bytes, so this is a line count. Returns 0 when the WebSocket
+    /// session is not open (i.e. before `__enter__` or after `__exit__`).
+    ///
+    /// FastLED/fbuild#605 — added as part of the deprecation of direct
+    /// pyserial use by fbuild clients.
+    #[getter]
+    fn in_waiting(&self) -> usize {
+        let (Some(ref rt), Some(ref ws_write), Some(ref ws_read)) =
+            (&self.runtime, &self.ws_write, &self.ws_read)
+        else {
+            return 0;
+        };
+
+        let msg = serde_json::to_string(&ClientMessage::GetInWaiting).unwrap();
+        {
+            let mut write = ws_write.lock().unwrap();
+            if rt
+                .block_on(write.send(tungstenite::Message::Text(msg)))
+                .is_err()
+            {
+                return 0;
+            }
+        }
+
+        // Read until we see an InWaiting reply. Other messages (e.g.
+        // streaming Data frames or Preempted notifications) can arrive
+        // in front of the reply; ignore them and keep waiting for the
+        // typed answer until the 2s deadline expires.
+        let mut read = ws_read.lock().unwrap();
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            let remaining = deadline - std::time::Instant::now();
+            let result =
+                rt.block_on(async { tokio::time::timeout(remaining, read.next()).await });
+            match result {
+                Ok(Some(Ok(tungstenite::Message::Text(text)))) => {
+                    if let Ok(ServerMessage::InWaiting { count }) =
+                        serde_json::from_str::<ServerMessage>(&text)
+                    {
+                        return count;
+                    }
+                    continue;
+                }
+                Ok(Some(Ok(tungstenite::Message::Close(_)))) | Ok(None) => break,
+                Err(_) => break,
+                _ => continue,
+            }
+        }
+        0
+    }
+
+    /// Drop any serial-line data the daemon has buffered for this
+    /// session. Matches pyserial's `Serial.reset_input_buffer()`. No-op
+    /// when the WebSocket session is not open.
+    ///
+    /// FastLED/fbuild#605 — added as part of the deprecation of direct
+    /// pyserial use by fbuild clients.
+    fn reset_input_buffer(&self) {
+        let (Some(ref rt), Some(ref ws_write)) = (&self.runtime, &self.ws_write) else {
+            return;
+        };
+        let msg = serde_json::to_string(&ClientMessage::ClearBuffer).unwrap();
+        let mut write = ws_write.lock().unwrap();
+        let _ = rt.block_on(write.send(tungstenite::Message::Text(msg)));
+    }
+
     /// Reset the device via the daemon's DTR/RTS reset endpoint.
     ///
     /// Sends POST /api/reset to the daemon, which preempts any active

--- a/crates/fbuild-serial/src/messages.rs
+++ b/crates/fbuild-serial/src/messages.rs
@@ -22,6 +22,16 @@ pub enum SerialClientMessage {
         data: String,
     },
     Detach,
+    /// Drop any serial-line data the daemon has buffered for this
+    /// client's broadcast receiver so the next read returns only data
+    /// produced after this message. Matches pyserial's
+    /// `Serial.reset_input_buffer()` semantic. See FastLED/fbuild#605.
+    ClearBuffer,
+    /// Ask the daemon for the number of buffered lines the client's
+    /// broadcast receiver has not yet observed. Maps to pyserial's
+    /// `Serial.in_waiting` (modulo bytes-vs-lines — see #605). The
+    /// daemon replies with `SerialServerMessage::InWaiting`.
+    GetInWaiting,
 }
 
 /// Messages sent by the daemon to the client.
@@ -49,6 +59,12 @@ pub enum SerialServerMessage {
         bytes_written: usize,
         #[serde(skip_serializing_if = "Option::is_none")]
         message: Option<String>,
+    },
+    /// Reply to `SerialClientMessage::GetInWaiting`. `count` is the
+    /// number of buffered lines this client's broadcast receiver has
+    /// not yet observed. See FastLED/fbuild#605.
+    InWaiting {
+        count: usize,
     },
     Error {
         message: String,
@@ -244,6 +260,39 @@ mod tests {
         match parsed {
             SerialServerMessage::Error { message } => assert_eq!(message, "bad"),
             _ => panic!("expected Error"),
+        }
+    }
+
+    // --- FastLED/fbuild#605 ClearBuffer / GetInWaiting / InWaiting ---
+
+    #[test]
+    fn client_clear_buffer_roundtrip() {
+        let msg = SerialClientMessage::ClearBuffer;
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"clear_buffer\""));
+        let parsed: SerialClientMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, SerialClientMessage::ClearBuffer));
+    }
+
+    #[test]
+    fn client_get_in_waiting_roundtrip() {
+        let msg = SerialClientMessage::GetInWaiting;
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"get_in_waiting\""));
+        let parsed: SerialClientMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, SerialClientMessage::GetInWaiting));
+    }
+
+    #[test]
+    fn server_in_waiting_roundtrip() {
+        let msg = SerialServerMessage::InWaiting { count: 42 };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"in_waiting\""));
+        assert!(json.contains("\"count\":42"));
+        let parsed: SerialServerMessage = serde_json::from_str(&json).unwrap();
+        match parsed {
+            SerialServerMessage::InWaiting { count } => assert_eq!(count, 42),
+            _ => panic!("expected InWaiting"),
         }
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -4,11 +4,8 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "fbuild"
-version = "2.2.27"
+version = "2.2.29"
 source = { editable = "." }
-dependencies = [
-    { name = "zccache" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -16,7 +13,6 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "zccache", specifier = ">=1.11.20" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "fbuild-dev-tools", editable = "ci/dev-tools" }]
@@ -25,16 +21,3 @@ dev = [{ name = "fbuild-dev-tools", editable = "ci/dev-tools" }]
 name = "fbuild-dev-tools"
 version = "0.0.0"
 source = { editable = "ci/dev-tools" }
-
-[[package]]
-name = "zccache"
-version = "1.11.20"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/43/5bbd5ddadcb71e7165a49af22beb679c48e01c774819c5841127056fa0e6/zccache-1.11.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a135255e0397233d507d5f008fc906dffd426085b4838044e38fc7de35694988", size = 13741190, upload-time = "2026-06-07T21:37:28.456Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/5c/14caa93cb8ee983d895704ad28d25cb90e8640af54f923c54b2df674d444/zccache-1.11.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a942dc993c69009e3f888467056391ed19c4985fa54c34ca357dcdac7e84ac56", size = 13139000, upload-time = "2026-06-07T21:37:30.906Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ab/1e785ff5836653edb5407c6d43053dd14e29f37bd2463e1383e86df5e837/zccache-1.11.20-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:419ca7963a4f3bf86120159681636c748baa40891a0305a43b59ebc0e3a928e3", size = 15649817, upload-time = "2026-06-07T21:37:33.166Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/72/d5e00ad178dc9aa6c16f5452b9d0151d3371054aadd940a0ea7182123e15/zccache-1.11.20-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:30d456ad47bcb6759cc7b8add98eeac6980cda2bf3796d8ccf65543a1d122f5e", size = 17513041, upload-time = "2026-06-07T21:37:35.547Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/dc/58ad3d3ee488a58400c90eb0f4a8a0c0082a1ae4524516799f789c2f4215/zccache-1.11.20-py3-none-win_amd64.whl", hash = "sha256:9c7c49b7e153cd353cf8c1c06740b78ada401f6629aee3d8b0016fc2c139ad67", size = 13812408, upload-time = "2026-06-07T21:37:38.771Z" },
-    { url = "https://files.pythonhosted.org/packages/73/68/c3421626e3c349dcb176df9979eac0b4ef7461ae75ac6f7724582cd729aa/zccache-1.11.20-py3-none-win_arm64.whl", hash = "sha256:b4b51ccfbc67bc59d65b5a6b10072849b68ba7fd5c5032fa0284fd6c4fbbc752", size = 12192960, upload-time = "2026-06-07T21:37:40.932Z" },
-]


### PR DESCRIPTION
## Summary

Phase 0 of FastLED/fbuild#605 — the trait + protocol seam that Phase 1 will rewire FastLED-side clients onto. Mechanically small (the issue author flagged the cut as "Phase 0 (trait + daemon rewire + the two PyO3 method adds) is mechanically small").

- **`Deployer::post_deploy_recovery`** — added as a default method on the existing trait at `crates/fbuild-deploy/src/lib.rs`. Default impl is the 3-second 100ms fast-poll lifted verbatim from `crates/fbuild-daemon/src/handlers/operations/deploy.rs`. Behavior is unchanged for every existing deployer; the override seam is the planned LPC + CMSIS-DAP wedge-recovery (TODO comment in place).
- **Daemon rewire** — `crates/fbuild-daemon/src/handlers/operations/deploy.rs` now calls `deployer.post_deploy_recovery(port)` instead of the inline fast-poll. The closure returns `Option<Box<dyn Deployer>>` so the verify-skip early-return paths can pass `None` (no flash, no recovery needed). VerifySkip → `deploy_skipped_bus_work` short-circuit is preserved verbatim.
- **`SerialMonitor.in_waiting` + `reset_input_buffer()`** — added to the PyO3 binding in `crates/fbuild-python/src/serial_monitor.rs`. They speak two new daemon-side WebSocket messages handled inline in the existing `/ws/serial-monitor` loop: `GetInWaiting` → `InWaiting { count }`, and `ClearBuffer`. `in_waiting` returns the per-client broadcast queue depth; `reset_input_buffer` drains that queue.
- **CLAUDE.md** — one architectural-commitment row added declaring `Deployer::post_deploy_recovery` as the seam and `SerialMonitor` as the only blessed client serial path. Direct-pyserial deprecation noted as a Phase 1 follow-up.

## Tests

- `crates/fbuild-deploy/src/lib.rs` — new `post_deploy_recovery_tests` module verifies:
  - Override is dispatched via `Box<dyn Deployer>` and receives the port verbatim.
  - Default impl returns `Ok` within the 3-second budget on a non-existent port.
  - Default impl does not invoke `deploy()`.
- `crates/fbuild-serial/src/messages.rs` — roundtrip tests for the three new variants (`SerialClientMessage::ClearBuffer`, `SerialClientMessage::GetInWaiting`, `SerialServerMessage::InWaiting { count }`).

## Out of Scope (Phase 1, tracked separately)

Per the issue author's explicit split — _"Phase 1 (the 9-site sweep + lint) is the higher-LOC follow-up"_:

- 9-site sweep of `ci/autoresearch/` in FastLED to migrate off direct pyserial.
- `ban_client_pyserial` rule in FastLED's `tool_guard.py`.
- `FbuildSerialAdapter` in FastLED's `ci/util/serial_interface.py`.
- Windows `CM_Reenumerate_DevNode` LPC-specific override of `post_deploy_recovery` (lives in FastLED's autoresearch path today; will migrate when FastLED routes LPC through `fbuild deploy lpc845brk`).
- `probe_open()` PyO3 method (issue author marked optional — `__enter__`/`__exit__` cycling covers it).

## Local Verification

- `cargo check --workspace --all-targets` passes cleanly.
- Trait dispatch + roundtrip tests included.
- Clippy and `cargo test` invocations hit pre-existing local-environment toolchain issues (mingw `ld` vs MSVC `link.exe` for `libsqlite3-sys`; soldr/zccache daemon cache-dir mismatch reported separately at zackees/zccache#770). CI uses clean runners that avoid both — relying on CI for `cargo clippy --workspace --all-targets -- -D warnings` and the full test sweep.

## Test plan

- [ ] CI: `soldr cargo check --workspace --all-targets` passes
- [ ] CI: `soldr cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] CI: `uv run test` passes (incl. new trait + message tests)
- [ ] CI: `RUSTDOCFLAGS="-D warnings" soldr cargo doc --workspace --no-deps` passes (new trait method has rustdoc)

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)