### PR TITLE
test: document daemon lock recovery status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "blake3",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "blake3",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "libc",
  "running-process",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "criterion",
  "rayon",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "bincode",
  "blake3",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "axum",
  "bzip2",
@@ -1093,14 +1093,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "base64",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/crates/fbuild-daemon/src/handlers/locks.rs
+++ b/crates/fbuild-daemon/src/handlers/locks.rs
@@ -72,3 +72,65 @@ pub async fn clear_locks(State(ctx): State<Arc<DaemonContext>>) -> Json<ClearLoc
         message,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tokio::sync::Mutex;
+
+    fn test_context() -> Arc<DaemonContext> {
+        let (shutdown_tx, _shutdown_rx) = tokio::sync::watch::channel(false);
+        Arc::new(DaemonContext::new(
+            0,
+            shutdown_tx,
+            "lock-handler-test".to_string(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn lock_status_reports_held_project_locks_without_stale_entries() {
+        let ctx = test_context();
+        let project = PathBuf::from("/tmp/fbuild-held-project");
+        let lock = Arc::new(Mutex::new(()));
+        let guard = lock.lock().await;
+        ctx.project_locks.insert(project.clone(), lock.clone());
+
+        let Json(status) = lock_status(State(ctx)).await;
+
+        assert!(status.success);
+        assert!(
+            status.stale_locks.is_empty(),
+            "stale_locks is reserved for future durable stale-lock detection"
+        );
+        assert_eq!(status.project_locks.len(), 1);
+        assert_eq!(
+            status.project_locks[0].project_dir,
+            project.to_string_lossy()
+        );
+        assert!(status.project_locks[0].is_held);
+
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn clear_locks_removes_only_unheld_project_lock_entries() {
+        let ctx = test_context();
+        let unheld = PathBuf::from("/tmp/fbuild-unheld-project");
+        let held = PathBuf::from("/tmp/fbuild-held-project");
+        let held_lock = Arc::new(Mutex::new(()));
+        let guard = held_lock.lock().await;
+        ctx.project_locks
+            .insert(unheld.clone(), Arc::new(Mutex::new(())));
+        ctx.project_locks.insert(held.clone(), held_lock.clone());
+
+        let Json(response) = clear_locks(State(ctx.clone())).await;
+
+        assert!(response.success);
+        assert_eq!(response.cleared_count, 1);
+        assert!(!ctx.project_locks.contains_key(&unheld));
+        assert!(ctx.project_locks.contains_key(&held));
+
+        drop(guard);
+    }
+}


### PR DESCRIPTION
## Summary

- add daemon lock handler regression tests for current in-memory project lock behavior
- verify `/api/locks/status` reports held project locks while `stale_locks` remains empty until durable stale-lock detection exists
- verify `/api/locks/clear` removes only unheld project-lock entries and preserves held locks
- sync Cargo.lock workspace package versions to the 2.2.30 release manifests so locked Cargo runs are consistent

Refs #603

## Tests

- soldr cargo test -p fbuild-daemon handlers::locks::tests
- soldr cargo test --locked -p fbuild-daemon handlers::locks::tests
- soldr cargo fmt --all --check
- git diff --check