### PR TITLE
fix(daemon): attribute shutdown requests

### DIFF
--- a/crates/fbuild-cli/src/daemon_client.rs
+++ b/crates/fbuild-cli/src/daemon_client.rs
@@ -399,13 +399,22 @@ impl DaemonClient {
     /// Shut down the daemon.
     #[allow(dead_code)]
     pub async fn shutdown(&self) -> fbuild_core::Result<()> {
-        self.client
+        let resp = self
+            .client
             .post(format!("{}/api/daemon/shutdown", self.base_url))
+            .headers(shutdown_caller_headers())
             .send()
             .await
             .map_err(|e| {
                 fbuild_core::FbuildError::DaemonError(format!("shutdown failed: {}", e))
             })?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(fbuild_core::FbuildError::DaemonError(format!(
+                "shutdown failed with {status}: {body}"
+            )));
+        }
         Ok(())
     }
 
@@ -590,6 +599,45 @@ impl DaemonClient {
         resp.json::<OperationResponse>()
             .await
             .map_err(|e| fbuild_core::FbuildError::DaemonError(format!("invalid response: {}", e)))
+    }
+}
+
+fn shutdown_caller_headers() -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    insert_shutdown_header(
+        &mut headers,
+        "x-fbuild-client-pid",
+        std::process::id().to_string(),
+    );
+    if let Ok(cwd) = std::env::current_dir() {
+        insert_shutdown_header(
+            &mut headers,
+            "x-fbuild-client-cwd",
+            cwd.to_string_lossy().into_owned(),
+        );
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        insert_shutdown_header(
+            &mut headers,
+            "x-fbuild-client-exe",
+            exe.to_string_lossy().into_owned(),
+        );
+    }
+    insert_shutdown_header(
+        &mut headers,
+        "x-fbuild-client-argv",
+        std::env::args().collect::<Vec<_>>().join(" "),
+    );
+    headers
+}
+
+fn insert_shutdown_header(
+    headers: &mut reqwest::header::HeaderMap,
+    name: &'static str,
+    value: String,
+) {
+    if let Ok(value) = reqwest::header::HeaderValue::from_str(&value) {
+        headers.insert(reqwest::header::HeaderName::from_static(name), value);
     }
 }
 

--- a/crates/fbuild-daemon/src/handlers/health.rs
+++ b/crates/fbuild-daemon/src/handlers/health.rs
@@ -4,9 +4,10 @@ use crate::context::DaemonContext;
 use crate::models::{
     DaemonInfoResponse, HealthResponse, RootResponse, ShutdownParams, ShutdownResponse,
 };
