### PR TITLE
[codex] docs: direct planning to GitHub issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Custom Claude Code skills in `.claude/skills/`:
 - Simplicity first. Minimal code impact. No over-engineering.
 - No laziness. Root causes only. Senior developer standards.
 - Verify before done. Run tests, demonstrate correctness.
-- Plan non-trivial work in `tasks/todo.md`. Capture lessons in `tasks/lessons.md`.
+- Plan non-trivial work in GitHub issues for `FastLED/fbuild`. Capture lessons in the relevant issue or PR discussion; only add repo docs when the information is durable reference material.
 
 ## Key Constraints
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,6 +1,6 @@
 # Tasks
 
-Planning and tracking for the fbuild Rust port.
+Historical planning notes for the fbuild Rust port. Active planning and tracking live in GitHub issues for `FastLED/fbuild`.
 
 ## Contents
 


### PR DESCRIPTION
## Summary

- Direct non-trivial planning and lesson capture to GitHub issues and PRs instead of `tasks/` markdown files.
- Mark `tasks/` as historical planning notes rather than active tracking.

## Validation

- `git diff --check HEAD~1..HEAD`
- `rg -n "fbuild-sync-design|tasks/fbuild-sync-design|Plan non-trivial work in ``tasks|tasks/todo\\.md|tasks/lessons\\.md" .` returned no matches.