### PR TITLE
test: guard broker cache manifest roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "blake3",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "blake3",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "libc",
  "running-process",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "criterion",
  "rayon",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "bincode",
  "blake3",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "axum",
  "bzip2",
@@ -1093,14 +1093,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "base64",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/crates/fbuild-daemon/src/broker/service.rs
+++ b/crates/fbuild-daemon/src/broker/service.rs
@@ -321,6 +321,51 @@ mod tests {
     }
 
     #[test]
+    fn cache_manifest_uses_artifact_roots_not_runtime_roots() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let roots = CacheRoots {
+            artifact: tmp.path().join("explicit-cache"),
+            index: tmp.path().join("explicit-cache").join("index"),
+            temp: tmp.path().join("fbuild-root").join("tmp"),
+            log: tmp.path().join("fbuild-root").join("daemon"),
+            lock: tmp.path().join("fbuild-root").join("daemon"),
+            runtime: tmp.path().join("versioned-runtime").join("bin"),
+            config: tmp.path().join("fbuild-root"),
+        };
+        let manifest = fbuild_cache_manifest("2.2.27", &roots).expect("build manifest");
+
+        let root = |kind: CacheRootKind| {
+            manifest
+                .roots
+                .iter()
+                .find(|root| root.kind == kind as i32)
+                .map(|root| root.path.clone())
+                .unwrap_or_else(|| panic!("manifest missing {kind:?}"))
+        };
+
+        assert_eq!(
+            root(CacheRootKind::CacheData),
+            roots.artifact.display().to_string(),
+            "CacheData must advertise the fbuild artifact/cache root"
+        );
+        assert_eq!(
+            root(CacheRootKind::CacheIndex),
+            roots.index.display().to_string(),
+            "CacheIndex must stay below the artifact/cache root"
+        );
+        assert_eq!(
+            root(CacheRootKind::CacheRuntime),
+            roots.runtime.display().to_string(),
+            "CacheRuntime is daemon provenance only"
+        );
+        assert_ne!(
+            root(CacheRootKind::CacheData),
+            root(CacheRootKind::CacheRuntime),
+            "broker runtime path must not become artifact repository ownership"
+        );
+    }
+
+    #[test]
     fn cache_data_root_is_stable_across_backend_versions() {
         let runtime_v1 = if cfg!(windows) {
             PathBuf::from(r"C:\opt\fbuild-1\bin")


### PR DESCRIPTION
## Summary

- add a daemon broker `CacheManifest` regression test with disjoint artifact, index, and runtime roots
- prove `CacheData` and `CacheIndex` come from fbuild artifact/cache ownership while `CacheRuntime` remains daemon provenance only
- sync Cargo.lock workspace package versions to the 2.2.30 release manifests so locked Cargo runs are consistent

Refs #603

## Tests

- cargo test -p fbuild-daemon broker::service::tests::cache_manifest
- cargo test --locked -p fbuild-daemon broker::service::tests::cache_manifest
- cargo fmt --all --check
- git diff --check