### PR TITLE
fix(deploy): select default port by USB identity

### DIFF
--- a/crates/fbuild-build/src/zccache.rs
+++ b/crates/fbuild-build/src/zccache.rs
@@ -243,7 +243,7 @@ fn format_zccache_start_failure(
         if stderr.is_empty() {
             message.push_str(":\n");
         } else {
-            message.push_str("\n");
+            message.push('\n');
         }
         message.push_str("zccache stdout:\n");
         message.push_str(&stdout);

--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -5,6 +5,7 @@ use super::common::{
     parse_deploy_route, qemu_extra_build_flags, resolve_build_dir, resolve_client_path,
     trust_device_hash_enabled, DeployRoute, EmulatorKind, OperationGuard,
 };
+use super::deploy_port::{append_warning_to_stderr, choose_deploy_port};
 use super::monitor::{run_monitor_loop, MonitorOutcome};
 use crate::context::DaemonContext;
 use crate::models::{DeployRequest, OperationResponse};
@@ -361,30 +362,27 @@ pub async fn deploy(
         .await;
     }
 
-    // Preempt serial if port specified
-    let deploy_port_str = req.port.clone();
+    let deploy_port_choice = if req.port.is_none() {
+        ctx.device_manager.refresh_devices();
+        choose_deploy_port(
+            None,
+            platform,
+            board.as_ref(),
+            ctx.device_manager.get_all_devices().into_values().collect(),
+        )
+    } else {
+        choose_deploy_port(req.port.clone(), platform, board.as_ref(), Vec::new())
+    };
+    let deploy_port_warning = deploy_port_choice.warning.clone();
+
+    // Preempt serial if port specified or auto-selected.
+    let deploy_port_str = deploy_port_choice.port;
     if let Some(ref p) = deploy_port_str {
         let _ = ctx
             .serial_manager
             .preempt_for_deploy(p, "deploy".to_string(), request_id.clone())
             .await;
     }
-
-    // Extract board ID before spawn_blocking (env_config borrows config)
-    let board_id = env_config.get("board").cloned().unwrap_or_else(|| {
-        fbuild_build::get_platform_support(platform)
-            .map(|s| s.default_board_id().to_string())
-            .unwrap_or_else(|_| "unknown".to_string())
-    });
-
-    // Extract env-section board_build.* / board_upload.* overrides BEFORE
-    // spawn_blocking (env_config borrows config). Without these, fbuild
-    // would silently ignore `board_build.flash_mode = dio` (and friends)
-    // from the user's [env:X] section and fall back to whatever the board
-    // JSON says — producing a firmware/bootloader that doesn't match the
-    // hardware. The build phase already passes overrides; the deploy phase
-    // must do the same so esptool flashes with the right --flash-mode.
-    let board_overrides = config.get_board_overrides(&env_name).unwrap_or_default();
 
     // Deploy
     let deploy_env = env_name.clone();
@@ -780,7 +778,7 @@ pub async fn deploy(
         }
     }
 
-    let (deploy_success, deploy_stdout, deploy_stderr, deploy_outcome, deploy_post_port) =
+    let (deploy_success, deploy_stdout, mut deploy_stderr, deploy_outcome, deploy_post_port) =
         match deploy_result {
             Ok(Ok(r)) if r.success => (true, Some(r.stdout), Some(r.stderr), r.outcome, r.port),
             Ok(Ok(r)) => {
@@ -818,6 +816,7 @@ pub async fn deploy(
                 );
             }
         };
+    append_warning_to_stderr(&mut deploy_stderr, deploy_port_warning);
     // Build the "deploy succeeded (...)" prefix used by every
     // monitor-attached and non-monitor-attached response below. Stable
     // wording — see GitHub issue #76 and the DeployOutcome::describe