-use axum::extract::{Query, State};
-use axum::http::StatusCode;
+use axum::extract::{ConnectInfo, Query, State};
+use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
+use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -69,11 +70,23 @@ pub async fn daemon_info(State(ctx): State<Arc<DaemonContext>>) -> Json<DaemonIn
 /// POST /api/daemon/shutdown
 pub async fn shutdown(
     State(ctx): State<Arc<DaemonContext>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
     query: Query<ShutdownParams>,
 ) -> (StatusCode, Json<ShutdownResponse>) {
     let force = query.force.unwrap_or(false);
+    let caller = ShutdownCaller::from_headers(peer, &headers);
 
     if !force && ctx.operation_in_progress.load(Ordering::Relaxed) {
+        tracing::warn!(
+            peer = %caller.peer,
+            client_pid = caller.pid.as_deref().unwrap_or("unknown"),
+            client_cwd = caller.cwd.as_deref().unwrap_or("unknown"),
+            client_exe = caller.exe.as_deref().unwrap_or("unknown"),
+            client_argv = caller.argv.as_deref().unwrap_or("unknown"),
+            current_operation = current_operation_for_log(&ctx).as_deref().unwrap_or("unknown"),
+            "shutdown refused: operation in progress"
+        );
         return (
             StatusCode::CONFLICT,
             Json(ShutdownResponse {
@@ -84,11 +97,114 @@ pub async fn shutdown(
 
     ctx.is_shutting_down.store(true, Ordering::Relaxed);
     let _ = ctx.shutdown_tx.send(true);
-    tracing::info!("shutdown requested");
+    tracing::info!(
+        peer = %caller.peer,
+        client_pid = caller.pid.as_deref().unwrap_or("unknown"),
+        client_cwd = caller.cwd.as_deref().unwrap_or("unknown"),
+        client_exe = caller.exe.as_deref().unwrap_or("unknown"),
+        client_argv = caller.argv.as_deref().unwrap_or("unknown"),
+        force,
+        current_operation = current_operation_for_log(&ctx).as_deref().unwrap_or("none"),
+        "shutdown requested"
+    );
     (
         StatusCode::OK,
         Json(ShutdownResponse {
             message: "shutting down".to_string(),
         }),
     )
+}
+
+#[derive(Debug)]
+struct ShutdownCaller {
+    peer: SocketAddr,
+    pid: Option<String>,
+    cwd: Option<String>,
+    exe: Option<String>,
+    argv: Option<String>,
+}
+
+impl ShutdownCaller {
+    fn from_headers(peer: SocketAddr, headers: &HeaderMap) -> Self {
+        Self {
+            peer,
+            pid: shutdown_header(headers, "x-fbuild-client-pid"),
+            cwd: shutdown_header(headers, "x-fbuild-client-cwd"),
+            exe: shutdown_header(headers, "x-fbuild-client-exe"),
+            argv: shutdown_header(headers, "x-fbuild-client-argv"),
+        }
+    }
+}
+
+fn shutdown_header(headers: &HeaderMap, name: &'static str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+}
+
+fn current_operation_for_log(ctx: &DaemonContext) -> Option<String> {
+    ctx.current_operation
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn test_context() -> Arc<DaemonContext> {
+        let (shutdown_tx, _shutdown_rx) = tokio::sync::watch::channel(false);
+        Arc::new(DaemonContext::new(8765, shutdown_tx, "test".to_string()))
+    }
+
+    #[test]
+    fn shutdown_caller_extracts_client_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-fbuild-client-pid", HeaderValue::from_static("1234"));
+        headers.insert(
+            "x-fbuild-client-cwd",
+            HeaderValue::from_static("C:/work/fastled"),
+        );
+        headers.insert(
+            "x-fbuild-client-exe",
+            HeaderValue::from_static("C:/tools/fbuild.exe"),
+        );
+        headers.insert(
+            "x-fbuild-client-argv",
+            HeaderValue::from_static("fbuild build"),
+        );
+
+        let caller = ShutdownCaller::from_headers("127.0.0.1:5555".parse().unwrap(), &headers);
+
+        assert_eq!(caller.pid.as_deref(), Some("1234"));
+        assert_eq!(caller.cwd.as_deref(), Some("C:/work/fastled"));
+        assert_eq!(caller.exe.as_deref(), Some("C:/tools/fbuild.exe"));
+        assert_eq!(caller.argv.as_deref(), Some("fbuild build"));
+    }
+
+    #[tokio::test]
+    async fn shutdown_refuses_non_force_when_operation_in_progress() {
+        let ctx = test_context();
+        ctx.operation_in_progress.store(true, Ordering::Relaxed);
+        *ctx.current_operation.write().unwrap() = Some("Building C:/work/fastled".to_string());
+
+        let (status, body) = shutdown(
+            State(ctx.clone()),
+            ConnectInfo("127.0.0.1:5555".parse().unwrap()),
+            HeaderMap::new(),
+            Query(ShutdownParams { force: None }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(
+            body.message,
+            "operation in progress; use ?force=true to force shutdown"
+        );
+        assert!(!ctx.is_shutting_down.load(Ordering::Relaxed));
+    }
 }

--- a/crates/fbuild-daemon/src/main.rs
+++ b/crates/fbuild-daemon/src/main.rs
@@ -366,7 +366,7 @@ async fn main() {
     let shutdown_tx_signal = context.shutdown_tx.clone();
     let op_in_progress = context.operation_in_progress.clone();
 
-    axum::serve(listener, app)
+    axum::serve(listener, app.into_make_service_with_connect_info::<std::net::SocketAddr>())
         .with_graceful_shutdown(async move {
             // Wait for either the HTTP shutdown endpoint or Ctrl+C / SIGTERM
             tokio::select! {

--- a/crates/fbuild-python/src/daemon.rs
+++ b/crates/fbuild-python/src/daemon.rs
@@ -58,6 +58,45 @@ fn daemon_in_dir(dir: &Path) -> Option<PathBuf> {
     }
 }
 
+fn shutdown_caller_headers() -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    insert_shutdown_header(
+        &mut headers,
+        "x-fbuild-client-pid",
+        std::process::id().to_string(),
+    );
+    if let Ok(cwd) = std::env::current_dir() {
+        insert_shutdown_header(
+            &mut headers,
+            "x-fbuild-client-cwd",
+            cwd.to_string_lossy().into_owned(),
+        );
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        insert_shutdown_header(
+            &mut headers,
+            "x-fbuild-client-exe",
+            exe.to_string_lossy().into_owned(),
+        );
+    }
+    insert_shutdown_header(
+        &mut headers,
+        "x-fbuild-client-argv",
+        std::env::args().collect::<Vec<_>>().join(" "),
+    );
+    headers
+}
+
+fn insert_shutdown_header(
+    headers: &mut reqwest::header::HeaderMap,
+    name: &'static str,
+    value: String,
+) {
+    if let Ok(value) = reqwest::header::HeaderValue::from_str(&value) {
+        headers.insert(reqwest::header::HeaderName::from_static(name), value);
+    }
+}
+
 /// Build the spawn target for the daemon: prefer the venv-adjacent absolute
 /// path (`Some`) and fall back to the PATH-relative bare name (`None`).
 ///
@@ -299,6 +338,7 @@ impl Daemon {
         let url = format!("{}/api/daemon/shutdown", fbuild_paths::get_daemon_url());
         reqwest::blocking::Client::new()
             .post(&url)
+            .headers(shutdown_caller_headers())
             .send()
             .map(|r| r.status().is_success())
             .unwrap_or(false)
@@ -468,6 +508,7 @@ impl AsyncDaemon {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let ok = reqwest::Client::new()
                 .post(&url)
+                .headers(shutdown_caller_headers())
                 .timeout(std::time::Duration::from_secs(10))
                 .send()
                 .await


### PR DESCRIPTION
## Summary
- logs shutdown caller provenance from peer address plus fbuild client PID/CWD/exe/argv headers
- makes refused shutdowns visible in logs with the active operation description
- sends caller provenance headers from Rust CLI and PyO3 shutdown clients
- treats non-2xx daemon shutdown responses as Rust CLI errors instead of silent success

Closes #627

## Tests
- `soldr cargo fmt --all --check`
- `soldr cargo test -p fbuild-daemon handlers::health -- --nocapture`
- `soldr cargo test -p fbuild-cli daemon_client -- --nocapture`
- `soldr cargo check -p fbuild-python`
- `soldr cargo clippy -p fbuild-daemon -p fbuild-cli -p fbuild-python --all-targets -- -D warnings`

Note: `uv run --script lint` timed out after 10 minutes without a diagnostic in this worktree, so the final verification used `soldr cargo` directly for the touched crates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shutdown requests now include caller metadata (PID, CWD, executable path, argv) for improved tracking.

* **Improvements**
  * Daemon now validates shutdown response status and provides detailed error reporting.
  * Enhanced shutdown logging with client connection information.
  * Better error handling when shutdown requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->