### PR TITLE
chore(release): bump 2.2.29 -> 2.2.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.29"
+version = "2.2.30"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.29"
+version = "2.2.30"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Cuts 2.2.30. The Autonomous Release workflow tags + publishes to PyPI after this lands on main.

Headline content:

- **#605 Phase 0** (merged in #606) — `Deployer::post_deploy_recovery` default method, daemon dispatch through the hook, `SerialMonitor.in_waiting` + `reset_input_buffer` PyO3 surface, `ClearBuffer`/`GetInWaiting`/`InWaiting` WebSocket protocol, CLAUDE.md commitment row.
- **#607** — disk cache recovery invariant tests.
- Plus prior dev-since-2.2.29 (zccache kvstore dependency replacement, broker-mediated daemon startup, version 2.2.28 → 2.2.29 follow-ups).

## Test plan

- [ ] CI passes (workspace check, clippy, fmt, doc, board validation, all platform builds, dylint, subprocess-spawns lint, LOC gate)
- [ ] Release-auto workflow tags `v2.2.30` and uploads wheels to PyPI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)