--- a/crates/fbuild-daemon/src/handlers/operations/deploy_port.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy_port.rs
@@ -1,0 +1,263 @@
+use crate::device_manager::DeviceState;
+use fbuild_config::BoardConfig;
+use fbuild_core::Platform;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DeployPortChoice {
+    pub port: Option<String>,
+    pub warning: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PortCandidate {
+    port: String,
+    vid: Option<u16>,
+    pid: Option<u16>,
+    description: String,
+}
+
+pub(super) fn choose_deploy_port(
+    requested: Option<String>,
+    platform: Platform,
+    board: Option<&BoardConfig>,
+    devices: Vec<DeviceState>,
+) -> DeployPortChoice {
+    if requested.is_some() {
+        return DeployPortChoice {
+            port: requested,
+            warning: None,
+        };
+    }
+
+    let expected_vids = expected_vids(platform, board);
+    if expected_vids.is_empty() {
+        return DeployPortChoice {
+            port: None,
+            warning: None,
+        };
+    }
+
+    let mut candidates: Vec<_> = devices
+        .into_iter()
+        .filter(|d| d.is_connected)
+        .map(|d| PortCandidate {
+            port: d.port,
+            vid: d.vid,
+            pid: d.pid,
+            description: d.description,
+        })
+        .collect();
+    candidates.sort_by(|a, b| a.port.cmp(&b.port));
+
+    let matches: Vec<_> = candidates
+        .iter()
+        .filter(|d| d.vid.is_some_and(|vid| expected_vids.contains(&vid)))
+        .collect();
+
+    if matches.len() == 1 {
+        let selected = matches[0];
+        DeployPortChoice {
+            port: Some(selected.port.clone()),
+            warning: None,
+        }
+    } else if !matches.is_empty() {
+        let selected = matches[0];
+        DeployPortChoice {
+            port: Some(selected.port.clone()),
+            warning: Some(format!(
+                "multiple serial ports matched expected VID(s) {}; selected {} deterministically from {}; pass -p/--port to choose explicitly",
+                format_vids(&expected_vids),
+                selected.port,
+                format_candidates(matches.iter().copied()),
+            )),
+        }
+    } else if !candidates.is_empty() {
+        let selected = &candidates[0];
+        DeployPortChoice {
+                port: Some(selected.port.clone()),
+                warning: Some(format!(
+                    "no serial port matched expected VID(s) {}; falling back to {} from {}; pass -p/--port to choose explicitly",
+                    format_vids(&expected_vids),
+                    selected.port,
+                    format_candidates(candidates.iter()),
+                )),
+            }
+    } else {
+        DeployPortChoice {
+            port: None,
+            warning: Some(format!(
+                "no serial ports found while looking for expected VID(s) {}",
+                format_vids(&expected_vids)
+            )),
+        }
+    }
+}
+
+pub(super) fn append_warning_to_stderr(stderr: &mut Option<String>, warning: Option<String>) {
+    let Some(warning) = warning else {
+        return;
+    };
+    let warning = format!("warning: {}", warning);
+    match stderr {
+        Some(existing) if !existing.is_empty() => {
+            existing.push('\n');
+            existing.push_str(&warning);
+        }
+        Some(existing) => existing.push_str(&warning),
+        None => *stderr = Some(warning),
+    }
+}
+
+fn expected_vids(platform: Platform, board: Option<&BoardConfig>) -> Vec<u16> {
+    let mut vids = Vec::new();
+    if let Some(vid) = board.and_then(|b| parse_u16_id(b.vid.as_deref())) {
+        vids.push(vid);
+    }
+
+    let defaults: &[u16] = match platform {
+        Platform::Teensy => &[0x16C0],
+        Platform::Espressif32 => &[0x303A],
+        Platform::AtmelAvr | Platform::AtmelMegaAvr => &[0x2341, 0x2A03, 0x1A86, 0x10C4, 0x0403],
+        Platform::NxpLpc => &[0x1FC9, 0x0D28],
+        Platform::RaspberryPi => &[0x2E8A],
+        _ => &[],
+    };
+
+    for vid in defaults {
+        if !vids.contains(vid) {
+            vids.push(*vid);
+        }
+    }
+    vids
+}
+
+fn parse_u16_id(value: Option<&str>) -> Option<u16> {
+    let raw = value?.trim();
+    let raw = raw
+        .strip_prefix("0x")
+        .or_else(|| raw.strip_prefix("0X"))
+        .unwrap_or(raw);
+    u16::from_str_radix(raw, 16)
+        .or_else(|_| raw.parse::<u16>())
+        .ok()
+}
+
+fn format_vids(vids: &[u16]) -> String {
+    vids.iter()
+        .map(|v| format!("0x{v:04X}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn format_candidates<'a>(candidates: impl Iterator<Item = &'a PortCandidate>) -> String {
+    candidates
+        .map(|d| {
+            let id = match (d.vid, d.pid) {
+                (Some(vid), Some(pid)) => format!("{vid:04X}:{pid:04X}"),
+                (Some(vid), None) => format!("{vid:04X}:????"),
+                _ => "unknown".to_string(),
+            };
+            format!("{} ({}, {})", d.port, id, d.description)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn device(port: &str, vid: Option<u16>, pid: Option<u16>) -> DeviceState {
+        DeviceState {
+            device_id: vid
+                .map(|v| format!("{v:04x}:{:04x}", pid.unwrap_or(0)))
+                .unwrap_or_else(|| port.to_string()),
+            port: port.to_string(),
+            description: "USB Serial Device".to_string(),
+            vid,
+            pid,
+            exclusive_lease: None,
+            monitor_leases: HashMap::new(),
+            last_seen_at: 0.0,
+            is_connected: true,
+            trusted_firmware: None,
+            last_disconnect_at: None,
+        }
+    }
+
+    #[test]
+    fn explicit_port_wins() {
+        let choice = choose_deploy_port(
+            Some("COM21".to_string()),
+            Platform::Teensy,
+            None,
+            vec![device("COM22", Some(0x303A), Some(0x1001))],
+        );
+        assert_eq!(choice.port.as_deref(), Some("COM21"));
+        assert!(choice.warning.is_none());
+    }
+
+    #[test]
+    fn selects_single_matching_teensy_vid() {
+        let choice = choose_deploy_port(
+            None,
+            Platform::Teensy,
+            None,
+            vec![
+                device("COM22", Some(0x303A), Some(0x1001)),
+                device("COM21", Some(0x16C0), Some(0x0489)),
+            ],
+        );
+        assert_eq!(choice.port.as_deref(), Some("COM21"));
+        assert!(choice.warning.is_none());
+    }
+
+    #[test]
+    fn multiple_matches_pick_sorted_port_and_warn() {
+        let choice = choose_deploy_port(
+            None,
+            Platform::Espressif32,
+            None,
+            vec![
+                device("COM22", Some(0x303A), Some(0x1001)),
+                device("COM9", Some(0x303A), Some(0x1001)),
+            ],
+        );
+        assert_eq!(choice.port.as_deref(), Some("COM22"));
+        assert!(choice
+            .warning
+            .unwrap()
+            .contains("multiple serial ports matched"));
+    }
+
+    #[test]
+    fn no_match_falls_back_sorted_and_warns() {
+        let choice = choose_deploy_port(
+            None,
+            Platform::Teensy,
+            None,
+            vec![
+                device("COM22", Some(0x303A), Some(0x1001)),
+                device("COM9", Some(0x303A), Some(0x1001)),
+            ],
+        );
+        assert_eq!(choice.port.as_deref(), Some("COM22"));
+        assert!(choice.warning.unwrap().contains("no serial port matched"));
+    }
+
+    #[test]
+    fn board_vid_augments_family_defaults() {
+        let overrides = HashMap::new();
+        let mut board =
+            BoardConfig::from_board_id_or_default("seeed_xiao_esp32s3", "", &overrides, None);
+        board.vid = Some("0x2886".to_string());
+        let choice = choose_deploy_port(
+            None,
+            Platform::Espressif32,
+            Some(&board),
+            vec![device("COM7", Some(0x2886), Some(0x0056))],
+        );
+        assert_eq!(choice.port.as_deref(), Some("COM7"));
+    }
+}

--- a/crates/fbuild-daemon/src/handlers/operations/mod.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/mod.rs
@@ -8,6 +8,7 @@
 mod build;
 mod common;
 mod deploy;
+mod deploy_port;
 mod install_deps;
 mod monitor;
 mod reset;


### PR DESCRIPTION
## Summary

- auto-select a deploy port by expected USB VID when -p/--port is omitted
- keep explicit -p/--port behavior unchanged
- warn when multiple ports match or when selection falls back to a non-matching port
- include board JSON VID as an override alongside platform-family defaults
- fix an existing clippy single-character push_str lint that blocked the repo lint gate

Closes #591

## Tests

- cargo test -p fbuild-daemon deploy_port
- uv run --script lint