### PR TITLE
Track leased devices by USB serial

### DIFF
--- a/crates/fbuild-cli/src/cli/args.rs
+++ b/crates/fbuild-cli/src/cli/args.rs
@@ -616,6 +616,9 @@ pub enum DeviceAction {
         /// Description for the lease
         #[arg(short, long, default_value = "")]
         description: String,
+        /// Follow this USB device by serial number across port renumbering
+        #[arg(long)]
+        track_serial: bool,
     },
     /// Release a lease on a device
     Release {

--- a/crates/fbuild-cli/src/cli/device.rs
+++ b/crates/fbuild-cli/src/cli/device.rs
@@ -32,7 +32,11 @@ pub async fn run_device(action: DeviceAction) -> fbuild_core::Result<()> {
                     .unwrap_or("-");
                 println!(
                     "{:<20} {:<12} {:<12} {:<24} {}",
-                    dev.port, id, lease, holder, dev.description
+                    dev.port,
+                    id,
+                    lease,
+                    holder,
+                    device_description(&dev.description, dev.previous_port.as_deref())
                 );
             }
             println!("\n{} device(s) found", resp.devices.len());
@@ -51,6 +55,12 @@ pub async fn run_device(action: DeviceAction) -> fbuild_core::Result<()> {
             println!("  {}", resp.port);
             println!("    Device ID: {}", resp.device_id);
             println!("    Description: {}", resp.description);
+            if let Some(ref serial) = resp.serial_number {
+                println!("    Serial: {}", serial);
+            }
+            if let Some(ref previous_port) = resp.previous_port {
+                println!("    Previous port: {}", previous_port);
+            }
             println!("    Status: {}", connected);
             println!(
                 "    Available: {}",
@@ -77,9 +87,10 @@ pub async fn run_device(action: DeviceAction) -> fbuild_core::Result<()> {
             port,
             lease_type,
             description,
+            track_serial,
         } => {
             let resp = client
-                .device_lease(&port, &lease_type, &description)
+                .device_lease(&port, &lease_type, &description, track_serial)
                 .await?;
             if resp.success {
                 println!("lease acquired on '{}'", port);
@@ -129,6 +140,7 @@ fn print_lease(label: &str, lease: &DeviceLeaseInfoResponse) {
     println!("      client_id: {}", lease.client_id);
     println!("      description: {}", empty_dash(&lease.description));
     println!("      acquired_at: {:.3}", lease.acquired_at);
+    println!("      track_serial: {}", lease.track_serial);
 }
 
 fn print_conflict(conflict: &DeviceLeaseConflictResponse) {
@@ -147,5 +159,12 @@ fn empty_dash(value: &str) -> &str {
         "-"
     } else {
         value
+    }
+}
+
+fn device_description(description: &str, previous_port: Option<&str>) -> String {
+    match previous_port {
+        Some(port) => format!("{description} (renum from {port})"),
+        None => description.to_string(),
     }
 }

--- a/crates/fbuild-cli/src/daemon_client.rs
+++ b/crates/fbuild-cli/src/daemon_client.rs
@@ -458,6 +458,7 @@ impl DaemonClient {
         port: &str,
         lease_type: &str,
         description: &str,
+        track_serial: bool,
     ) -> fbuild_core::Result<DeviceLeaseResponse> {
         let resp = self
             .client
@@ -469,6 +470,7 @@ impl DaemonClient {
             .json(&serde_json::json!({
                 "lease_type": lease_type,
                 "description": description,
+                "track_serial": track_serial,
             }))
             .timeout(std::time::Duration::from_secs(10))
             .send()

--- a/crates/fbuild-cli/src/daemon_client/types.rs
+++ b/crates/fbuild-cli/src/daemon_client/types.rs
@@ -314,6 +314,10 @@ pub struct DeviceInfoResponse {
     pub device_id: Option<String>,
     pub vid: Option<u16>,
     pub pid: Option<u16>,
+    #[serde(default)]
+    pub serial_number: Option<String>,
+    #[serde(default)]
+    pub previous_port: Option<String>,
     pub description: String,
     #[serde(default)]
     pub available_for_exclusive: bool,
@@ -329,6 +333,10 @@ pub struct DeviceStatusResponse {
     pub port: String,
     pub device_id: String,
     pub description: String,
+    #[serde(default)]
+    pub serial_number: Option<String>,
+    #[serde(default)]
+    pub previous_port: Option<String>,
     pub is_connected: bool,
     pub available_for_exclusive: bool,
     pub exclusive_holder: Option<String>,
@@ -357,6 +365,8 @@ pub struct DeviceLeaseInfoResponse {
     pub lease_type: String,
     pub description: String,
     pub acquired_at: f64,
+    #[serde(default)]
+    pub track_serial: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/fbuild-daemon/src/device_manager.rs
+++ b/crates/fbuild-daemon/src/device_manager.rs
@@ -25,6 +25,7 @@ pub struct DeviceLease {
     pub lease_type: LeaseType,
     pub description: String,
     pub acquired_at: f64,
+    pub track_serial: bool,
 }
 
 /// Structured error for lease acquisition failures.
@@ -100,6 +101,8 @@ pub struct DeviceState {
     pub description: String,
     pub vid: Option<u16>,
     pub pid: Option<u16>,
+    pub serial_number: Option<String>,
+    pub previous_port: Option<String>,
     pub exclusive_lease: Option<DeviceLease>,
     pub monitor_leases: HashMap<String, DeviceLease>,
     pub last_seen_at: f64,
@@ -123,6 +126,24 @@ impl DeviceState {
     pub fn monitor_count(&self) -> usize {
         self.monitor_leases.len()
     }
+
+    pub fn has_tracked_serial_lease(&self) -> bool {
+        self.exclusive_lease
+            .as_ref()
+            .map(|lease| lease.track_serial)
+            .unwrap_or(false)
+            || self.monitor_leases.values().any(|lease| lease.track_serial)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DiscoveredDevice {
+    port: String,
+    device_id: String,
+    description: String,
+    vid: Option<u16>,
+    pid: Option<u16>,
+    serial_number: Option<String>,
 }
 
 /// Thread-safe device manager.
@@ -189,6 +210,47 @@ impl DeviceManager {
             }
         };
 
+        let discovered: Vec<DiscoveredDevice> = ports
+            .into_iter()
+            .map(|port_info| {
+                let (vid, pid, desc) = match &port_info.port_type {
+                    serialport::SerialPortType::UsbPort(usb) => (
+                        Some(usb.vid),
+                        Some(usb.pid),
+                        usb.product
+                            .clone()
+                            .unwrap_or_else(|| "USB Serial Device".to_string()),
+                    ),
+                    serialport::SerialPortType::BluetoothPort => {
+                        (None, None, "Bluetooth Serial".to_string())
+                    }
+                    serialport::SerialPortType::PciPort => (None, None, "PCI Serial".to_string()),
+                    serialport::SerialPortType::Unknown => (None, None, "Unknown".to_string()),
+                };
+                let serial_number = match &port_info.port_type {
+                    serialport::SerialPortType::UsbPort(usb) => usb.serial_number.clone(),
+                    _ => None,
+                };
+                let device_id = vid
+                    .map(|v| format!("{:04x}:{:04x}", v, pid.unwrap_or(0)))
+                    .unwrap_or_else(|| port_info.port_name.clone());
+
+                DiscoveredDevice {
+                    port: port_info.port_name,
+                    device_id,
+                    description: desc,
+                    vid,
+                    pid,
+                    serial_number,
+                }
+            })
+            .collect();
+
+        self.refresh_from_discovered(discovered);
+        *self.last_refresh_at.lock().unwrap() = Some(Instant::now());
+    }
+
+    fn refresh_from_discovered(&self, discovered: Vec<DiscoveredDevice>) {
         let mut devices = self.devices.lock().unwrap();
         let now = Self::now_unix();
 
@@ -205,35 +267,42 @@ impl DeviceManager {
         }
 
         // Update from discovered ports
-        for port_info in ports {
-            let (vid, pid, desc) = match &port_info.port_type {
-                serialport::SerialPortType::UsbPort(usb) => (
-                    Some(usb.vid),
-                    Some(usb.pid),
-                    usb.product
-                        .clone()
-                        .unwrap_or_else(|| "USB Serial Device".to_string()),
-                ),
-                serialport::SerialPortType::BluetoothPort => {
-                    (None, None, "Bluetooth Serial".to_string())
+        for device in discovered {
+            let key = device.port.clone();
+            if !devices.contains_key(&key) {
+                if let Some(serial) = device.serial_number.as_deref() {
+                    let moved_from = devices.iter().find_map(|(old_port, state)| {
+                        (state.serial_number.as_deref() == Some(serial)
+                            && !state.is_connected
+                            && state.has_tracked_serial_lease())
+                        .then(|| old_port.clone())
+                    });
+                    if let Some(old_port) = moved_from {
+                        if let Some(mut state) = devices.remove(&old_port) {
+                            state.previous_port = Some(old_port);
+                            state.port = key.clone();
+                            state.is_connected = true;
+                            state.last_seen_at = now;
+                            state.description = device.description;
+                            state.device_id = device.device_id;
+                            state.vid = device.vid;
+                            state.pid = device.pid;
+                            state.serial_number = device.serial_number;
+                            devices.insert(key, state);
+                            continue;
+                        }
+                    }
                 }
-                serialport::SerialPortType::PciPort => (None, None, "PCI Serial".to_string()),
-                serialport::SerialPortType::Unknown => (None, None, "Unknown".to_string()),
-            };
-
-            let device_id = vid
-                .map(|v| format!("{:04x}:{:04x}", v, pid.unwrap_or(0)))
-                .unwrap_or_else(|| port_info.port_name.clone());
-
-            // Use port name as the unique key (device_id can have duplicates for same VID:PID)
-            let key = port_info.port_name.clone();
+            }
 
             let entry = devices.entry(key).or_insert_with(|| DeviceState {
-                device_id: device_id.clone(),
-                port: port_info.port_name.clone(),
-                description: desc.clone(),
-                vid,
-                pid,
+                device_id: device.device_id.clone(),
+                port: device.port.clone(),
+                description: device.description.clone(),
+                vid: device.vid,
+                pid: device.pid,
+                serial_number: device.serial_number.clone(),
+                previous_port: None,
                 exclusive_lease: None,
                 monitor_leases: HashMap::new(),
                 last_seen_at: now,
@@ -244,10 +313,11 @@ impl DeviceManager {
 
             entry.is_connected = true;
             entry.last_seen_at = now;
-            entry.description = desc;
-            entry.device_id = device_id;
-            entry.vid = vid;
-            entry.pid = pid;
+            entry.description = device.description;
+            entry.device_id = device.device_id;
+            entry.vid = device.vid;
+            entry.pid = device.pid;
+            entry.serial_number = device.serial_number;
         }
 
         // Stamp `last_disconnect_at` for every device that went from
@@ -264,11 +334,6 @@ impl DeviceManager {
                 }
             }
         }
-        drop(devices);
-        // Record the successful enumeration so `refresh_devices_if_stale`
-        // can short-circuit subsequent calls inside the freshness
-        // window.
-        *self.last_refresh_at.lock().unwrap() = Some(Instant::now());
     }
 
     /// Get all devices.
@@ -287,6 +352,7 @@ impl DeviceManager {
         port: &str,
         client_id: &str,
         description: &str,
+        track_serial: bool,
     ) -> Result<DeviceLease, DeviceLeaseError> {
         let mut devices = self.devices.lock().unwrap();
         let state = devices
@@ -316,6 +382,7 @@ impl DeviceManager {
             lease_type: LeaseType::Exclusive,
             description: description.to_string(),
             acquired_at: Self::now_unix(),
+            track_serial,
         };
 
         state.exclusive_lease = Some(lease.clone());
@@ -333,6 +400,7 @@ impl DeviceManager {
         port: &str,
         client_id: &str,
         description: &str,
+        track_serial: bool,
     ) -> Result<DeviceLease, DeviceLeaseError> {
         let mut devices = self.devices.lock().unwrap();
         let state = devices
@@ -353,6 +421,7 @@ impl DeviceManager {
             lease_type: LeaseType::Monitor,
             description: description.to_string(),
             acquired_at: Self::now_unix(),
+            track_serial,
         };
 
         state
@@ -457,6 +526,7 @@ impl DeviceManager {
             lease_type: LeaseType::Exclusive,
             description: format!("preempted: {}", reason),
             acquired_at: Self::now_unix(),
+            track_serial: false,
         };
 
         state.exclusive_lease = Some(lease.clone());
@@ -545,6 +615,8 @@ impl DeviceManager {
                 description: "Test Device".to_string(),
                 vid: Some(0x1234),
                 pid: Some(0x5678),
+                serial_number: Some("TEST-SERIAL".to_string()),
+                previous_port: None,
                 exclusive_lease: None,
                 monitor_leases: HashMap::new(),
                 last_seen_at: Self::now_unix(),
@@ -576,7 +648,7 @@ mod tests {
     fn acquire_exclusive_succeeds() {
         let mgr = make_manager_with_device("COM3");
         let lease = mgr
-            .acquire_exclusive("COM3", "client-1", "testing")
+            .acquire_exclusive("COM3", "client-1", "testing", false)
             .unwrap();
         assert_eq!(lease.lease_type, LeaseType::Exclusive);
         assert_eq!(lease.client_id, "client-1");
@@ -585,8 +657,9 @@ mod tests {
     #[test]
     fn acquire_exclusive_twice_fails() {
         let mgr = make_manager_with_device("COM3");
-        mgr.acquire_exclusive("COM3", "client-1", "first").unwrap();
-        let result = mgr.acquire_exclusive("COM3", "client-2", "second");
+        mgr.acquire_exclusive("COM3", "client-1", "first", false)
+            .unwrap();
+        let result = mgr.acquire_exclusive("COM3", "client-2", "second", false);
         match result.unwrap_err() {
             DeviceLeaseError::ExclusiveConflict {
                 port,
@@ -607,7 +680,7 @@ mod tests {
     fn acquire_monitor_succeeds() {
         let mgr = make_manager_with_device("COM3");
         let lease = mgr
-            .acquire_monitor("COM3", "client-1", "monitoring")
+            .acquire_monitor("COM3", "client-1", "monitoring", false)
             .unwrap();
         assert_eq!(lease.lease_type, LeaseType::Monitor);
     }
@@ -615,8 +688,10 @@ mod tests {
     #[test]
     fn multiple_monitor_leases_allowed() {
         let mgr = make_manager_with_device("COM3");
-        mgr.acquire_monitor("COM3", "client-1", "m1").unwrap();
-        mgr.acquire_monitor("COM3", "client-2", "m2").unwrap();
+        mgr.acquire_monitor("COM3", "client-1", "m1", false)
+            .unwrap();
+        mgr.acquire_monitor("COM3", "client-2", "m2", false)
+            .unwrap();
         let state = mgr.get_device_status("COM3").unwrap();
         assert_eq!(state.monitor_count(), 2);
     }
@@ -624,7 +699,9 @@ mod tests {
     #[test]
     fn release_lease_by_id() {
         let mgr = make_manager_with_device("COM3");
-        let lease = mgr.acquire_exclusive("COM3", "client-1", "test").unwrap();
+        let lease = mgr
+            .acquire_exclusive("COM3", "client-1", "test", false)
+            .unwrap();
         mgr.release_lease(&lease.lease_id).unwrap();
         let state = mgr.get_device_status("COM3").unwrap();
         assert!(state.exclusive_lease.is_none());
@@ -639,8 +716,8 @@ mod tests {
     #[test]
     fn release_device_leases_clears_all() {
         let mgr = make_manager_with_device("COM3");
-        mgr.acquire_exclusive("COM3", "c1", "exc").unwrap();
-        mgr.acquire_monitor("COM3", "c2", "mon").unwrap();
+        mgr.acquire_exclusive("COM3", "c1", "exc", false).unwrap();
+        mgr.acquire_monitor("COM3", "c2", "mon", false).unwrap();
         let count = mgr.release_device_leases("COM3").unwrap();
         assert_eq!(count, 2); // 1 exclusive + 1 monitor
         let state = mgr.get_device_status("COM3").unwrap();
@@ -651,7 +728,8 @@ mod tests {
     #[test]
     fn preempt_requires_reason() {
         let mgr = make_manager_with_device("COM3");
-        mgr.acquire_exclusive("COM3", "c1", "holder").unwrap();
+        mgr.acquire_exclusive("COM3", "c1", "holder", false)
+            .unwrap();
         let result = mgr.preempt_device("COM3", "c2", "");
         assert!(result.is_err());
         assert!(result.unwrap_err().message().contains("reason is required"));
@@ -660,7 +738,8 @@ mod tests {
     #[test]
     fn preempt_replaces_holder() {
         let mgr = make_manager_with_device("COM3");
-        mgr.acquire_exclusive("COM3", "c1", "original").unwrap();
+        mgr.acquire_exclusive("COM3", "c1", "original", false)
+            .unwrap();
         let (lease, preempted) = mgr.preempt_device("COM3", "c2", "urgent deploy").unwrap();
         assert_eq!(lease.client_id, "c2");
         assert_eq!(lease.lease_type, LeaseType::Exclusive);
@@ -673,8 +752,8 @@ mod tests {
     #[test]
     fn device_not_found_errors() {
         let mgr = DeviceManager::new();
-        assert!(mgr.acquire_exclusive("COM99", "c1", "x").is_err());
-        assert!(mgr.acquire_monitor("COM99", "c1", "x").is_err());
+        assert!(mgr.acquire_exclusive("COM99", "c1", "x", false).is_err());
+        assert!(mgr.acquire_monitor("COM99", "c1", "x", false).is_err());
         assert!(mgr.preempt_device("COM99", "c1", "reason").is_err());
     }
 
@@ -685,8 +764,8 @@ mod tests {
             let mut devices = mgr.devices.lock().unwrap();
             devices.get_mut("COM3").unwrap().is_connected = false;
         }
-        assert!(mgr.acquire_exclusive("COM3", "c1", "x").is_err());
-        assert!(mgr.acquire_monitor("COM3", "c1", "x").is_err());
+        assert!(mgr.acquire_exclusive("COM3", "c1", "x", false).is_err());
+        assert!(mgr.acquire_monitor("COM3", "c1", "x", false).is_err());
         assert!(mgr.preempt_device("COM3", "c1", "reason").is_err());
     }
 
@@ -722,6 +801,56 @@ mod tests {
         let mgr = DeviceManager::new();
         assert!(mgr.refresh_devices_if_stale(std::time::Duration::from_secs(5)));
         assert!(mgr.refresh_devices_if_stale(std::time::Duration::ZERO));
+    }
+
+    #[test]
+    fn tracked_serial_lease_moves_to_new_port_on_refresh() {
+        let mgr = make_manager_with_device("COM3");
+        mgr.acquire_exclusive("COM3", "c1", "tracked deploy", true)
+            .unwrap();
+
+        mgr.refresh_from_discovered(vec![DiscoveredDevice {
+            port: "COM4".to_string(),
+            device_id: "1234:5678".to_string(),
+            description: "Test Device Renumbered".to_string(),
+            vid: Some(0x1234),
+            pid: Some(0x5678),
+            serial_number: Some("TEST-SERIAL".to_string()),
+        }]);
+
+        assert!(mgr.get_device_status("COM3").is_none());
+        let moved = mgr.get_device_status("COM4").unwrap();
+        assert_eq!(moved.previous_port.as_deref(), Some("COM3"));
+        assert_eq!(
+            moved.exclusive_lease.as_ref().map(|l| l.client_id.as_str()),
+            Some("c1")
+        );
+        assert!(
+            moved.exclusive_lease.as_ref().unwrap().track_serial,
+            "moved lease must retain track_serial"
+        );
+    }
+
+    #[test]
+    fn untracked_serial_lease_stays_on_old_disconnected_port() {
+        let mgr = make_manager_with_device("COM3");
+        mgr.acquire_exclusive("COM3", "c1", "untracked deploy", false)
+            .unwrap();
+
+        mgr.refresh_from_discovered(vec![DiscoveredDevice {
+            port: "COM4".to_string(),
+            device_id: "1234:5678".to_string(),
+            description: "Test Device Renumbered".to_string(),
+            vid: Some(0x1234),
+            pid: Some(0x5678),
+            serial_number: Some("TEST-SERIAL".to_string()),
+        }]);
+
+        let old = mgr.get_device_status("COM3").unwrap();
+        assert!(!old.is_connected);
+        assert!(old.exclusive_lease.is_some());
+        let new = mgr.get_device_status("COM4").unwrap();
+        assert!(new.exclusive_lease.is_none());
     }
 
     #[test]
@@ -794,7 +923,8 @@ mod tests {
     #[test]
     fn cleanup_preserves_leased_disconnected() {
         let mgr = make_manager_with_device("COM3");
-        mgr.acquire_exclusive("COM3", "c1", "deploy").unwrap();
+        mgr.acquire_exclusive("COM3", "c1", "deploy", false)
+            .unwrap();
         {
             let mut devices = mgr.devices.lock().unwrap();
             devices.get_mut("COM3").unwrap().is_connected = false;

--- a/crates/fbuild-daemon/src/handlers/devices.rs
+++ b/crates/fbuild-daemon/src/handlers/devices.rs
@@ -41,6 +41,8 @@ pub async fn device_status(
             port: port.clone(),
             device_id: String::new(),
             description: format!("device '{}' not found", port),
+            serial_number: None,
+            previous_port: None,
             is_connected: false,
             available_for_exclusive: false,
             exclusive_holder: None,
@@ -57,6 +59,8 @@ fn device_info(state: &DeviceState) -> DeviceInfo {
         device_id: Some(state.device_id.clone()),
         vid: state.vid,
         pid: state.pid,
+        serial_number: state.serial_number.clone(),
+        previous_port: state.previous_port.clone(),
         description: state.description.clone(),
         available_for_exclusive: state.is_available_for_exclusive(),
         exclusive_lease: state.exclusive_lease.as_ref().map(lease_info),
@@ -75,6 +79,8 @@ fn device_status_response(state: DeviceState) -> DeviceStatusResponse {
         port: state.port,
         device_id: state.device_id,
         description: state.description,
+        serial_number: state.serial_number,
+        previous_port: state.previous_port,
         is_connected: state.is_connected,
         available_for_exclusive: available,
         exclusive_holder: holder,
@@ -96,12 +102,18 @@ pub async fn device_lease(
     state.device_manager.refresh_devices();
 
     let result = match req.lease_type.as_str() {
-        "exclusive" => state
-            .device_manager
-            .acquire_exclusive(&port, &client_id, &req.description),
-        "monitor" => state
-            .device_manager
-            .acquire_monitor(&port, &client_id, &req.description),
+        "exclusive" => state.device_manager.acquire_exclusive(
+            &port,
+            &client_id,
+            &req.description,
+            req.track_serial,
+        ),
+        "monitor" => state.device_manager.acquire_monitor(
+            &port,
+            &client_id,
+            &req.description,
+            req.track_serial,
+        ),
         other => Err(DeviceLeaseError::InvalidLeaseType {
             lease_type: other.to_string(),
         }),
@@ -197,6 +209,7 @@ fn lease_info(lease: &DeviceLease) -> DeviceLeaseInfo {
         },
         description: lease.description.clone(),
         acquired_at: lease.acquired_at,
+        track_serial: lease.track_serial,
     }
 }
 
@@ -227,10 +240,10 @@ mod tests {
         let manager = DeviceManager::new();
         manager.insert_test_device("COM3");
         manager
-            .acquire_exclusive("COM3", "pid 100 alice", "deploy")
+            .acquire_exclusive("COM3", "pid 100 alice", "deploy", true)
             .unwrap();
         manager
-            .acquire_monitor("COM3", "pid 200 bob", "monitor")
+            .acquire_monitor("COM3", "pid 200 bob", "monitor", false)
             .unwrap();
 
         let state = manager.get_device_status("COM3").unwrap();
@@ -252,7 +265,7 @@ mod tests {
         let manager = DeviceManager::new();
         manager.insert_test_device("COM4");
         manager
-            .acquire_exclusive("COM4", "pid 300 carol", "autoresearch")
+            .acquire_exclusive("COM4", "pid 300 carol", "autoresearch", true)
             .unwrap();
 
         let state = manager.get_device_status("COM4").unwrap();
@@ -272,10 +285,10 @@ mod tests {
         let manager = DeviceManager::new();
         manager.insert_test_device("COM5");
         manager
-            .acquire_exclusive("COM5", "pid 400 dave", "first deploy")
+            .acquire_exclusive("COM5", "pid 400 dave", "first deploy", true)
             .unwrap();
         let err = manager
-            .acquire_exclusive("COM5", "pid 500 erin", "second deploy")
+            .acquire_exclusive("COM5", "pid 500 erin", "second deploy", false)
             .unwrap_err();
 
         let conflict = lease_conflict(&err).expect("exclusive conflict payload");

--- a/crates/fbuild-daemon/src/handlers/operations/deploy_port.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy_port.rs
@@ -177,6 +177,8 @@ mod tests {
             description: "USB Serial Device".to_string(),
             vid,
             pid,
+            serial_number: None,
+            previous_port: None,
             exclusive_lease: None,
             monitor_leases: HashMap::new(),
             last_seen_at: 0.0,

--- a/crates/fbuild-daemon/src/models.rs
+++ b/crates/fbuild-daemon/src/models.rs
@@ -281,6 +281,10 @@ pub struct DeviceInfo {
     pub vid: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serial_number: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_port: Option<String>,
     pub description: String,
     pub available_for_exclusive: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -351,6 +355,9 @@ pub struct DeviceLeaseRequest {
     pub description: String,
     /// Client identifier (auto-generated if omitted)
     pub client_id: Option<String>,
+    /// Follow a USB device by serial number across port renumbering.
+    #[serde(default)]
+    pub track_serial: bool,
 }
 
 fn default_exclusive() -> String {
@@ -378,6 +385,7 @@ pub struct DeviceLeaseInfo {
     pub lease_type: String,
     pub description: String,
     pub acquired_at: f64,
+    pub track_serial: bool,
 }
 
 /// Structured details for an exclusive lease conflict.
@@ -431,6 +439,10 @@ pub struct DeviceStatusResponse {
     pub port: String,
     pub device_id: String,
     pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serial_number: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_port: Option<String>,
     pub is_connected: bool,
     pub available_for_exclusive: bool,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- add track_serial to device lease requests and lease attribution
- preserve tracked leases when a USB device reappears on a different port with the same serial number
- expose serial/previous-port metadata through daemon responses and CLI device output

Closes #638

## Verification
- soldr cargo fmt --all --check
- soldr cargo check -p fbuild-daemon -p fbuild-cli
- soldr cargo test -p fbuild-daemon device_manager -- --nocapture
- soldr cargo test -p fbuild-daemon handlers::devices -- --nocapture
- soldr cargo test -p fbuild-daemon handlers::operations::deploy_port -- --nocapture
- soldr cargo clippy -p fbuild-daemon -p fbuild-cli --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--track-serial` flag to `fbuild device lease` to follow USB devices by serial number across port renumbering.
  * Device output now displays USB serial numbers when available.
  * Device output now shows previous port information when a device has been renumbered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->