### PR TITLE
test: guard broker cache root ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "blake3",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "blake3",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "libc",
  "running-process",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "criterion",
  "rayon",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "bincode",
  "blake3",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "axum",
  "bzip2",
@@ -1093,14 +1093,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "base64",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/crates/fbuild-paths/src/running_process.rs
+++ b/crates/fbuild-paths/src/running_process.rs
@@ -169,6 +169,20 @@ fn stable_path_key(path: &Path) -> String {
 /// The seven cache roots fbuild records in its broker manifest, resolved from
 /// this crate (the single source of truth for fbuild's on-disk layout).
 ///
+/// Ownership contract:
+///
+/// - `artifact` is the authoritative fbuild global artifact repository root.
+///   It comes from `FBUILD_CACHE_DIR` when set, otherwise
+///   `~/.fbuild/{dev|prod}/cache`. Package/toolchain/framework archives,
+///   installed payloads, `.lnk` blobs, and the disk-cache database live below
+///   this root.
+/// - `index` is broker metadata for the same artifact repository, not a
+///   daemon-version partition.
+/// - `temp`, `log`, `lock`, and `config` are fbuild-owned support roots under
+///   `~/.fbuild/{dev|prod}`.
+/// - `runtime` identifies daemon binary provenance only. Broker runtime
+///   version/path changes must not fork `artifact` or `index`.
+///
 /// The broker's `CacheManifest` (built in `fbuild-daemon`) maps these to
 /// `running-process` `CacheRootKind`s. `CacheRoots` itself is dependency-free so
 /// the CLI diagnostic can resolve and print the same paths without pulling in
@@ -243,6 +257,31 @@ fn platform_service_definition_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        name: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
 
     #[test]
     fn service_definition_metadata_matches_tracker() {
@@ -286,6 +325,49 @@ mod tests {
         assert!(
             !identity.label_value().contains(env!("CARGO_PKG_VERSION")),
             "backend crate version must not be a cache-owner dimension"
+        );
+    }
+
+    #[test]
+    fn cache_roots_respect_fbuild_cache_dir_as_artifact_owner() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let cache_root =
+            std::env::temp_dir().join(format!("fbuild-cache-roots-{}", std::process::id()));
+        let _cache_guard = EnvVarGuard::set(FBUILD_CACHE_DIR_ENV, &cache_root);
+        let runtime = PathBuf::from("/opt/fbuild/bin");
+
+        let roots = CacheRoots::discover(&runtime);
+
+        assert_eq!(roots.artifact, cache_root);
+        assert_eq!(roots.index, cache_root.join("index"));
+        assert_eq!(roots.runtime, runtime);
+        assert_ne!(
+            roots.artifact, roots.runtime,
+            "daemon runtime provenance must not become the artifact repository"
+        );
+    }
+
+    #[test]
+    fn cache_roots_keep_artifacts_stable_across_runtime_dirs() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let cache_root =
+            std::env::temp_dir().join(format!("fbuild-cache-roots-stable-{}", std::process::id()));
+        let _cache_guard = EnvVarGuard::set(FBUILD_CACHE_DIR_ENV, &cache_root);
+        let runtime_v1 = PathBuf::from("/opt/fbuild-1/bin");
+        let runtime_v2 = PathBuf::from("/opt/fbuild-2/bin");
+
+        let roots_v1 = CacheRoots::discover(&runtime_v1);
+        let roots_v2 = CacheRoots::discover(&runtime_v2);
+
+        assert_eq!(roots_v1.artifact, roots_v2.artifact);
+        assert_eq!(roots_v1.index, roots_v2.index);
+        assert_eq!(roots_v1.temp, roots_v2.temp);
+        assert_eq!(roots_v1.log, roots_v2.log);
+        assert_eq!(roots_v1.lock, roots_v2.lock);
+        assert_eq!(roots_v1.config, roots_v2.config);
+        assert_ne!(
+            roots_v1.runtime, roots_v2.runtime,
+            "runtime changes are daemon provenance, not cache ownership"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Document the fbuild-owned broker cache-root ownership contract in the dependency-free path layer.
- Add regression tests proving FBUILD_CACHE_DIR owns CacheRoots::artifact/index while daemon runtime dirs remain provenance only.
- Sync Cargo.lock workspace package versions after the 2.2.30 release bump so locked Cargo runs work from current main.

Refs #603

## Tests
- cargo test -p fbuild-paths running_process --lib
- cargo test --locked -p fbuild-paths running_process --lib
- cargo fmt --all --check
- git diff --check