### PR TITLE
fix(device): expose lease attribution

### DIFF
--- a/crates/fbuild-cli/src/cli/device.rs
+++ b/crates/fbuild-cli/src/cli/device.rs
@@ -1,6 +1,8 @@
 //! `fbuild device` subcommand: list / status / lease / release / take.
 
-use crate::daemon_client::{self, DaemonClient};
+use crate::daemon_client::{
+    self, DaemonClient, DeviceLeaseConflictResponse, DeviceLeaseInfoResponse,
+};
 
 use super::args::DeviceAction;
 
@@ -15,11 +17,23 @@ pub async fn run_device(action: DeviceAction) -> fbuild_core::Result<()> {
                 println!("no devices found");
                 return Ok(());
             }
-            println!("{:<20} {:<12} {:<20}", "PORT", "DEVICE ID", "DESCRIPTION");
-            println!("{}", "-".repeat(52));
+            println!(
+                "{:<20} {:<12} {:<12} {:<24} DESCRIPTION",
+                "PORT", "DEVICE ID", "LEASE", "HOLDER"
+            );
+            println!("{}", "-".repeat(88));
             for dev in &resp.devices {
                 let id = dev.device_id.as_deref().unwrap_or("-");
-                println!("{:<20} {:<12} {:<20}", dev.port, id, dev.description);
+                let lease = lease_summary(dev.exclusive_lease.as_ref(), dev.monitor_count);
+                let holder = dev
+                    .exclusive_lease
+                    .as_ref()
+                    .map(|l| l.client_id.as_str())
+                    .unwrap_or("-");
+                println!(
+                    "{:<20} {:<12} {:<12} {:<24} {}",
+                    dev.port, id, lease, holder, dev.description
+                );
             }
             println!("\n{} device(s) found", resp.devices.len());
         }
@@ -49,8 +63,14 @@ pub async fn run_device(action: DeviceAction) -> fbuild_core::Result<()> {
             if let Some(ref holder) = resp.exclusive_holder {
                 println!("    Exclusive holder: {}", holder);
             }
+            if let Some(ref lease) = resp.exclusive_lease {
+                print_lease("    Exclusive lease", lease);
+            }
             if resp.monitor_count > 0 {
                 println!("    Monitor sessions: {}", resp.monitor_count);
+                for lease in &resp.monitor_leases {
+                    print_lease("      Monitor lease", lease);
+                }
             }
         }
         DeviceAction::Lease {
@@ -68,6 +88,9 @@ pub async fn run_device(action: DeviceAction) -> fbuild_core::Result<()> {
                 }
             } else {
                 eprintln!("error: {}", resp.message);
+                if let Some(ref conflict) = resp.conflict {
+                    print_conflict(conflict);
+                }
             }
         }
         DeviceAction::Release { port, lease_id } => {
@@ -88,4 +111,41 @@ pub async fn run_device(action: DeviceAction) -> fbuild_core::Result<()> {
         }
     }
     Ok(())
+}
+
+fn lease_summary(exclusive: Option<&DeviceLeaseInfoResponse>, monitor_count: usize) -> String {
+    match (exclusive, monitor_count) {
+        (Some(_), 0) => "exclusive".to_string(),
+        (Some(_), n) => format!("exclusive+{n}m"),
+        (None, 0) => "-".to_string(),
+        (None, n) => format!("{n} monitor"),
+    }
+}
+
+fn print_lease(label: &str, lease: &DeviceLeaseInfoResponse) {
+    println!("{}:", label);
+    println!("      lease_id: {}", lease.lease_id);
+    println!("      type: {}", lease.lease_type);
+    println!("      client_id: {}", lease.client_id);
+    println!("      description: {}", empty_dash(&lease.description));
+    println!("      acquired_at: {:.3}", lease.acquired_at);
+}
+
+fn print_conflict(conflict: &DeviceLeaseConflictResponse) {
+    eprintln!(
+        "  holder: {} ({})",
+        conflict.holder.client_id,
+        empty_dash(&conflict.holder.description)
+    );
+    eprintln!("  lease_id: {}", conflict.holder.lease_id);
+    eprintln!("  device: {} {}", conflict.port, conflict.device_id);
+    eprintln!("  description: {}", empty_dash(&conflict.description));
+}
+
+fn empty_dash(value: &str) -> &str {
+    if value.is_empty() {
+        "-"
+    } else {
+        value
+    }
 }

