### PR TITLE
fix(serial): emit disconnect events

### DIFF
--- a/crates/fbuild-daemon/src/handlers/operations/monitor.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/monitor.rs
@@ -7,6 +7,7 @@ use crate::models::{MonitorRequest, OperationResponse};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
+use fbuild_serial::SerialStreamEvent;
 use std::sync::Arc;
 
 /// Outcome of a post-deploy monitor session.
@@ -160,7 +161,7 @@ impl MonitorState {
 /// Run a monitor loop reading lines from broadcast, checking halt conditions
 /// using case-insensitive regex (matching Python's re.search behavior).
 pub(crate) async fn run_monitor_loop(
-    rx: &mut tokio::sync::broadcast::Receiver<String>,
+    rx: &mut tokio::sync::broadcast::Receiver<SerialStreamEvent>,
     timeout_secs: Option<f64>,
     halt_on_error: Option<&str>,
     halt_on_success: Option<&str>,
@@ -186,10 +187,19 @@ pub(crate) async fn run_monitor_loop(
             .unwrap_or(std::time::Duration::from_secs(1));
 
         match tokio::time::timeout(recv_timeout, rx.recv()).await {
-            Ok(Ok(line)) => {
+            Ok(Ok(SerialStreamEvent::Data(line))) => {
                 if let Some(outcome) = state.process_line(&line) {
                     return outcome;
                 }
+            }
+            Ok(Ok(SerialStreamEvent::PortDisconnected {
+                port,
+                reason,
+                message,
+            })) => {
+                return MonitorOutcome::Error(format!(
+                    "serial port {port} disconnected ({reason}): {message}"
+                ));
             }
             Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(n))) => {
                 tracing::warn!("monitor lagged, skipped {} messages", n);
@@ -458,6 +468,29 @@ mod tests {
         match s.process_line("system READY now") {
             Some(MonitorOutcome::Success(msg)) => assert!(msg.contains("READY")),
             other => panic!("expected Success outcome, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn monitor_loop_errors_on_port_disconnected_event() {
+        let (tx, mut rx) = tokio::sync::broadcast::channel(4);
+        tx.send(SerialStreamEvent::PortDisconnected {
+            port: "COM3".to_string(),
+            reason: "read_error".to_string(),
+            message: "device disconnected".to_string(),
+        })
+        .unwrap();
+
+        let outcome =
+            run_monitor_loop(&mut rx, Some(5.0), None, Some("READY"), None, false, false).await;
+
+        match outcome {
+            MonitorOutcome::Error(msg) => {
+                assert!(msg.contains("COM3"));
+                assert!(msg.contains("read_error"));
+                assert!(msg.contains("device disconnected"));
+            }
+            other => panic!("expected Error outcome, got {other:?}"),
         }
     }
 }

--- a/crates/fbuild-daemon/src/handlers/websockets.rs
+++ b/crates/fbuild-daemon/src/handlers/websockets.rs
@@ -6,7 +6,7 @@ use crate::context::DaemonContext;
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{Path, State, WebSocketUpgrade};
 use axum::response::IntoResponse;
-use fbuild_serial::{SerialClientMessage, SerialServerMessage};
+use fbuild_serial::{SerialClientMessage, SerialServerMessage, SerialStreamEvent};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -177,7 +177,7 @@ async fn handle_serial_ws(mut socket: WebSocket, ctx: Arc<DaemonContext>) {
             // Forward serial output to WebSocket
             result = rx.recv() => {
                 match result {
-                    Ok(line) => {
+                    Ok(SerialStreamEvent::Data(line)) => {
                         line_index += 1;
                         // A streaming serial monitor is "active" — bump
                         // last_activity on every line so the 12-hour
@@ -204,6 +204,15 @@ async fn handle_serial_ws(mut socket: WebSocket, ctx: Arc<DaemonContext>) {
                         if socket.send(Message::Text(serde_json::to_string(&data_msg).unwrap())).await.is_err() {
                             break;
                         }
+                    }
+                    Ok(SerialStreamEvent::PortDisconnected { port, reason, message }) => {
+                        let msg = SerialServerMessage::PortDisconnected {
+                            port,
+                            reason,
+                            message,
+                        };
+                        let _ = socket.send(Message::Text(serde_json::to_string(&msg).unwrap())).await;
+                        break;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         tracing::warn!(client_id, port, n, "reader lagged, skipping lines");

--- a/crates/fbuild-python/src/json_rpc.rs
+++ b/crates/fbuild-python/src/json_rpc.rs
@@ -80,6 +80,7 @@ pub(crate) async fn read_lines_async(
                         break;
                     }
                     Ok(ServerMessage::Reconnected { .. }) => continue,
+                    Ok(ServerMessage::PortDisconnected { .. }) => break,
                     _ => continue,
                 }
             }

--- a/crates/fbuild-python/src/messages.rs
+++ b/crates/fbuild-python/src/messages.rs
@@ -48,6 +48,14 @@ pub(crate) enum ServerMessage {
         #[allow(dead_code)]
         message: String,
     },
+    PortDisconnected {
+        #[allow(dead_code)]
+        port: String,
+        #[allow(dead_code)]
+        reason: String,
+        #[allow(dead_code)]
+        message: String,
+    },
     Error {
         message: String,
     },

--- a/crates/fbuild-python/src/serial_monitor.rs
+++ b/crates/fbuild-python/src/serial_monitor.rs
@@ -213,6 +213,7 @@ impl SerialMonitor {
                                 // Resume after deploy
                                 continue;
                             }
+                            Ok(ServerMessage::PortDisconnected { .. }) => break,
                             _ => continue,
                         }
                     }
@@ -554,6 +555,7 @@ impl SerialMonitor {
                         Ok(ServerMessage::Reconnected { .. }) => {
                             continue;
                         }
+                        Ok(ServerMessage::PortDisconnected { .. }) => break,
                         _ => continue,
                     }
                 }

--- a/crates/fbuild-serial/src/lib.rs
+++ b/crates/fbuild-serial/src/lib.rs
@@ -39,5 +39,5 @@ pub mod preemption;
 pub mod session;
 
 pub use manager::{PortSessionInfo, SharedSerialManager};
-pub use messages::{SerialClientMessage, SerialServerMessage};
+pub use messages::{SerialClientMessage, SerialServerMessage, SerialStreamEvent};
 pub use session::SerialSession;

--- a/crates/fbuild-serial/src/manager.rs
+++ b/crates/fbuild-serial/src/manager.rs
@@ -19,6 +19,7 @@
 //! 5. Toggle DTR/RTS for flow control
 
 use crate::crash_decoder::CrashDecoder;
+use crate::messages::SerialStreamEvent;
 use crate::preemption::PreemptionTracker;
 use crate::session::SerialSession;
 use dashmap::DashMap;
@@ -43,7 +44,7 @@ struct PortOutputBuffer {
 pub struct SharedSerialManager {
     sessions: DashMap<String, SerialSession>,
     /// Broadcast channels per port for output distribution.
-    broadcasters: DashMap<String, broadcast::Sender<String>>,
+    broadcasters: DashMap<String, broadcast::Sender<SerialStreamEvent>>,
     /// Monotonic per-port generation that invalidates delayed physical closes.
     close_generations: DashMap<String, u64>,
     preemption: Arc<PreemptionTracker>,
@@ -195,7 +196,7 @@ impl SharedSerialManager {
                                             }
 
                                             // Broadcast the line
-                                            let _ = tx.send(line.clone());
+                                            let _ = tx.send(SerialStreamEvent::Data(line.clone()));
 
                                             // Append to output buffer
                                             if let Ok(mut ob) = port_buf.buffer.lock() {
@@ -218,11 +219,17 @@ impl SharedSerialManager {
                                         std::thread::sleep(Duration::from_millis(10));
                                     }
                                     Err(e) => {
+                                        let message = e.to_string();
                                         tracing::error!(
                                             port = port_clone,
                                             "serial read error: {}",
-                                            e
+                                            message
                                         );
+                                        let _ = tx.send(SerialStreamEvent::PortDisconnected {
+                                            port: port_clone.clone(),
+                                            reason: "read_error".to_string(),
+                                            message,
+                                        });
                                         break;
                                     }
                                 }
@@ -462,7 +469,7 @@ impl SharedSerialManager {
         &self,
         port: &str,
         client_id: &str,
-    ) -> Option<broadcast::Receiver<String>> {
+    ) -> Option<broadcast::Receiver<SerialStreamEvent>> {
         let rx = self.broadcasters.get(port).map(|tx| tx.subscribe())?;
         if let Some(mut session) = self.sessions.get_mut(port) {
             session.reader_client_ids.insert(client_id.to_string());

--- a/crates/fbuild-serial/src/messages.rs
+++ b/crates/fbuild-serial/src/messages.rs
@@ -54,6 +54,11 @@ pub enum SerialServerMessage {
     Reconnected {
         message: String,
     },
+    PortDisconnected {
+        port: String,
+        reason: String,
+        message: String,
+    },
     WriteAck {
         success: bool,
         bytes_written: usize,
@@ -67,6 +72,17 @@ pub enum SerialServerMessage {
         count: usize,
     },
     Error {
+        message: String,
+    },
+}
+
+/// Internal stream event broadcast by the shared serial manager.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SerialStreamEvent {
+    Data(String),
+    PortDisconnected {
+        port: String,
+        reason: String,
         message: String,
     },
 }
@@ -204,6 +220,30 @@ mod tests {
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains("\"type\":\"reconnected\""));
+    }
+
+    #[test]
+    fn server_port_disconnected_roundtrip() {
+        let msg = SerialServerMessage::PortDisconnected {
+            port: "COM3".into(),
+            reason: "read_error".into(),
+            message: "device disconnected".into(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"port_disconnected\""));
+        let parsed: SerialServerMessage = serde_json::from_str(&json).unwrap();
+        match parsed {
+            SerialServerMessage::PortDisconnected {
+                port,
+                reason,
+                message,
+            } => {
+                assert_eq!(port, "COM3");
+                assert_eq!(reason, "read_error");
+                assert_eq!(message, "device disconnected");
+            }
+            _ => panic!("expected PortDisconnected"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #636\nRefs #592\n\n## Summary\n- add a typed serial stream event channel for data vs port disconnects\n- emit port_disconnected WebSocket messages when the daemon reader loses the port\n- make HTTP/deploy monitor loops fail clearly on disconnect events\n- make Python serial readers tolerate the new event\n\n## Tests\n- soldr cargo fmt --all --check\n- soldr cargo check -p fbuild-serial -p fbuild-daemon -p fbuild-python\n- soldr cargo test -p fbuild-serial messages -- --nocapture\n- soldr cargo test -p fbuild-daemon handlers::operations::monitor -- --nocapture\n- soldr cargo clippy -p fbuild-serial -p fbuild-daemon -p fbuild-python --all-targets -- -D warnings