### PR TITLE
test: guard global artifact root ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "blake3",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "blake3",
  "clap",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "libc",
  "running-process",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "axum",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "criterion",
  "rayon",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "bincode",
  "blake3",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "axum",
  "bzip2",
@@ -1093,14 +1093,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "async-trait",
  "base64",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.29"
+version = "2.2.30"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -543,6 +543,22 @@ mod tests {
     }
 
     #[test]
+    fn managed_zccache_lives_under_mode_root_bin_not_cache_runtime() {
+        let root = fbuild_paths::get_fbuild_root();
+        let cache_root = fbuild_paths::get_cache_root();
+        let dir = managed_dir();
+        let managed_version_dir = format!("zccache-{MANAGED_ZCCACHE_VERSION}");
+
+        assert!(dir.starts_with(root.join("bin")));
+        assert!(!dir.starts_with(&cache_root));
+        assert_eq!(
+            dir.file_name().and_then(|name| name.to_str()),
+            Some(managed_version_dir.as_str())
+        );
+        assert_eq!(managed_zccache_exe().parent(), Some(dir.as_path()));
+    }
+
+    #[test]
     fn sha256_for_asset_parses_dot_slash_entries() {
         let sums = "\
 601f68d19f2bfdc0f277636851dc582989fbcb697c6754952416dd6a2a9b2adb  ./zccache-v1.12.0-x86_64-unknown-linux-musl.tar.gz

--- a/crates/fbuild-packages/src/cache.rs
+++ b/crates/fbuild-packages/src/cache.rs
@@ -352,6 +352,28 @@ mod tests {
     }
 
     #[test]
+    fn global_artifact_roots_stay_under_authoritative_cache_root() {
+        let tmp = TempDir::new().unwrap();
+        let cache_root = tmp.path().join("cache-root");
+        let cache = Cache::with_cache_root(tmp.path(), cache_root.as_path());
+
+        assert_eq!(cache.packages_dir(), cache_root.join("packages"));
+        assert_eq!(cache.toolchains_dir(), cache_root.join("toolchains"));
+        assert_eq!(cache.platforms_dir(), cache_root.join("platforms"));
+        assert_eq!(cache.libraries_dir(), cache_root.join("libraries"));
+        assert_eq!(cache.core_artifacts_dir(), cache_root.join("core"));
+        assert!(cache
+            .get_package_path("https://example.test/pkg.tar.gz", "1.0.0")
+            .starts_with(cache_root.join("packages")));
+        assert!(cache
+            .get_toolchain_path("https://example.test/tool.tar.gz", "1.0.0")
+            .starts_with(cache_root.join("toolchains")));
+        assert!(cache
+            .get_platform_path("https://example.test/platform.tar.gz", "1.0.0")
+            .starts_with(cache_root.join("platforms")));
+    }
+
+    #[test]
     fn test_get_package_path_with_stem_hash() {
         let tmp = TempDir::new().unwrap();
         let cache = Cache::with_cache_root(tmp.path(), tmp.path().join("cache").as_path());

--- a/docs/running-process/inventory.md
+++ b/docs/running-process/inventory.md
@@ -16,7 +16,7 @@ payload-protocol registration: zackees/running-process#440.
 | **daemon model** | A single **persistent per-user daemon** (`fbuild-daemon`), an axum HTTP/WebSocket server. The CLI spawns it detached (`ensure_daemon_running`) and it self-evicts on idle. It is **not** one-worker-per-build and **not** direct child processes. Dev/prod isolation: `FBUILD_DEV_MODE=1` → port 8865 + `~/.fbuild/dev/`; prod → port 8765 + `~/.fbuild/prod/`. |
 | **request wire** | **JSON over loopback HTTP** (`http://127.0.0.1:<port>`). Requests are `serde_json`-serialized structs POSTed to fixed paths: `/api/build`, `/api/deploy`, `/api/monitor`, `/api/test-emu`, plus `GET /api/daemon/info`, `GET /api/cache/stats`, `POST /api/cache/gc`, `GET /api/locks/status`, `GET /health`. Build supports an NDJSON streaming variant. **No explicit protocol-version constant exists today** — compatibility is the implicit "same endpoints + JSON schemas as the Python FastAPI daemon" contract (see `crates/fbuild-daemon/README.md`). This PR introduces an explicit `FBUILD_PROTOCOL_VERSION = 1` for the fbuild payload schema. |
 | **response wire** | **JSON** (`OperationResponse`, `DaemonInfoResponse`, `CacheStatsResponse`, …). Error envelope: non-2xx HTTP status with a JSON body (or a plain `OperationResponse { success: false, message }`). Retry behavior: the **client** retries daemon *spawn* with backoff `[0.0s, 0.5s, 2.0s]` and polls `/health`; individual RPCs are not auto-retried (the 100 ms connect-timeout fails fast on ECONNREFUSED). |
-| **cache roots** | Resolved from `fbuild-paths`: **artifact** = `get_cache_root()` (`~/.fbuild/<mode>/cache`, or `FBUILD_CACHE_DIR`); **index** = `<cache>/index`; **temp** = `<fbuild_root>/tmp`; **log** = daemon dir (`~/.fbuild/<mode>/daemon/daemon.log`); **lock** = daemon dir (`fbuild_daemon.pid`, `daemon.port`, in-memory project/port locks) plus per-install lock dirs co-located with package/toolchain/framework final install paths; **runtime** = directory holding the relocated `fbuild-daemon` binary; **config** = `get_fbuild_root()` (`~/.fbuild/<mode>`). The artifact root is the ownership boundary for large shared packages/toolchains/frameworks/sidecars. Runtime is provenance only and must not fork artifact ownership by daemon version. |
+| **cache roots** | Resolved from `fbuild-paths`: **artifact** = `get_cache_root()` (`~/.fbuild/<mode>/cache`, or `FBUILD_CACHE_DIR`); **index** = `<cache>/index`; **temp** = `<fbuild_root>/tmp`; **log** = daemon dir (`~/.fbuild/<mode>/daemon/daemon.log`); **lock** = daemon dir (`fbuild_daemon.pid`, `daemon.port`, in-memory project/port locks) plus per-install lock dirs co-located with package/toolchain/framework final install paths; **runtime** = directory holding the relocated `fbuild-daemon` binary; **config** = `get_fbuild_root()` (`~/.fbuild/<mode>`). The artifact root owns large shared package/toolchain/framework/cache artifacts. Managed sidecar binaries such as zccache live under `<fbuild_root>/bin/` and are shared by mode/trust domain, not by broker backend version. Runtime is provenance only and must not fork artifact ownership by daemon version. |
 | **CI trust grouping** | Local dev = a single per-user shared cache (`SHARED_BROKER`). CI jobs that intentionally isolate trust groups use a dedicated `EXPLICIT_INSTANCE` named **`ci-trusted`** so a poisoned/untrusted job cannot reach another group's negotiated backend. |
 | **rollback path** | `RUNNING_PROCESS_DISABLE=1` selects the legacy direct loopback-HTTP path (`DaemonClient`). `FbuildBrokerSession::adopt` honours it first and returns `AdoptOutcome::UseDirectPath` without dialing the broker. (`FBUILD_RUNNING_PROCESS_BROKER=1` remains the opt-in broker request flag from the prior minimal seam.) |
 
@@ -45,6 +45,25 @@ Package/toolchain/framework installs take a process-shared sibling lock before
 network fetch or extraction begins, then re-check the final install path while
 holding that lock. This keeps different projects or daemon processes from
 duplicating large downloads for the same global artifact root.
+
+### Global Artifact Ownership
+
+The following paths are fbuild-owned and must not gain broker-instance or daemon
+package-version path segments:
+
+| Root | Owner | Shared across daemon versions? |
+|---|---|---|
+| `get_cache_root()/packages` | downloaded and extracted package archives | yes, subject to cache schema compatibility |
+| `get_cache_root()/toolchains` | toolchain archives, metadata, and extracted toolchains | yes, subject to cache schema compatibility |
+| `get_cache_root()/platforms` | platform packages | yes, subject to cache schema compatibility |
+| `get_cache_root()/libraries` | library and framework packages | yes, subject to cache schema compatibility |
+| `get_cache_root()/core` | shared compiled core artifacts | yes, subject to cache schema compatibility |
+| `get_cache_root()/index` | disk-cache index and migration state | yes only when schema checks pass |
+| `get_fbuild_root()/bin/zccache-<version>` | managed zccache sidecar binaries | yes for the mode/trust domain; independent of broker runtime |
+| `get_fbuild_root()/tmp` | shared staging/temp area | yes, guarded by install locks and atomic finalization |
+| `get_daemon_dir()` | daemon PID, port, status, and log files | no; daemon-state/provenance only |
+| broker `CacheRuntime` | relocated `fbuild-daemon` binary directory | no; provenance only |
+| `get_fbuild_root()` | mode config root | yes for local shared mode, separated by CI trust domain |
 
 Dependency installs publish best-effort phase updates (`waiting_for_lock`,
 `downloading`, `verifying`, `extracting`, `installed`) through daemon status.


### PR DESCRIPTION
## Summary
- advances #603 by documenting the global artifact ownership contract
- adds a package cache test that keeps packages, toolchains, platforms, libraries, and core artifacts under the authoritative cache root
- adds a managed zccache path test that keeps the sidecar under the mode root bin directory, outside cache/runtime provenance
- syncs Cargo.lock package versions to the existing 2.2.30 manifest versions

## Tests
- soldr cargo test --locked -p fbuild-packages global_artifact_roots_stay_under_authoritative_cache_root
- soldr cargo test --locked -p fbuild-build managed_zccache_lives_under_mode_root_bin_not_cache_runtime
- soldr cargo fmt --all --check
- git diff --check

Reference #603