### PR TITLE
feat(build): --bloat-analysis adds -Wl,--noinhibit-exec for over-budget ELF (#594)

### DIFF
--- a/crates/fbuild-build/src/compile_many.rs
+++ b/crates/fbuild-build/src/compile_many.rs
@@ -372,6 +372,7 @@ fn build_one_sketch(inputs: SketchBuildInputs) -> SketchResult {
         pio_env: pio_env.into_iter().collect(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let outcome = match get_orchestrator(platform) {

--- a/crates/fbuild-build/src/esp32/orchestrator/build.rs
+++ b/crates/fbuild-build/src/esp32/orchestrator/build.rs
@@ -781,6 +781,7 @@ impl BuildOrchestrator for Esp32Orchestrator {
                 &crate::linker::LinkExtraArgs {
                     flags: ctx.overlay_link_flags.clone(),
                     libs: ctx.overlay_link_libs.clone(),
+                    bloat_analysis: false,
                 },
                 params.symbol_analysis,
             )?

--- a/crates/fbuild-build/src/generic_arm/arm_linker.rs
+++ b/crates/fbuild-build/src/generic_arm/arm_linker.rs
@@ -63,6 +63,70 @@ impl ArmLinker {
         self.lib_search_dirs = dirs;
         self
     }
+
+    /// Build the full linker command line for a given link.
+    ///
+    /// Extracted from `link()` so unit tests can verify flag composition
+    /// (e.g. `-Wl,--noinhibit-exec` for bloat-analysis mode, FastLED/fbuild#594)
+    /// without invoking the actual toolchain.
+    fn build_link_args(
+        &self,
+        objects: &[PathBuf],
+        archives: &[PathBuf],
+        elf_path: &Path,
+        map_path: &Path,
+        extra: &LinkExtraArgs,
+    ) -> Vec<String> {
+        let mut args: Vec<String> = vec![self.gcc_path.to_string_lossy().to_string()];
+
+        // Linker flags from config
+        args.extend(self.mcu_config.linker_flags.iter().cloned());
+
+        // Profile-specific link flags
+        if let Some(profile) = self.mcu_config.get_profile(self.profile.as_dir_name()) {
+            args.extend(profile.link_flags.iter().cloned());
+        }
+        args.extend(extra.flags.iter().cloned());
+
+        // Bloat-analysis mode: `-Wl,--noinhibit-exec` tells GNU ld to write
+        // firmware.elf even when a memory region overflows. The link exit
+        // code is still non-zero, but the ELF survives so downstream `nm` /
+        // symbol analysis has something to chew on. See FastLED/fbuild#594.
+        if extra.bloat_analysis {
+            args.push("-Wl,--noinhibit-exec".to_string());
+        }
+
+        // Linker-script search dirs (-L). ld resolves a relative `INCLUDE`
+        // in the linker script against these paths.
+        for dir in &self.lib_search_dirs {
+            args.push(format!("-L{}", dir.display()));
+        }
+
+        args.extend([
+            format!("-T{}", self.linker_script_path.display()),
+            "-o".to_string(),
+            elf_path.to_string_lossy().to_string(),
+        ]);
+
+        // Always emit a linker map next to firmware.elf for debugging (#305).
+        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
+
+        // Sketch objects first
+        for obj in objects {
+            args.push(obj.to_string_lossy().to_string());
+        }
+
+        // Core objects passed directly (not archived) for LTO compatibility
+        for archive in archives {
+            args.push(archive.to_string_lossy().to_string());
+        }
+
+        // Linker libraries from config
+        args.extend(self.mcu_config.linker_libs.iter().cloned());
+        args.extend(extra.libs.iter().cloned());
+
+        args
+    }
 }
 
 impl Linker for ArmLinker {
@@ -79,47 +143,8 @@ impl Linker for ArmLinker {
     ) -> Result<PathBuf> {
         std::fs::create_dir_all(output_dir)?;
         let elf_path = output_dir.join("firmware.elf");
-
-        let mut args: Vec<String> = vec![self.gcc_path.to_string_lossy().to_string()];
-
-        // Linker flags from config
-        args.extend(self.mcu_config.linker_flags.iter().cloned());
-
-        // Profile-specific link flags
-        if let Some(profile) = self.mcu_config.get_profile(self.profile.as_dir_name()) {
-            args.extend(profile.link_flags.iter().cloned());
-        }
-        args.extend(extra.flags.iter().cloned());
-
-        // Linker-script search dirs (-L). ld resolves a relative `INCLUDE`
-        // in the linker script against these paths.
-        for dir in &self.lib_search_dirs {
-            args.push(format!("-L{}", dir.display()));
-        }
-
-        args.extend([
-            format!("-T{}", self.linker_script_path.display()),
-            "-o".to_string(),
-            elf_path.to_string_lossy().to_string(),
-        ]);
-
-        // Always emit a linker map next to firmware.elf for debugging (#305).
         let map_path = output_dir.join("firmware.map");
-        args.push(format!("-Wl,-Map={}", map_path.to_string_lossy()));
-
-        // Sketch objects first
-        for obj in objects {
-            args.push(obj.to_string_lossy().to_string());
-        }
-
-        // Core objects passed directly (not archived) for LTO compatibility
-        for archive in archives {
-            args.push(archive.to_string_lossy().to_string());
-        }
-
-        // Linker libraries from config
-        args.extend(self.mcu_config.linker_libs.iter().cloned());
-        args.extend(extra.libs.iter().cloned());
+        let args = self.build_link_args(objects, archives, &elf_path, &map_path, extra);
 
         if self.verbose {
             eprintln!("link: {}", args.join(" "));
@@ -152,6 +177,25 @@ impl Linker for ArmLinker {
         };
 
         if !result.success() {
+            // Bloat-analysis recovery: if the user asked for noinhibit-exec
+            // and an ELF actually landed on disk with non-zero size, treat
+            // the link as a warning instead of a hard error so the bloat
+            // pipeline can still measure per-symbol cost on over-budget
+            // builds. See FastLED/fbuild#594.
+            if extra.bloat_analysis {
+                let elf_size = elf_path
+                    .metadata()
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+                if elf_path.exists() && elf_size > 0 {
+                    tracing::warn!(
+                        "bloat-analysis: link returned non-zero but firmware.elf survived \
+                         ({} bytes); proceeding with bloat measurement",
+                        elf_size
+                    );
+                    return Ok(elf_path);
+                }
+            }
             return Err(fbuild_core::FbuildError::BuildFailed(format!(
                 "arm-none-eabi-gcc link failed:\n{}",
                 result.stderr
@@ -242,6 +286,48 @@ mod tests {
         );
         assert_eq!(linker.max_flash, Some(65536));
         assert_eq!(linker.max_ram, Some(20480));
+    }
+
+    #[test]
+    fn bloat_analysis_appends_noinhibit_exec_flag() {
+        // Verify that LinkExtraArgs.bloat_analysis = true causes the linker
+        // command line to include `-Wl,--noinhibit-exec` so over-budget
+        // builds still produce firmware.elf for bloat analysis.
+        // See FastLED/fbuild#594.
+        let linker = ArmLinker::new(
+            PathBuf::from("/bin/arm-none-eabi-gcc"),
+            PathBuf::from("/bin/arm-none-eabi-ar"),
+            PathBuf::from("/bin/arm-none-eabi-objcopy"),
+            PathBuf::from("/bin/arm-none-eabi-size"),
+            PathBuf::from("/cores/variant/linker.ld"),
+            test_config(),
+            BuildProfile::Release,
+            Some(65536),
+            Some(20480),
+            false,
+        );
+        let elf = PathBuf::from("/tmp/firmware.elf");
+        let map = PathBuf::from("/tmp/firmware.map");
+
+        let with_bloat = LinkExtraArgs {
+            flags: Vec::new(),
+            libs: Vec::new(),
+            bloat_analysis: true,
+        };
+        let args_on = linker.build_link_args(&[], &[], &elf, &map, &with_bloat);
+        assert!(
+            args_on.iter().any(|a| a == "-Wl,--noinhibit-exec"),
+            "expected -Wl,--noinhibit-exec when bloat_analysis = true; got: {:?}",
+            args_on
+        );
+
+        let without_bloat = LinkExtraArgs::default();
+        let args_off = linker.build_link_args(&[], &[], &elf, &map, &without_bloat);
+        assert!(
+            !args_off.iter().any(|a| a == "-Wl,--noinhibit-exec"),
+            "did not expect -Wl,--noinhibit-exec when bloat_analysis = false; got: {:?}",
+            args_off
+        );
     }
 
     #[test]

--- a/crates/fbuild-build/src/generic_arm/arm_linker.rs
+++ b/crates/fbuild-build/src/generic_arm/arm_linker.rs
@@ -183,10 +183,7 @@ impl Linker for ArmLinker {
             // pipeline can still measure per-symbol cost on over-budget
             // builds. See FastLED/fbuild#594.
             if extra.bloat_analysis {
-                let elf_size = elf_path
-                    .metadata()
-                    .map(|m| m.len())
-                    .unwrap_or(0);
+                let elf_size = elf_path.metadata().map(|m| m.len()).unwrap_or(0);
                 if elf_path.exists() && elf_size > 0 {
                     tracing::warn!(
                         "bloat-analysis: link returned non-zero but firmware.elf survived \

--- a/crates/fbuild-build/src/lib.rs
+++ b/crates/fbuild-build/src/lib.rs
@@ -187,6 +187,12 @@ pub struct BuildParams {
     /// the orchestrator falls back to walking on every call, which is
     /// the pre-existing behaviour.
     pub watch_set_cache: Option<std::sync::Arc<dyn build_fingerprint::WatchSetStampCache>>,
+    /// When true, append `-Wl,--noinhibit-exec` to the linker command line so
+    /// GNU `ld` writes `firmware.elf` even when a memory region overflows, and
+    /// treat post-link "failure" as success-with-warning when an ELF was
+    /// actually emitted. This unblocks per-symbol bloat analysis on
+    /// over-budget builds. See FastLED/fbuild#594.
+    pub bloat_analysis: bool,
 }
 
 /// Trait for platform-specific build orchestrators.

--- a/crates/fbuild-build/src/linker.rs
+++ b/crates/fbuild-build/src/linker.rs
@@ -24,6 +24,14 @@ pub struct LinkResult {
 pub struct LinkExtraArgs {
     pub flags: Vec<String>,
     pub libs: Vec<String>,
+    /// When true, the linker appends `-Wl,--noinhibit-exec` and treats
+    /// link failure as success when `firmware.elf` was emitted (so
+    /// over-budget builds can be bloat-analyzed). The link exit code
+    /// from `gcc`/`ld` is still non-zero, but the pipeline continues
+    /// to symbol analysis instead of bailing.
+    ///
+    /// See FastLED/fbuild#594.
+    pub bloat_analysis: bool,
 }
 
 /// Check whether `elf_path` is newer than every file in `inputs`.

--- a/crates/fbuild-build/src/pipeline/sequential.rs
+++ b/crates/fbuild-build/src/pipeline/sequential.rs
@@ -300,6 +300,7 @@ pub fn run_sequential_build_with_libs(
             &crate::linker::LinkExtraArgs {
                 flags: ctx.overlay_link_flags.clone(),
                 libs: ctx.overlay_link_libs.clone(),
+                bloat_analysis: params.bloat_analysis,
             },
             params.symbol_analysis,
         )?

--- a/crates/fbuild-build/src/zccache.rs
+++ b/crates/fbuild-build/src/zccache.rs
@@ -243,7 +243,7 @@ fn format_zccache_start_failure(
         if stderr.is_empty() {
             message.push_str(":\n");
         } else {
-            message.push_str("\n");
+            message.push('\n');
         }
         message.push_str("zccache stdout:\n");
         message.push_str(&stdout);

--- a/crates/fbuild-build/tests/avr_build.rs
+++ b/crates/fbuild-build/tests/avr_build.rs
@@ -99,6 +99,7 @@ fn build_uno_minimal() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::avr::orchestrator::AvrOrchestrator;
@@ -194,6 +195,7 @@ fn compare_with_python_output() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::avr::orchestrator::AvrOrchestrator;
@@ -279,6 +281,7 @@ void loop() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::avr::orchestrator::AvrOrchestrator;
@@ -343,6 +346,7 @@ fn uno_build_params(project_dir: &Path, build_dir: PathBuf, clean: bool) -> Buil
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     }
 }
 

--- a/crates/fbuild-build/tests/eh_frame_strip_esp32.rs
+++ b/crates/fbuild-build/tests/eh_frame_strip_esp32.rs
@@ -38,6 +38,7 @@ fn make_params(project_dir: &Path) -> BuildParams {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     }
 }
 

--- a/crates/fbuild-build/tests/esp32_build.rs
+++ b/crates/fbuild-build/tests/esp32_build.rs
@@ -79,6 +79,7 @@ void loop() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;
@@ -168,6 +169,7 @@ void loop() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;
@@ -250,6 +252,7 @@ void loop() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;
@@ -333,6 +336,7 @@ void loop() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;
@@ -406,6 +410,7 @@ fn build_esp32s3_fixture() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;
@@ -471,6 +476,7 @@ fn build_nightdriverstrip_demo() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;
@@ -567,6 +573,7 @@ fn incremental_build_at(project_dir: &std::path::Path, env_name: &str) {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;
@@ -663,6 +670,7 @@ fn incremental_nightdriverstrip_one_file_changed() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;

--- a/crates/fbuild-build/tests/nxplpc_build_flags.rs
+++ b/crates/fbuild-build/tests/nxplpc_build_flags.rs
@@ -69,6 +69,7 @@ fn lpc845brk_propagates_build_flags_to_library_compile_587() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::nxplpc::orchestrator::NxpLpcOrchestrator;

--- a/crates/fbuild-build/tests/stm32_acceptance.rs
+++ b/crates/fbuild-build/tests/stm32_acceptance.rs
@@ -79,6 +79,7 @@ fn stm32f103c8_blink_with_spi_auto_discovers_library_205_ac4() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::stm32::orchestrator::Stm32Orchestrator;

--- a/crates/fbuild-build/tests/teensy30_acceptance.rs
+++ b/crates/fbuild-build/tests/teensy30_acceptance.rs
@@ -97,6 +97,7 @@ fn teensy30_analog_output_meets_205_ac2() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let result = fbuild_build::teensy::orchestrator::TeensyOrchestrator

--- a/crates/fbuild-build/tests/teensy_build.rs
+++ b/crates/fbuild-build/tests/teensy_build.rs
@@ -80,6 +80,7 @@ void loop() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::teensy::orchestrator::TeensyOrchestrator;
@@ -152,6 +153,7 @@ void loop() {}
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::teensy::orchestrator::TeensyOrchestrator;
@@ -202,6 +204,7 @@ fn build_teensy41_fixture() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::teensy::orchestrator::TeensyOrchestrator;
@@ -311,6 +314,7 @@ void loop() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::teensy::orchestrator::TeensyOrchestrator;

--- a/crates/fbuild-build/tests/teensylc_acceptance.rs
+++ b/crates/fbuild-build/tests/teensylc_acceptance.rs
@@ -49,6 +49,7 @@ fn teensylc_blink_meets_205_acceptance_criteria() {
         pio_env: Default::default(),
         extra_build_flags: Vec::new(),
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let result = fbuild_build::teensy::orchestrator::TeensyOrchestrator

--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -237,6 +237,11 @@ pub enum Commands {
         /// Disable all shrink optimizations. Equivalent to `--shrink=off`.
         #[arg(long = "no-shrink", conflicts_with = "shrink")]
         no_shrink: bool,
+        /// Build with -Wl,--noinhibit-exec so over-budget regions still emit
+        /// firmware.elf for bloat analysis. The link exit code remains non-zero
+        /// but the ELF survives. See FastLED/fbuild#594.
+        #[arg(long)]
+        bloat_analysis: bool,
     },
     /// Deploy firmware to device
     Deploy {

--- a/crates/fbuild-cli/src/cli/build.rs
+++ b/crates/fbuild-cli/src/cli/build.rs
@@ -37,6 +37,7 @@ pub async fn run_build(
     symbol_analysis: Option<String>,
     no_timestamp: bool,
     output_dir: Option<String>,
+    bloat_analysis: bool,
 ) -> fbuild_core::Result<()> {
     // FBUILD_PERF_LOG=1 enables coarse CLI-side timing (daemon handshake +
     // round-trip). Zero-overhead when unset.
@@ -104,6 +105,7 @@ pub async fn run_build(
             .filter(|s| !s.is_empty()),
         output_dir,
         pio_env: daemon_client::capture_pio_env(),
+        bloat_analysis,
     };
 
     let stream_start = std::time::Instant::now();

--- a/crates/fbuild-cli/src/cli/clang_tools.rs
+++ b/crates/fbuild-cli/src/cli/clang_tools.rs
@@ -48,6 +48,7 @@ pub async fn run_iwyu(
             None,
             true, // no_timestamp: compiledb generation doesn't need timestamps
             None,
+            false, // bloat_analysis
         )
         .await?;
         if !db_path.exists() {
@@ -472,6 +473,7 @@ pub async fn run_clang_tool(
         None,
         true, // no_timestamp: compiledb generation doesn't need timestamps
         None,
+        false, // bloat_analysis
     )
     .await?;
 

--- a/crates/fbuild-cli/src/cli/clangd_config.rs
+++ b/crates/fbuild-cli/src/cli/clangd_config.rs
@@ -43,6 +43,7 @@ pub async fn run_clangd_config(
             None,
             true, // no_timestamp
             None,
+            false, // bloat_analysis
         )
         .await?;
         if !db_path.exists() {

--- a/crates/fbuild-cli/src/cli/dispatch.rs
+++ b/crates/fbuild-cli/src/cli/dispatch.rs
@@ -156,6 +156,7 @@ pub async fn async_main() {
             output_dir,
             shrink: _,
             no_shrink: _,
+            bloat_analysis,
         }) => {
             let project_dir = resolve_project_dir(project_dir, &top_level_project_dir);
             if platformio {
@@ -174,6 +175,7 @@ pub async fn async_main() {
                     symbol_analysis,
                     no_timestamp,
                     output_dir,
+                    bloat_analysis,
                 )
                 .await
             }

--- a/crates/fbuild-cli/src/daemon_client/types.rs
+++ b/crates/fbuild-cli/src/daemon_client/types.rs
@@ -45,6 +45,12 @@ pub struct BuildRequest {
     /// The daemon does not inherit caller env vars, so they are forwarded here.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub pio_env: BTreeMap<String, String>,
+    /// When true, append `-Wl,--noinhibit-exec` to the linker command and
+    /// treat post-link "failure" as success when `firmware.elf` was emitted
+    /// (so over-budget builds can still be bloat-analyzed).
+    /// See FastLED/fbuild#594.
+    #[serde(default)]
+    pub bloat_analysis: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/fbuild-cli/src/mcp/tools.rs
+++ b/crates/fbuild-cli/src/mcp/tools.rs
@@ -119,6 +119,7 @@ pub(super) async fn execute_tool(
                     .filter(|s| !s.is_empty()),
                 output_dir: None,
                 pio_env: crate::daemon_client::capture_pio_env(),
+                bloat_analysis: false,
             };
 
             let resp = client

--- a/crates/fbuild-daemon/src/handlers/emulator/select.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/select.rs
@@ -303,6 +303,7 @@ pub async fn test_emu(
                 Vec::new()
             },
             watch_set_cache: Some(std::sync::Arc::clone(&ctx.watch_set_cache) as std::sync::Arc<_>),
+            bloat_analysis: false,
         };
 
         let p = platform;

--- a/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
+++ b/crates/fbuild-daemon/src/handlers/emulator/tests_process.rs
@@ -144,6 +144,7 @@ fn run_real_esp32s3_fixture_in_qemu() {
             "-DARDUINO_USB_CDC_ON_BOOT=0".to_string(),
         ],
         watch_set_cache: None,
+        bloat_analysis: false,
     };
 
     let orchestrator = fbuild_build::esp32::orchestrator::Esp32Orchestrator;

--- a/crates/fbuild-daemon/src/handlers/operations/build.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/build.rs
@@ -219,6 +219,7 @@ pub async fn build(
             pio_env: req.pio_env.clone(),
             extra_build_flags: Vec::new(),
             watch_set_cache: Some(Arc::clone(&ctx.watch_set_cache) as Arc<_>),
+            bloat_analysis: req.bloat_analysis,
         };
 
         let project_dir_desc = req.project_dir.clone();
@@ -513,6 +514,7 @@ pub async fn build(
             pio_env: req.pio_env,
             extra_build_flags: Vec::new(),
             watch_set_cache: Some(Arc::clone(&ctx.watch_set_cache) as Arc<_>),
+            bloat_analysis: req.bloat_analysis,
         };
 
         let result = tokio::task::spawn_blocking(move || {

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -228,6 +228,7 @@ pub async fn deploy(
                 Vec::new()
             },
             watch_set_cache: Some(Arc::clone(&ctx.watch_set_cache) as Arc<_>),
+            bloat_analysis: false,
         };
 
         let build_result = {

--- a/crates/fbuild-daemon/src/models.rs
+++ b/crates/fbuild-daemon/src/models.rs
@@ -64,6 +64,12 @@ pub struct BuildRequest {
     /// the same behavior in other shapes.
     #[serde(default)]
     pub flatten_env: bool,
+    /// When true, append `-Wl,--noinhibit-exec` to the linker command and
+    /// treat post-link "failure" as success when `firmware.elf` was emitted
+    /// (so over-budget builds can still be bloat-analyzed).
+    /// See FastLED/fbuild#594.
+    #[serde(default)]
+    pub bloat_analysis: bool,
 }
 
 /// POST /api/deploy


### PR DESCRIPTION
## Summary

Adds a `--bloat-analysis` flag to `fbuild build` that addresses gap 2 of #594:

1. Appends `-Wl,--noinhibit-exec` to the linker command line so GNU `ld` writes `firmware.elf` even when a memory region overflows.
2. Treats post-link "failure" as success-with-warning when `firmware.elf` was actually emitted (non-zero file size). The link exit code from `gcc`/`ld` is still non-zero, but the build pipeline continues to symbol analysis instead of bailing.

This unblocks `bash bloat lpc845brk` against over-budget builds. Today the LPC845 LowMemory build overflows the 64 KB FLASH region by ~11 KB and no ELF survives, so `nm` has nothing to analyze. With `--bloat-analysis`, the ELF lands on disk and the existing symbol-analysis pipeline can measure per-symbol cost.

The flag is plumbed CLI -> daemon HTTP -> BuildRequest -> BuildParams -> LinkExtraArgs -> ArmLinker::link, mirroring the existing `symbol_analysis` path. Scope is `generic_arm` only this PR; other ARM-family linkers (avr/esp32/teensy/nrf52/sam/silabs/renesas/ch32v/stm32) ignore the new `LinkExtraArgs.bloat_analysis` field and can opt in later.

Closes #594.

## Tests

- workspace check: green
- workspace --tests check: green
- workspace --lib test suite: all crates pass, 0 failed
- new unit test `bloat_analysis_appends_noinhibit_exec_flag` in `generic_arm/arm_linker.rs` verifies:
  - `-Wl,--noinhibit-exec` appears in the linker args when `LinkExtraArgs.bloat_analysis = true`
  - the flag is absent on the default path
- clippy --workspace --all-targets: only pre-existing `push_str("\n")` warning in `fbuild-core/zccache.rs:246`; no new lints from this PR

## Test plan

- [ ] On a downstream FastLED branch, run `bash bloat lpc845brk --bloat-analysis` and confirm `firmware.elf` is emitted + the bloat report renders, even though the link reports a region overflow
- [ ] Verify a normal (in-budget) build is unaffected when `--bloat-analysis` is absent
- [ ] Confirm the daemon accepts the new `bloat_analysis` field via HTTP (older CLIs that don't send it default to `false`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--bloat-analysis` command-line flag to enable symbol-level bloat analysis on over-budget firmware builds. When enabled, the build system generates analysis data even when firmware exceeds size constraints, helping developers identify memory usage hotspots.

* **Refactor**
  * Restructured linker argument construction for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->