### PR TITLE
test: guard broker refusal policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "blake3",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "blake3",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "libc",
  "running-process",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "criterion",
  "rayon",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "bincode",
  "blake3",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "axum",
  "bzip2",
@@ -1093,14 +1093,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "base64",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/crates/fbuild-cli/src/daemon_client.rs
+++ b/crates/fbuild-cli/src/daemon_client.rs
@@ -681,10 +681,7 @@ async fn try_acquire_broker_daemon() -> fbuild_core::Result<bool> {
             Err(fbuild_core::FbuildError::DaemonError(err.to_string()))
         }
         Err(AdoptError::Connect(err)) => {
-            if matches!(
-                err.refusal_kind(),
-                Some(RefusalKind::VersionUnsupported | RefusalKind::VersionBlocked)
-            ) {
+            if broker_refusal_is_fatal(err.refusal_kind()) {
                 return Err(fbuild_core::FbuildError::DaemonError(format!(
                     "running-process broker refused fbuild daemon version: {err}"
                 )));
@@ -701,6 +698,13 @@ async fn try_acquire_broker_daemon() -> fbuild_core::Result<bool> {
             Ok(false)
         }
     }
+}
+
+fn broker_refusal_is_fatal(kind: Option<RefusalKind>) -> bool {
+    matches!(
+        kind,
+        Some(RefusalKind::VersionUnsupported | RefusalKind::VersionBlocked)
+    )
 }
 
 /// Legacy direct HTTP daemon acquisition path.
@@ -896,7 +900,21 @@ fn strip_std_handle_inheritance() {
 
 #[cfg(test)]
 mod tests {
-    use super::{daemon_cache_identity_error, DaemonAcquisition, DaemonInfoResponse};
+    use super::{
+        broker_refusal_is_fatal, daemon_cache_identity_error, DaemonAcquisition, DaemonInfoResponse,
+    };
+    use running_process::broker::client::RefusalKind::{VersionBlocked, VersionUnsupported};
+
+    #[test]
+    fn broker_version_refusals_are_fatal() {
+        assert!(broker_refusal_is_fatal(Some(VersionUnsupported)));
+        assert!(broker_refusal_is_fatal(Some(VersionBlocked)));
+    }
+
+    #[test]
+    fn broker_non_refusal_errors_can_fallback() {
+        assert!(!broker_refusal_is_fatal(None));
+    }
 
     #[test]
     fn broker_acquisition_reports_negotiated_state() {

--- a/crates/fbuild-python/src/daemon.rs
+++ b/crates/fbuild-python/src/daemon.rs
@@ -168,10 +168,7 @@ fn ensure_running_via_broker_blocking(url: &str) -> Result<bool, String> {
         Err(AdoptError::BrokerDisabled) => Ok(false),
         Err(AdoptError::DisableEnv(err)) => Err(err.to_string()),
         Err(AdoptError::Connect(err)) => {
-            if matches!(
-                err.refusal_kind(),
-                Some(RefusalKind::VersionUnsupported | RefusalKind::VersionBlocked)
-            ) {
+            if broker_refusal_is_fatal(err.refusal_kind()) {
                 Err(format!(
                     "running-process broker refused fbuild daemon version: {err}"
                 ))
@@ -218,10 +215,7 @@ async fn ensure_running_via_broker_async(url: &str) -> Result<bool, String> {
         Err(AdoptError::BrokerDisabled) => Ok(false),
         Err(AdoptError::DisableEnv(err)) => Err(err.to_string()),
         Err(AdoptError::Connect(err)) => {
-            if matches!(
-                err.refusal_kind(),
-                Some(RefusalKind::VersionUnsupported | RefusalKind::VersionBlocked)
-            ) {
+            if broker_refusal_is_fatal(err.refusal_kind()) {
                 Err(format!(
                     "running-process broker refused fbuild daemon version: {err}"
                 ))
@@ -231,6 +225,13 @@ async fn ensure_running_via_broker_async(url: &str) -> Result<bool, String> {
         }
         Err(AdoptError::AsyncJoin(_)) => Ok(false),
     }
+}
+
+fn broker_refusal_is_fatal(kind: Option<RefusalKind>) -> bool {
+    matches!(
+        kind,
+        Some(RefusalKind::VersionUnsupported | RefusalKind::VersionBlocked)
+    )
 }
 
 /// Python-visible Daemon class (high-level API).
@@ -486,8 +487,24 @@ mod tests {
     //! resolution rule (filename + `is_file()` check) is what we own and
     //! what the bug hinged on. Mocking the Python interpreter just to
     //! re-test stdlib attribute access would dilute the signal.
-    use super::{daemon_cache_identity_error, daemon_in_dir, DAEMON_BIN_NAME};
+    use super::{
+        broker_refusal_is_fatal, daemon_cache_identity_error, daemon_in_dir, DAEMON_BIN_NAME,
+    };
+    use running_process::broker::client::RefusalKind;
     use std::fs;
+
+    #[test]
+    fn broker_version_refusals_are_fatal() {
+        assert!(broker_refusal_is_fatal(Some(
+            RefusalKind::VersionUnsupported
+        )));
+        assert!(broker_refusal_is_fatal(Some(RefusalKind::VersionBlocked)));
+    }
+
+    #[test]
+    fn broker_non_refusal_errors_can_fallback() {
+        assert!(!broker_refusal_is_fatal(None));
+    }
 
     #[test]
     fn daemon_bin_name_matches_platform() {


### PR DESCRIPTION
## Summary

- factor broker refusal fatal/fallback classification into explicit helpers for CLI and Python daemon adoption
- add regression tests that `VersionUnsupported` and `VersionBlocked` remain fatal while non-refusal broker connection failures can still fall back
- sync Cargo.lock workspace package versions to the 2.2.30 release manifests so locked Cargo runs are consistent

Refs #603

## Tests

- cargo test --locked -p fbuild-cli broker_
- cargo test --locked -p fbuild-python broker_
- cargo fmt --all --check
- git diff --check