### PR TITLE
fix: clean stale managed zccache staging dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "blake3",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "blake3",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "libc",
  "running-process",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "criterion",
  "rayon",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "bincode",
  "blake3",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "axum",
  "bzip2",
@@ -1093,14 +1093,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "base64",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -98,6 +98,7 @@ fn download_and_install() -> Result<()> {
     std::fs::create_dir_all(parent)?;
 
     let _install_lock = acquire_install_lock(parent)?;
+    cleanup_stale_install_staging(parent, INSTALL_LOCK_STALE_AFTER)?;
     if managed_zccache_exe().is_file() {
         return Ok(());
     }
@@ -196,6 +197,46 @@ fn download_and_install() -> Result<()> {
 
 fn install_lock_dir(parent: &Path) -> PathBuf {
     parent.join(format!(".zccache-{MANAGED_ZCCACHE_VERSION}.install.lock"))
+}
+
+fn cleanup_stale_install_staging(parent: &Path, stale_after: Duration) -> Result<usize> {
+    let mut removed = 0;
+    let entries = std::fs::read_dir(parent).map_err(|e| {
+        FbuildError::Other(format!(
+            "failed to scan managed zccache install dir {}: {e}",
+            parent.display()
+        ))
+    })?;
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !is_zccache_staging_dir(&path) || !path.is_dir() {
+            continue;
+        }
+        if path_is_stale(&path, stale_after) {
+            tracing::warn!(
+                "fbuild: removing stale managed zccache staging dir {}",
+                path.display()
+            );
+            std::fs::remove_dir_all(&path).map_err(|e| {
+                FbuildError::Other(format!(
+                    "failed to remove stale managed zccache staging dir {}: {e}",
+                    path.display()
+                ))
+            })?;
+            removed += 1;
+        }
+    }
+
+    Ok(removed)
+}
+
+fn is_zccache_staging_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with(".zccache-") && name.ends_with(".tmp"))
+        .unwrap_or(false)
 }
 
 fn acquire_install_lock(parent: &Path) -> Result<InstallLockGuard> {
@@ -300,7 +341,11 @@ fn write_lock_owner(lock_dir: &Path) -> Result<()> {
 }
 
 fn lock_is_stale(lock_dir: &Path, stale_after: Duration) -> bool {
-    let Ok(metadata) = std::fs::metadata(lock_dir) else {
+    path_is_stale(lock_dir, stale_after)
+}
+
+fn path_is_stale(path: &Path, stale_after: Duration) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
         return true;
     };
     let Ok(modified) = metadata.modified() else {
@@ -661,6 +706,45 @@ mod tests {
 
         let owner = std::fs::read_to_string(lock_dir.join("owner.txt")).unwrap();
         assert!(owner.contains("version="));
+    }
+
+    #[test]
+    fn cleanup_stale_install_staging_removes_only_old_zccache_temp_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stale = tmp.path().join(".zccache-deadbeef.tmp");
+        let fresh = tmp.path().join(".zccache-active.tmp");
+        let unrelated = tmp.path().join(".other-tool.tmp");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::create_dir_all(&fresh).unwrap();
+        std::fs::create_dir_all(&unrelated).unwrap();
+        std::fs::write(stale.join("zccache"), b"partial").unwrap();
+
+        let old = filetime::FileTime::from_unix_time(1, 0);
+        filetime::set_file_mtime(&stale, old).unwrap();
+        filetime::set_file_mtime(&unrelated, old).unwrap();
+
+        let removed = cleanup_stale_install_staging(tmp.path(), Duration::from_secs(60)).unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(!stale.exists());
+        assert!(fresh.exists());
+        assert!(unrelated.exists());
+    }
+
+    #[test]
+    fn cleanup_stale_install_staging_ignores_final_install_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let final_dir = tmp
+            .path()
+            .join(format!("zccache-{MANAGED_ZCCACHE_VERSION}"));
+        std::fs::create_dir_all(&final_dir).unwrap();
+        let old = filetime::FileTime::from_unix_time(1, 0);
+        filetime::set_file_mtime(&final_dir, old).unwrap();
+
+        let removed = cleanup_stale_install_staging(tmp.path(), Duration::from_secs(60)).unwrap();
+
+        assert_eq!(removed, 0);
+        assert!(final_dir.exists());
     }
 
     /// Real end-to-end download against GitHub Releases. Ignored by


### PR DESCRIPTION
## Summary
- Remove stale managed zccache .zccache-*.tmp staging directories while holding the sidecar install lock.
- Add tests that stale sidecar staging cleanup removes only old zccache temp dirs, preserves fresh temp dirs, and ignores the final zccache-<version> install directory.
- Sync Cargo.lock workspace package versions after the 2.2.30 release bump so locked Cargo runs work from current main.

Refs #603
Follow-up to #609; #609 merged before this sidecar cleanup amendment landed on main.

## Tests
- cargo test -p fbuild-build managed_zccache --lib
- cargo fmt --all --check
- git diff --check