### PR TITLE
test: enforce broker daemon version policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "blake3",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "blake3",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "libc",
  "running-process",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "criterion",
  "rayon",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "bincode",
  "blake3",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "axum",
  "bzip2",
@@ -1093,14 +1093,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "base64",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/crates/fbuild-daemon/src/broker/README.md
+++ b/crates/fbuild-daemon/src/broker/README.md
@@ -33,6 +33,18 @@ consumer); a drift test asserts it equals the `fbuild-paths` copy.
 ## Cache Schema Compatibility
 
 `CACHE_SCHEMA_VERSION` is the compatibility key for fbuild-owned shared artifact
-repository layout. Broker/backend package version is not a cache-owner
-dimension; future resolver policy should compare cache identity plus this schema
-version before reusing an already-running daemon for the same cache root.
+repository layout. Broker/backend package version is not a cache-owner dimension:
+package, toolchain, framework, and managed sidecar artifacts belong to the
+canonical fbuild cache root.
+
+The current broker policy is intentionally strict. The generated
+`ServiceDefinition` publishes a `version_allow_list` containing only the current
+installed fbuild version, so the broker returns a version-block refusal instead
+of spawning or reusing an arbitrary parallel daemon version for the same
+`SHARED_BROKER` cache root. CLI and Python callers treat those refusals as fatal,
+then verify `/api/daemon/info` cache identity plus `CACHE_SCHEMA_VERSION` after a
+successful negotiation.
+
+Future multi-version reuse should relax the allow-list only after fbuild owns an
+explicit cache-schema compatibility matrix and resolver policy for safely sharing
+one artifact repository across daemon versions.

--- a/crates/fbuild-daemon/src/broker/service.rs
+++ b/crates/fbuild-daemon/src/broker/service.rs
@@ -100,6 +100,7 @@ fn shared_broker_builder(daemon_binary: impl AsRef<Path>) -> ServiceDefinitionBu
         daemon_binary.as_ref().display().to_string(),
     )
     .min_version(MIN_VERSION)
+    .allow_version(env!("CARGO_PKG_VERSION"))
     .label("consumer", "fbuild")
     .label("cache-owner", "fbuild-global-artifact-repository")
     .label("cache-identity", identity.label_value())
@@ -121,6 +122,7 @@ fn ci_builder(daemon_binary: impl AsRef<Path>) -> ServiceDefinitionBuilder {
         CI_TRUSTED_INSTANCE,
     )
     .min_version(MIN_VERSION)
+    .allow_version(env!("CARGO_PKG_VERSION"))
     .label("consumer", "fbuild")
     .label("cache-owner", "fbuild-global-artifact-repository")
     .label("cache-schema-version", CACHE_SCHEMA_VERSION.to_string())
@@ -208,6 +210,7 @@ mod tests {
         let def = fbuild_service_definition(abs_daemon()).expect("build shared definition");
         assert_eq!(def.service_name, "fbuild");
         assert_eq!(def.min_version, MIN_VERSION);
+        assert_eq!(def.version_allow_list, [env!("CARGO_PKG_VERSION")]);
         // SHARED_BROKER isolation discriminant.
         assert_eq!(
             def.isolation,
@@ -255,6 +258,8 @@ mod tests {
     fn ci_explicit_instance_service_definition_validates() {
         let def = fbuild_ci_service_definition(abs_daemon()).expect("build ci definition");
         assert_eq!(def.service_name, "fbuild");
+        assert_eq!(def.min_version, MIN_VERSION);
+        assert_eq!(def.version_allow_list, [env!("CARGO_PKG_VERSION")]);
         assert_eq!(def.explicit_instance, CI_TRUSTED_INSTANCE);
         assert_eq!(
             def.isolation,


### PR DESCRIPTION
## Summary

Advances #603 by making the current broker resolver policy explicit and test-covered:

- publish a strict `version_allow_list` containing only the installed fbuild version for both local `SHARED_BROKER` and CI `ci-trusted` service definitions
- assert the allow-list in broker service-definition tests
- document that multi-version daemon reuse must stay disabled until fbuild has an explicit cache-schema compatibility matrix and resolver policy
- sync Cargo.lock workspace package versions after the 2.2.30 release bump so locked Cargo runs work from current main

## Validation

- `soldr cargo test -p fbuild-daemon broker::service::tests`
- `soldr cargo test --locked -p fbuild-daemon broker::service::tests`
- `soldr cargo fmt --all --check`
- `git diff --check`