### PR TITLE
chore: bump managed zccache 1.12.8 -> 1.12.9, version 2.2.30 -> 2.2.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "async-trait",
  "blake3",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "blake3",
  "clap",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "libc",
  "running-process",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "async-trait",
  "axum",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "criterion",
  "rayon",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "bincode",
  "blake3",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "axum",
  "bzip2",
@@ -1095,14 +1095,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "async-trait",
  "base64",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.2.30"
+version = "2.2.31"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.30"
+version = "2.2.31"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/crates/fbuild-build/src/managed_zccache.rs
+++ b/crates/fbuild-build/src/managed_zccache.rs
@@ -24,12 +24,12 @@ use fbuild_core::{FbuildError, Result};
 
 /// The zccache release fbuild pins. Bump in lockstep with the floor that
 /// the rest of the toolchain expects.
-pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.8";
+pub const MANAGED_ZCCACHE_VERSION: &str = "1.12.9";
 
 /// GitHub release tag for [`MANAGED_ZCCACHE_VERSION`]. The zccache release
 /// workflow tags without a `v` prefix, while the per-asset filenames carry
 /// `v<version>` — keep both spellings in sync when bumping.
-const RELEASE_TAG: &str = "1.12.8";
+const RELEASE_TAG: &str = "1.12.9";
 
 /// Source repository for managed downloads.
 const REPO: &str = "zackees/zccache";

--- a/crates/fbuild-daemon/src/models.rs
+++ b/crates/fbuild-daemon/src/models.rs
@@ -845,11 +845,11 @@ mod tests {
             current_operation: Some("Building /tmp/myproject".into()),
             dependency_install: Some(fbuild_core::install_status::status(
                 "zccache",
-                Some("1.12.8"),
+                Some("1.12.9"),
                 fbuild_core::install_status::InstallPhase::WaitingForLock,
                 fbuild_core::install_status::InstallRole::Waiter,
                 "waiting for managed zccache",
-                Some(".zccache-1.12.8.install.lock"),
+                Some(".zccache-1.12.9.install.lock"),
             )),
             client_count: 1,
             cache_dir: "/tmp/cache".into(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.30"
+version = "2.2.31"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bumps fbuild's pinned zccache release to **1.12.9** (Windows daemon unstick fix from zccache#775 + the v2 IPC scaffolding from zccache#778–#781). Bumps fbuild's own version 2.2.30 -> 2.2.31 so the autonomous-release action ships a wheel that resolves the new managed download.

### What ships

- `crates/fbuild-build/src/managed_zccache.rs` — `MANAGED_ZCCACHE_VERSION` and `RELEASE_TAG` 1.12.8 -> 1.12.9
- `crates/fbuild-daemon/src/models.rs` — `DaemonInfoResponse` test-fixture strings updated in lockstep
- `Cargo.toml`, `pyproject.toml`, `Cargo.lock` — workspace + Python version 2.2.30 -> 2.2.31

### Coordination

Coordinated with **zackees/zccache#783** (already merged + published — 1.12.9 is live on PyPI + crates.io + GitHub Releases). fbuild's managed-zccache downloader will resolve the new tag immediately on next run.

## Test plan

- [x] zccache 1.12.9 published on PyPI + crates.io + GitHub Releases before this PR opened (verified via `gh run view 27854992359 --repo zackees/zccache` → all green)
- [ ] fbuild CI on this PR is green
- [ ] After merge: `release-auto.yml` detects the version bump, builds wheels, ships fbuild 2.2.31 to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.2.31
  * Updated a build dependency to its latest patch version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->