### PR TITLE
chore: bump managed zccache to 1.12.8

### DIFF
--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -24,12 +24,12 @@ use fbuild_core::{FbuildError, Result};
 
 /// The zccache release fbuild pins. Bump in lockstep with the floor that
 /// the rest of the toolchain expects.
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.7";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.8";
 
 /// GitHub release tag for [`MANAGED_ZCCACHE_VERSION`]. The zccache release
 /// workflow tags without a `v` prefix, while the per-asset filenames carry
 /// `v<version>` — keep both spellings in sync when bumping.
-const RELEASE_TAG: &str = "1.12.7";
+const RELEASE_TAG: &str = "1.12.8";
 
 /// Source repository for managed downloads.
 const REPO: &str = "zackees/zccache";

--- a/crates/fbuild-daemon/src/models.rs
+++ b/crates/fbuild-daemon/src/models.rs
@@ -799,11 +799,11 @@ mod tests {
             current_operation: Some("Building /tmp/myproject".into()),
             dependency_install: Some(fbuild_core::install_status::status(
                 "zccache",
-                Some("1.12.7"),
+                Some("1.12.8"),
                 fbuild_core::install_status::InstallPhase::WaitingForLock,
                 fbuild_core::install_status::InstallRole::Waiter,
                 "waiting for managed zccache",
-                Some(".zccache-1.12.7.install.lock"),
+                Some(".zccache-1.12.8.install.lock"),
             )),
             client_count: 1,
             cache_dir: "/tmp/cache".into(),


### PR DESCRIPTION
## Summary
- bump fbuild's managed zccache pin from 1.12.7 to 1.12.8
- update daemon status model test expectations for the new lock/version string

## Release Check
- GitHub release `zackees/zccache@1.12.8` is the latest non-prerelease release, published 2026-06-16T09:01:56Z
- release assets include the expected Windows, macOS, and Linux non-debug archives plus `SHA256SUMS`
- the ignored managed-zccache network test successfully downloaded, checksum-verified, and extracted the pinned 1.12.8 release

## Tests
- `soldr cargo fmt --all --check`
- `soldr cargo test --locked -p fbuild-build managed_zccache --lib`
- `soldr cargo test --locked -p fbuild-build managed_zccache::tests::ensure_downloads_and_extracts_real_release --lib -- --ignored`
- `soldr cargo test --locked -p fbuild-daemon dependency_install --lib`
- `git diff --check`