### PR TITLE
fix(hooks): stop triggering full editable rebuild on every Edit/Write

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/board_context.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/board_context.py",
             "timeout": 5
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/tool_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/tool_guard.py",
             "timeout": 5
           }
         ]
@@ -29,12 +29,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/lint.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/lint.py",
             "timeout": 120
           },
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/readme_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/readme_guard.py",
             "timeout": 5
           }
         ]
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/check-on-start.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/check-on-start.py",
             "timeout": 10
           }
         ]
@@ -56,12 +56,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/code-review-on-stop.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/code-review-on-stop.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --script ci/hooks/check-on-stop.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/check-on-stop.py",
             "timeout": 120
           }
         ]

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ tasks/loop-runs/
 # clud project settings
 !.clud/
 !.clud/settings.json
+.claude/tmp/

--- a/ci/hooks/lint.py
+++ b/ci/hooks/lint.py
@@ -35,12 +35,11 @@ def main():
     if not file_path:
         return 0
 
-    # Normalize path
-    file_path = file_path.replace("\\", "/")
-
     # Resolve relative paths against project root
     if not os.path.isabs(file_path):
-        file_path = os.path.join(str(PROJECT_ROOT), file_path).replace("\\", "/")
+        file_path = os.path.join(str(PROJECT_ROOT), file_path)
+
+    file_path = os.path.realpath(file_path)
 
     # Only lint Rust files
     if not file_path.endswith(".rs"):
@@ -54,8 +53,9 @@ def main():
     # of another repo). detect_crate() would otherwise read the worktree's
     # `crates/<x>` segment and run clippy with -p <x> against fbuild, which
     # either fails or — when names collide — lints the wrong code.
-    project_root_norm = str(PROJECT_ROOT).replace("\\", "/").rstrip("/") + "/"
-    if not file_path.startswith(project_root_norm):
+    project_root_real = os.path.normcase(os.path.realpath(str(PROJECT_ROOT)))
+    file_path_check = os.path.normcase(file_path)
+    if os.path.commonpath([project_root_real, file_path_check]) != project_root_real:
         return 0
 
     # Delegate to ./lint in single-file mode. Use the active interpreter

--- a/ci/hooks/lint.py
+++ b/ci/hooks/lint.py
@@ -50,10 +50,21 @@ def main():
     if not os.path.isfile(file_path):
         return 0
 
-    # Delegate to ./lint in single-file mode
+    # Skip files outside this project (e.g. when editing inside a worktree
+    # of another repo). detect_crate() would otherwise read the worktree's
+    # `crates/<x>` segment and run clippy with -p <x> against fbuild, which
+    # either fails or — when names collide — lints the wrong code.
+    project_root_norm = str(PROJECT_ROOT).replace("\\", "/").rstrip("/") + "/"
+    if not file_path.startswith(project_root_norm):
+        return 0
+
+    # Delegate to ./lint in single-file mode. Use the active interpreter
+    # directly instead of `uv run --script` so we don't trigger another
+    # editable-build of the fbuild project (which would re-run
+    # `soldr cargo build --release -p fbuild-cli` on every Edit).
     lint_script = str(PROJECT_ROOT / "lint")
     result = subprocess.run(
-        ["uv", "run", "--script", lint_script, file_path],
+        [sys.executable, lint_script, file_path],
         capture_output=True,
         text=True,
         encoding="utf-8",


### PR DESCRIPTION
## Summary

Two long-standing pain points with `.claude/hooks`:

1. **Every Claude `Edit`/`Write` hook fire was a `soldr cargo build --release -p fbuild-cli`.** `settings.json` used `uv run --script ci/hooks/<name>.py` without `--no-project`. uv discovered the fbuild project and ran `setuptools.build_meta.build_editable` (which fbuild's pyproject wires to the native Rust build). So every file edit kicked off a release build of the CLI — minutes of latency per edit, plus a hard failure whenever the underlying soldr/zccache daemon flaked. All hook scripts use PEP 723 inline script metadata so they don't actually need the project installed.

2. **`lint.py` ran `./lint` against files outside this repo.** When editing files in a sibling repo's worktree (e.g. zccache's), `detect_crate()` read the worktree's `crates/<x>/` segment and ran `soldr cargo clippy -p <x>` against the fbuild workspace. Either errored (no such package) or — when names collided — lint'd the wrong code.

## Fix

- Add `--no-project` to every hook command in `.claude/settings.json`.
- `lint.py`: skip files outside `PROJECT_ROOT`. Invoke `./lint` via `sys.executable` instead of `uv run --script` so the inner call doesn't trigger another editable rebuild.
- `.gitignore`: `.claude/tmp/` (scratch dir for hereoc'd issue bodies during Claude sessions).

No CI behavior change — `cargo fmt --all --check` + clippy still run via the `Stop` hook on workspace-level passes. Per-file Edit hooks now finish in milliseconds instead of minutes.

## Test plan

- [x] Edit a `.rs` file inside this repo — hook fires fast, lints just that file
- [x] Edit a `.rs` file inside a sibling repo's worktree (e.g. `~/dev/zccache/.claude/worktrees/.../crates/zccache/src/...`) — hook skips, no spurious clippy run against fbuild
- [x] `uv run --no-project --script ci/hooks/lint.py < /dev/null` — completes without trying to build fbuild

Refs: surfaced during the zccache#784 work session — the cross-repo edit case is exactly what was misbehaving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration and build hooks.
  * Added temporary files directory to ignore list.

* **Refactor**
  * Optimized lint execution to improve build performance by reducing unnecessary rebuild steps.
  * Enhanced lint request validation to handle edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->