--- a/crates/fbuild-cli/src/daemon_client/types.rs
+++ b/crates/fbuild-cli/src/daemon_client/types.rs
@@ -315,6 +315,12 @@ pub struct DeviceInfoResponse {
     pub vid: Option<u16>,
     pub pid: Option<u16>,
     pub description: String,
+    #[serde(default)]
+    pub available_for_exclusive: bool,
+    #[serde(default)]
+    pub exclusive_lease: Option<DeviceLeaseInfoResponse>,
+    #[serde(default)]
+    pub monitor_count: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -326,7 +332,11 @@ pub struct DeviceStatusResponse {
     pub is_connected: bool,
     pub available_for_exclusive: bool,
     pub exclusive_holder: Option<String>,
+    #[serde(default)]
+    pub exclusive_lease: Option<DeviceLeaseInfoResponse>,
     pub monitor_count: usize,
+    #[serde(default)]
+    pub monitor_leases: Vec<DeviceLeaseInfoResponse>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -336,6 +346,25 @@ pub struct DeviceLeaseResponse {
     #[allow(dead_code)]
     pub lease_type: Option<String>,
     pub message: String,
+    #[serde(default)]
+    pub conflict: Option<DeviceLeaseConflictResponse>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeviceLeaseInfoResponse {
+    pub lease_id: String,
+    pub client_id: String,
+    pub lease_type: String,
+    pub description: String,
+    pub acquired_at: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DeviceLeaseConflictResponse {
+    pub port: String,
+    pub device_id: String,
+    pub description: String,
+    pub holder: DeviceLeaseInfoResponse,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/fbuild-daemon/src/device_manager.rs
+++ b/crates/fbuild-daemon/src/device_manager.rs
@@ -27,6 +27,55 @@ pub struct DeviceLease {
     pub acquired_at: f64,
 }
 
+/// Structured error for lease acquisition failures.
+#[derive(Debug, Clone)]
+pub enum DeviceLeaseError {
+    NotFound {
+        port: String,
+    },
+    Disconnected {
+        port: String,
+    },
+    ExclusiveConflict {
+        port: String,
+        device_id: String,
+        description: String,
+        holder: Box<DeviceLease>,
+    },
+    InvalidLeaseType {
+        lease_type: String,
+    },
+    InvalidPreemption {
+        message: String,
+    },
+}
+
+impl DeviceLeaseError {
+    pub fn message(&self) -> String {
+        match self {
+            Self::NotFound { port } => format!("device '{}' not found", port),
+            Self::Disconnected { port } => format!("device '{}' is disconnected", port),
+            Self::ExclusiveConflict { port, holder, .. } => format!(
+                "device '{}' already has exclusive lease held by client '{}' ({})",
+                port, holder.client_id, holder.description
+            ),
+            Self::InvalidLeaseType { lease_type } => format!(
+                "invalid lease_type '{}', must be 'exclusive' or 'monitor'",
+                lease_type
+            ),
+            Self::InvalidPreemption { message } => message.clone(),
+        }
+    }
+}
+
+impl std::fmt::Display for DeviceLeaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message())
+    }
+}
+
+impl std::error::Error for DeviceLeaseError {}
+
 /// In-memory record of the firmware image the daemon *last observed*
 /// on a given port (either written by us, or confirmed by
 /// `verify-flash` MD5 match). Used by the session-trusted verify-skip
@@ -238,21 +287,27 @@ impl DeviceManager {
         port: &str,
         client_id: &str,
         description: &str,
-    ) -> Result<DeviceLease, String> {
+    ) -> Result<DeviceLease, DeviceLeaseError> {
         let mut devices = self.devices.lock().unwrap();
         let state = devices
             .get_mut(port)
-            .ok_or_else(|| format!("device '{}' not found", port))?;
+            .ok_or_else(|| DeviceLeaseError::NotFound {
+                port: port.to_string(),
+            })?;
 
         if !state.is_connected {
-            return Err(format!("device '{}' is disconnected", port));
+            return Err(DeviceLeaseError::Disconnected {
+                port: port.to_string(),
+            });
         }
 
         if let Some(ref existing) = state.exclusive_lease {
-            return Err(format!(
-                "device '{}' already has exclusive lease held by client '{}' ({})",
-                port, existing.client_id, existing.description
-            ));
+            return Err(DeviceLeaseError::ExclusiveConflict {
+                port: port.to_string(),
+                device_id: state.device_id.clone(),
+                description: state.description.clone(),
+                holder: Box::new(existing.clone()),
+            });
         }
 
         let lease = DeviceLease {
@@ -278,14 +333,18 @@ impl DeviceManager {
         port: &str,
         client_id: &str,
         description: &str,
-    ) -> Result<DeviceLease, String> {
+    ) -> Result<DeviceLease, DeviceLeaseError> {
         let mut devices = self.devices.lock().unwrap();
         let state = devices
             .get_mut(port)
-            .ok_or_else(|| format!("device '{}' not found", port))?;
+            .ok_or_else(|| DeviceLeaseError::NotFound {
+                port: port.to_string(),
+            })?;
 
         if !state.is_connected {
-            return Err(format!("device '{}' is disconnected", port));
+            return Err(DeviceLeaseError::Disconnected {
+                port: port.to_string(),
+            });
         }
 
         let lease = DeviceLease {
@@ -353,18 +412,24 @@ impl DeviceManager {
         port: &str,
         client_id: &str,
         reason: &str,
-    ) -> Result<(DeviceLease, Option<String>), String> {
+    ) -> Result<(DeviceLease, Option<String>), DeviceLeaseError> {
         if reason.is_empty() {
-            return Err("preemption reason is required".to_string());
+            return Err(DeviceLeaseError::InvalidPreemption {
+                message: "preemption reason is required".to_string(),
+            });
         }
 
         let mut devices = self.devices.lock().unwrap();
         let state = devices
             .get_mut(port)
-            .ok_or_else(|| format!("device '{}' not found", port))?;
+            .ok_or_else(|| DeviceLeaseError::NotFound {
+                port: port.to_string(),
+            })?;
 
         if !state.is_connected {
-            return Err(format!("device '{}' is disconnected", port));
+            return Err(DeviceLeaseError::Disconnected {
+                port: port.to_string(),
+            });
         }
 
         // Capture preempted client before clearing
@@ -468,6 +533,27 @@ impl DeviceManager {
         }
         count
     }
+
+    #[cfg(test)]
+    pub(crate) fn insert_test_device(&self, port: &str) {
+        let mut devices = self.devices.lock().unwrap();
+        devices.insert(
+            port.to_string(),
+            DeviceState {
+                device_id: "1234:5678".to_string(),
+                port: port.to_string(),
+                description: "Test Device".to_string(),
+                vid: Some(0x1234),
+                pid: Some(0x5678),
+                exclusive_lease: None,
+                monitor_leases: HashMap::new(),
+                last_seen_at: Self::now_unix(),
+                is_connected: true,
+                trusted_firmware: None,
+                last_disconnect_at: None,
+            },
+        );
+    }
 }
 
 #[cfg(test)]
@@ -476,25 +562,7 @@ mod tests {
 
     fn make_manager_with_device(port: &str) -> DeviceManager {
         let mgr = DeviceManager::new();
-        {
-            let mut devices = mgr.devices.lock().unwrap();
-            devices.insert(
-                port.to_string(),
-                DeviceState {
-                    device_id: "1234:5678".to_string(),
-                    port: port.to_string(),
-                    description: "Test Device".to_string(),
-                    vid: Some(0x1234),
-                    pid: Some(0x5678),
-                    exclusive_lease: None,
-                    monitor_leases: HashMap::new(),
-                    last_seen_at: DeviceManager::now_unix(),
-                    is_connected: true,
-                    trusted_firmware: None,
-                    last_disconnect_at: None,
-                },
-            );
-        }
+        mgr.insert_test_device(port);
         mgr
     }
 
@@ -519,8 +587,20 @@ mod tests {
         let mgr = make_manager_with_device("COM3");
         mgr.acquire_exclusive("COM3", "client-1", "first").unwrap();
         let result = mgr.acquire_exclusive("COM3", "client-2", "second");
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("already has exclusive lease"));
+        match result.unwrap_err() {
+            DeviceLeaseError::ExclusiveConflict {
+                port,
+                device_id,
+                holder,
+                ..
+            } => {
+                assert_eq!(port, "COM3");
+                assert_eq!(device_id, "1234:5678");
+                assert_eq!(holder.client_id, "client-1");
+                assert_eq!(holder.description, "first");
+            }
+            other => panic!("expected exclusive conflict, got {other:?}"),
+        }
     }
 
     #[test]
@@ -574,7 +654,7 @@ mod tests {
         mgr.acquire_exclusive("COM3", "c1", "holder").unwrap();
         let result = mgr.preempt_device("COM3", "c2", "");
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("reason is required"));
+        assert!(result.unwrap_err().message().contains("reason is required"));
     }
 
     #[test]

--- a/crates/fbuild-daemon/src/handlers/devices.rs
+++ b/crates/fbuild-daemon/src/handlers/devices.rs
@@ -1,10 +1,11 @@
 //! Device discovery and management handlers.
 
 use crate::context::DaemonContext;
-use crate::device_manager::LeaseType;
+use crate::device_manager::{DeviceLease, DeviceLeaseError, DeviceState, LeaseType};
 use crate::models::{
-    DeviceInfo, DeviceLeaseRequest, DeviceLeaseResponse, DeviceListResponse, DevicePreemptRequest,
-    DevicePreemptResponse, DeviceReleaseRequest, DeviceReleaseResponse, DeviceStatusResponse,
+    DeviceInfo, DeviceLeaseConflict, DeviceLeaseInfo, DeviceLeaseRequest, DeviceLeaseResponse,
+    DeviceListResponse, DevicePreemptRequest, DevicePreemptResponse, DeviceReleaseRequest,
+    DeviceReleaseResponse, DeviceStatusResponse,
 };
 use axum::extract::{Path, State};
 use axum::Json;
@@ -17,16 +18,7 @@ pub async fn list_devices(state: State<Arc<DaemonContext>>) -> Json<DeviceListRe
     state.device_manager.refresh_devices();
 
     let all = state.device_manager.get_all_devices();
-    let devices = all
-        .values()
-        .map(|s| DeviceInfo {
-            port: s.port.clone(),
-            device_id: Some(s.device_id.clone()),
-            vid: s.vid,
-            pid: s.pid,
-            description: s.description.clone(),
-        })
-        .collect();
+    let devices = all.values().map(device_info).collect();
 
     Json(DeviceListResponse {
         success: true,
@@ -43,21 +35,7 @@ pub async fn device_status(
     state.device_manager.refresh_devices();
 
     match state.device_manager.get_device_status(&port) {
-        Some(ds) => {
-            let available = ds.is_available_for_exclusive();
-            let holder = ds.exclusive_lease.as_ref().map(|l| l.client_id.clone());
-            let monitors = ds.monitor_count();
-            Json(DeviceStatusResponse {
-                success: true,
-                port: ds.port,
-                device_id: ds.device_id,
-                description: ds.description,
-                is_connected: ds.is_connected,
-                available_for_exclusive: available,
-                exclusive_holder: holder,
-                monitor_count: monitors,
-            })
-        }
+        Some(ds) => Json(device_status_response(ds)),
         None => Json(DeviceStatusResponse {
             success: false,
             port: port.clone(),
@@ -66,8 +44,43 @@ pub async fn device_status(
             is_connected: false,
             available_for_exclusive: false,
             exclusive_holder: None,
+            exclusive_lease: None,
             monitor_count: 0,
+            monitor_leases: vec![],
         }),
+    }
+}
+
+fn device_info(state: &DeviceState) -> DeviceInfo {
+    DeviceInfo {
+        port: state.port.clone(),
+        device_id: Some(state.device_id.clone()),
+        vid: state.vid,
+        pid: state.pid,
+        description: state.description.clone(),
+        available_for_exclusive: state.is_available_for_exclusive(),
+        exclusive_lease: state.exclusive_lease.as_ref().map(lease_info),
+        monitor_count: state.monitor_count(),
+    }
+}
+
+fn device_status_response(state: DeviceState) -> DeviceStatusResponse {
+    let available = state.is_available_for_exclusive();
+    let holder = state.exclusive_lease.as_ref().map(|l| l.client_id.clone());
+    let monitors = state.monitor_count();
+    let exclusive_lease = state.exclusive_lease.as_ref().map(lease_info);
+    let monitor_leases = state.monitor_leases.values().map(lease_info).collect();
+    DeviceStatusResponse {
+        success: true,
+        port: state.port,
+        device_id: state.device_id,
+        description: state.description,
+        is_connected: state.is_connected,
+        available_for_exclusive: available,
+        exclusive_holder: holder,
+        exclusive_lease,
+        monitor_count: monitors,
+        monitor_leases,
     }
 }
 
@@ -89,10 +102,9 @@ pub async fn device_lease(
         "monitor" => state
             .device_manager
             .acquire_monitor(&port, &client_id, &req.description),
-        other => Err(format!(
-            "invalid lease_type '{}', must be 'exclusive' or 'monitor'",
-            other
-        )),
+        other => Err(DeviceLeaseError::InvalidLeaseType {
+            lease_type: other.to_string(),
+        }),
     };
 
     match result {
@@ -104,12 +116,14 @@ pub async fn device_lease(
                 LeaseType::Monitor => "monitor".to_string(),
             }),
             message: format!("lease acquired on '{}'", port),
+            conflict: None,
         }),
-        Err(msg) => Json(DeviceLeaseResponse {
+        Err(err) => Json(DeviceLeaseResponse {
             success: false,
             lease_id: None,
             lease_type: None,
-            message: msg,
+            message: err.message(),
+            conflict: lease_conflict(&err),
         }),
     }
 }
@@ -168,7 +182,108 @@ pub async fn device_preempt(
             success: false,
             lease_id: None,
             preempted_client_id: None,
-            message: msg,
+            message: msg.message(),
         }),
+    }
+}
+
+fn lease_info(lease: &DeviceLease) -> DeviceLeaseInfo {
+    DeviceLeaseInfo {
+        lease_id: lease.lease_id.clone(),
+        client_id: lease.client_id.clone(),
+        lease_type: match lease.lease_type {
+            LeaseType::Exclusive => "exclusive".to_string(),
+            LeaseType::Monitor => "monitor".to_string(),
+        },
+        description: lease.description.clone(),
+        acquired_at: lease.acquired_at,
+    }
+}
+
+fn lease_conflict(err: &DeviceLeaseError) -> Option<DeviceLeaseConflict> {
+    match err {
+        DeviceLeaseError::ExclusiveConflict {
+            port,
+            device_id,
+            description,
+            holder,
+        } => Some(DeviceLeaseConflict {
+            port: port.clone(),
+            device_id: device_id.clone(),
+            description: description.clone(),
+            holder: lease_info(holder),
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device_manager::DeviceManager;
+
+    #[test]
+    fn device_status_response_includes_full_lease_attribution() {
+        let manager = DeviceManager::new();
+        manager.insert_test_device("COM3");
+        manager
+            .acquire_exclusive("COM3", "pid 100 alice", "deploy")
+            .unwrap();
+        manager
+            .acquire_monitor("COM3", "pid 200 bob", "monitor")
+            .unwrap();
+
+        let state = manager.get_device_status("COM3").unwrap();
+        let response = device_status_response(state);
+
+        assert!(!response.available_for_exclusive);
+        let exclusive = response.exclusive_lease.unwrap();
+        assert_eq!(exclusive.client_id, "pid 100 alice");
+        assert_eq!(exclusive.lease_type, "exclusive");
+        assert_eq!(exclusive.description, "deploy");
+        assert_eq!(response.exclusive_holder.as_deref(), Some("pid 100 alice"));
+        assert_eq!(response.monitor_count, 1);
+        assert_eq!(response.monitor_leases[0].client_id, "pid 200 bob");
+        assert_eq!(response.monitor_leases[0].lease_type, "monitor");
+    }
+
+    #[test]
+    fn device_info_includes_lease_summary_fields() {
+        let manager = DeviceManager::new();
+        manager.insert_test_device("COM4");
+        manager
+            .acquire_exclusive("COM4", "pid 300 carol", "autoresearch")
+            .unwrap();
+
+        let state = manager.get_device_status("COM4").unwrap();
+        let info = device_info(&state);
+
+        assert_eq!(info.port, "COM4");
+        assert!(!info.available_for_exclusive);
+        assert_eq!(info.monitor_count, 0);
+        assert_eq!(
+            info.exclusive_lease.as_ref().map(|l| l.client_id.as_str()),
+            Some("pid 300 carol")
+        );
+    }
+
+    #[test]
+    fn exclusive_conflict_maps_to_structured_payload() {
+        let manager = DeviceManager::new();
+        manager.insert_test_device("COM5");
+        manager
+            .acquire_exclusive("COM5", "pid 400 dave", "first deploy")
+            .unwrap();
+        let err = manager
+            .acquire_exclusive("COM5", "pid 500 erin", "second deploy")
+            .unwrap_err();
+
+        let conflict = lease_conflict(&err).expect("exclusive conflict payload");
+
+        assert_eq!(conflict.port, "COM5");
+        assert_eq!(conflict.device_id, "1234:5678");
+        assert_eq!(conflict.holder.client_id, "pid 400 dave");
+        assert_eq!(conflict.holder.description, "first deploy");
+        assert_eq!(conflict.holder.lease_type, "exclusive");
     }
 }

--- a/crates/fbuild-daemon/src/models.rs
+++ b/crates/fbuild-daemon/src/models.rs
@@ -282,6 +282,10 @@ pub struct DeviceInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u16>,
     pub description: String,
+    pub available_for_exclusive: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclusive_lease: Option<DeviceLeaseInfo>,
+    pub monitor_count: usize,
 }
 
 /// POST /api/devices/list response.
@@ -362,6 +366,27 @@ pub struct DeviceLeaseResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lease_type: Option<String>,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conflict: Option<DeviceLeaseConflict>,
+}
+
+/// Public lease attribution record.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeviceLeaseInfo {
+    pub lease_id: String,
+    pub client_id: String,
+    pub lease_type: String,
+    pub description: String,
+    pub acquired_at: f64,
+}
+
+/// Structured details for an exclusive lease conflict.
+#[derive(Debug, Serialize)]
+pub struct DeviceLeaseConflict {
+    pub port: String,
+    pub device_id: String,
+    pub description: String,
+    pub holder: DeviceLeaseInfo,
 }
 
 /// POST /api/devices/{port}/release request.
@@ -410,7 +435,10 @@ pub struct DeviceStatusResponse {
     pub available_for_exclusive: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclusive_holder: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclusive_lease: Option<DeviceLeaseInfo>,
     pub monitor_count: usize,
+    pub monitor_leases: Vec<DeviceLeaseInfo>,
 }
 
 /// POST /api/test-emu — build firmware then run it in an emulator.


### PR DESCRIPTION
Closes #634\nRefs #592\n\n## Summary\n- add public lease attribution records to device list/status responses\n- return structured exclusive-lease conflict details from the lease endpoint\n- show lease/holder details in the device CLI\n\n## Tests\n- soldr cargo fmt --all --check\n- soldr cargo check -p fbuild-cli -p fbuild-daemon\n- soldr cargo test -p fbuild-daemon handlers::devices -- --nocapture\n- soldr cargo test -p fbuild-daemon device_manager -- --nocapture\n- soldr cargo clippy -p fbuild-cli -p fbuild-daemon --all-targets -- -D warnings