### PR TITLE
feat(nxplpc): honor platform_packages override for ArduinoCore-LPC8xx (#663)

### DIFF
--- a/crates/fbuild-build/src/nxplpc/mod.rs
+++ b/crates/fbuild-build/src/nxplpc/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod mcu_config;
 pub mod orchestrator;
+pub mod platform_packages;
 
 use std::path::Path;
 

--- a/crates/fbuild-build/src/nxplpc/orchestrator.rs
+++ b/crates/fbuild-build/src/nxplpc/orchestrator.rs
@@ -118,7 +118,33 @@ impl BuildOrchestrator for NxpLpcOrchestrator {
         //    embedded `arduino_stub/` shim (FastLED/fbuild#479, #487): the
         //    framework owns `main()`, startup + vector table, wiring,
         //    HardwareSerial, SPI, and the device headers.
-        let core = fbuild_packages::library::ArduinoCoreLpc8xx::new(&params.project_dir);
+        //
+        //    Consumer override (FastLED/fbuild#663): when `platformio.ini`
+        //    carries `platform_packages = framework-arduino-lpc8xx@<spec>`,
+        //    fetch and use that commit instead of the const-pinned default
+        //    — needed for bisection workflows like FastLED/FastLED#3325.
+        let env_config = ctx.config.get_env_config(&params.env_name)?;
+        let core_override =
+            super::platform_packages::lookup_override(env_config, "framework-arduino-lpc8xx");
+        let core = match &core_override {
+            Some(ovr) => {
+                let short = &ovr.git_ref[..7.min(ovr.git_ref.len())];
+                let version = format!("override+g{}", short);
+                let banner = format!(
+                    "ArduinoCore-LPC8xx OVERRIDE: {} (default pinned: {})",
+                    ovr.archive_url,
+                    fbuild_packages::library::ArduinoCoreLpc8xx::commit()
+                );
+                tracing::info!("{}", banner);
+                ctx.build_log.push(banner);
+                fbuild_packages::library::ArduinoCoreLpc8xx::with_override(
+                    &params.project_dir,
+                    &ovr.archive_url,
+                    &version,
+                )
+            }
+            None => fbuild_packages::library::ArduinoCoreLpc8xx::new(&params.project_dir),
+        };
         let core_root = fbuild_packages::Package::ensure_installed(&core)?;
         tracing::info!("ArduinoCore-LPC8xx at {}", core_root.display());
 

--- a/crates/fbuild-build/src/nxplpc/platform_packages.rs
+++ b/crates/fbuild-build/src/nxplpc/platform_packages.rs
@@ -1,0 +1,259 @@
+//! Parser for PlatformIO `platform_packages` framework overrides
+//! (FastLED/fbuild#663).
+//!
+//! `platform_packages` is a multi-line PIO config option whose value lines
+//! look like `<name>@<spec>`. For framework packages, the consumer is
+//! pinning an upstream source so fbuild can fetch the override commit
+//! instead of the const-pinned default. PIO honors several spec forms;
+//! the ones relevant here all resolve to a downloadable GitHub archive
+//! plus the ref the consumer pinned:
+//!
+//! - `<owner>/<repo>#<ref>` — GitHub shorthand.
+//! - `https://github.com/<owner>/<repo>.git#<ref>` — git URL.
+//! - `https://.../<commit>.tar.gz` — direct archive URL (no `#ref`).
+//!
+//! The parser is scoped to the lpc8xx fix in #663. Future work
+//! (FastLED/fbuild#664) will generalize this to every framework package.
+
+use std::collections::HashMap;
+
+/// A resolved framework override: a downloadable archive URL plus the ref
+/// (commit / tag) the consumer pinned. The caller turns the ref into a
+/// synthetic cache `version` so override installs don't collide with the
+/// default pin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlatformPackageOverride {
+    pub archive_url: String,
+    pub git_ref: String,
+}
+
+/// Look up `framework` inside the resolved `[env:*]` config and return
+/// the override the consumer pinned, if any.
+pub fn lookup_override(
+    env_config: &HashMap<String, String>,
+    framework: &str,
+) -> Option<PlatformPackageOverride> {
+    let raw = env_config.get("platform_packages")?;
+    parse_platform_packages_entry(raw, framework)
+}
+
+/// Scan a `platform_packages` multi-line value for `<framework>@<spec>`
+/// and resolve `<spec>` to an archive URL + ref.
+pub fn parse_platform_packages_entry(
+    raw: &str,
+    framework: &str,
+) -> Option<PlatformPackageOverride> {
+    for line in raw.lines() {
+        let line = strip_inline_comment(line.trim());
+        if line.is_empty() {
+            continue;
+        }
+        let (name, spec) = match line.split_once('@') {
+            Some(pair) => pair,
+            None => continue,
+        };
+        if name.trim() != framework {
+            continue;
+        }
+        if let Some(parsed) = resolve_spec(spec.trim()) {
+            return Some(parsed);
+        }
+    }
+    None
+}
+
+fn resolve_spec(spec: &str) -> Option<PlatformPackageOverride> {
+    if let Some((source, git_ref)) = spec.rsplit_once('#') {
+        let source = source.trim();
+        let git_ref = git_ref.trim();
+        if git_ref.is_empty() {
+            return None;
+        }
+
+        if let Some(rest) = source.strip_prefix("https://github.com/") {
+            let repo = rest.strip_suffix(".git").unwrap_or(rest);
+            let repo = repo.trim_end_matches('/');
+            if is_owner_repo(repo) {
+                return Some(PlatformPackageOverride {
+                    archive_url: github_archive_url(repo, git_ref),
+                    git_ref: git_ref.to_string(),
+                });
+            }
+        }
+
+        if is_owner_repo(source) {
+            return Some(PlatformPackageOverride {
+                archive_url: github_archive_url(source, git_ref),
+                git_ref: git_ref.to_string(),
+            });
+        }
+    }
+
+    if is_archive_url(spec) {
+        let git_ref = spec
+            .rsplit('/')
+            .next()
+            .unwrap_or(spec)
+            .trim_end_matches(".tar.gz")
+            .trim_end_matches(".tar.bz2")
+            .trim_end_matches(".zip")
+            .to_string();
+        return Some(PlatformPackageOverride {
+            archive_url: spec.to_string(),
+            git_ref,
+        });
+    }
+
+    None
+}
+
+fn is_owner_repo(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('/').collect();
+    parts.len() == 2
+        && !parts[0].is_empty()
+        && !parts[1].is_empty()
+        && !s.contains("://")
+        && !s.contains(' ')
+}
+
+fn is_archive_url(s: &str) -> bool {
+    (s.starts_with("http://") || s.starts_with("https://"))
+        && (s.ends_with(".tar.gz") || s.ends_with(".tar.bz2") || s.ends_with(".zip"))
+}
+
+fn github_archive_url(owner_repo: &str, git_ref: &str) -> String {
+    format!(
+        "https://github.com/{}/archive/{}.tar.gz",
+        owner_repo, git_ref
+    )
+}
+
+fn strip_inline_comment(s: &str) -> &str {
+    for marker in [" ;", " #"] {
+        if let Some(idx) = s.find(marker) {
+            return s[..idx].trim();
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(value: &str) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("platform_packages".to_string(), value.to_string());
+        m
+    }
+
+    #[test]
+    fn shorthand_owner_repo_resolves_to_archive_url() {
+        let got = parse_platform_packages_entry(
+            "framework-arduino-lpc8xx@zackees/ArduinoCore-LPC8xx#195a2ed",
+            "framework-arduino-lpc8xx",
+        )
+        .unwrap();
+        assert_eq!(
+            got,
+            PlatformPackageOverride {
+                archive_url: "https://github.com/zackees/ArduinoCore-LPC8xx/archive/195a2ed.tar.gz"
+                    .to_string(),
+                git_ref: "195a2ed".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn git_url_with_ref_resolves_to_archive_url() {
+        let got = parse_platform_packages_entry(
+            "framework-arduino-lpc8xx@https://github.com/zackees/ArduinoCore-LPC8xx.git#deadbee",
+            "framework-arduino-lpc8xx",
+        )
+        .unwrap();
+        assert_eq!(
+            got.archive_url,
+            "https://github.com/zackees/ArduinoCore-LPC8xx/archive/deadbee.tar.gz"
+        );
+        assert_eq!(got.git_ref, "deadbee");
+    }
+
+    #[test]
+    fn github_https_url_without_dot_git_still_resolves() {
+        let got = parse_platform_packages_entry(
+            "framework-arduino-lpc8xx@https://github.com/zackees/ArduinoCore-LPC8xx#abc1234",
+            "framework-arduino-lpc8xx",
+        )
+        .unwrap();
+        assert_eq!(
+            got.archive_url,
+            "https://github.com/zackees/ArduinoCore-LPC8xx/archive/abc1234.tar.gz"
+        );
+        assert_eq!(got.git_ref, "abc1234");
+    }
+
+    #[test]
+    fn direct_archive_url_passes_through() {
+        let got = parse_platform_packages_entry(
+            "framework-arduino-lpc8xx@https://github.com/zackees/ArduinoCore-LPC8xx/archive/195a2ed.tar.gz",
+            "framework-arduino-lpc8xx",
+        )
+        .unwrap();
+        assert_eq!(
+            got.archive_url,
+            "https://github.com/zackees/ArduinoCore-LPC8xx/archive/195a2ed.tar.gz"
+        );
+        assert_eq!(got.git_ref, "195a2ed");
+    }
+
+    #[test]
+    fn multiline_value_finds_the_matching_framework() {
+        let raw = "\n    other-framework@foo/bar#1\n    framework-arduino-lpc8xx@zackees/ArduinoCore-LPC8xx#deadbee\n";
+        let got = parse_platform_packages_entry(raw, "framework-arduino-lpc8xx").unwrap();
+        assert_eq!(got.git_ref, "deadbee");
+    }
+
+    #[test]
+    fn no_match_when_framework_name_differs() {
+        let got = parse_platform_packages_entry(
+            "framework-other@zackees/ArduinoCore-LPC8xx#deadbee",
+            "framework-arduino-lpc8xx",
+        );
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn returns_none_on_empty_value() {
+        let got = parse_platform_packages_entry("", "framework-arduino-lpc8xx");
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn lookup_override_reads_from_env_config() {
+        let cfg = env("framework-arduino-lpc8xx@zackees/ArduinoCore-LPC8xx#deadbee");
+        let got = lookup_override(&cfg, "framework-arduino-lpc8xx").unwrap();
+        assert_eq!(got.git_ref, "deadbee");
+    }
+
+    #[test]
+    fn lookup_override_returns_none_when_key_missing() {
+        let cfg: HashMap<String, String> = HashMap::new();
+        assert!(lookup_override(&cfg, "framework-arduino-lpc8xx").is_none());
+    }
+
+    #[test]
+    fn ignores_comments_and_blank_lines() {
+        let raw = "\n# comment\n    ; inline-style\n    framework-arduino-lpc8xx@zackees/ArduinoCore-LPC8xx#deadbee\n";
+        let got = parse_platform_packages_entry(raw, "framework-arduino-lpc8xx").unwrap();
+        assert_eq!(got.git_ref, "deadbee");
+    }
+
+    #[test]
+    fn empty_ref_rejected() {
+        let got = parse_platform_packages_entry(
+            "framework-arduino-lpc8xx@zackees/ArduinoCore-LPC8xx#",
+            "framework-arduino-lpc8xx",
+        );
+        assert!(got.is_none());
+    }
+}

--- a/crates/fbuild-packages/src/library/arduino_core_lpc8xx.rs
+++ b/crates/fbuild-packages/src/library/arduino_core_lpc8xx.rs
@@ -53,6 +53,33 @@ impl ArduinoCoreLpc8xx {
         }
     }
 
+    /// Consumer-overridden core source (FastLED/fbuild#663).
+    ///
+    /// Used when `platformio.ini` carries a
+    /// `platform_packages = framework-arduino-lpc8xx@<URL>#<sha>` line so
+    /// the consumer can swap in an arbitrary upstream commit for
+    /// development or bisection (e.g. FastLED/FastLED#3325). The cache
+    /// subdir keys on `url` + `version`, so an override never collides
+    /// with the default-pinned install.
+    ///
+    /// `url` must resolve to a downloadable archive (`.tar.gz` / `.zip`);
+    /// `version` is the synthetic cache-version string (e.g.
+    /// `override+g<short-sha>`). No sha256 check is performed — the
+    /// consumer is explicitly pinning their own commit.
+    pub fn with_override(project_dir: &Path, url: &str, version: &str) -> Self {
+        Self {
+            base: PackageBase::new(
+                "framework-arduino-lpc8xx",
+                version,
+                url,
+                url,
+                None,
+                CacheSubdir::Platforms,
+                project_dir,
+            ),
+        }
+    }
+
     #[cfg(test)]
     fn with_cache_root(project_dir: &Path, cache_root: &Path) -> Self {
         Self {
@@ -62,6 +89,27 @@ impl ArduinoCoreLpc8xx {
                 ACLPC_URL,
                 ACLPC_URL,
                 Some(ACLPC_CHECKSUM),
+                CacheSubdir::Platforms,
+                project_dir,
+                cache_root,
+            ),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_override_and_cache_root(
+        project_dir: &Path,
+        url: &str,
+        version: &str,
+        cache_root: &Path,
+    ) -> Self {
+        Self {
+            base: PackageBase::with_cache_root(
+                "framework-arduino-lpc8xx",
+                version,
+                url,
+                url,
+                None,
                 CacheSubdir::Platforms,
                 project_dir,
                 cache_root,
@@ -205,5 +253,22 @@ mod tests {
     #[test]
     fn commit_is_pinned() {
         assert_eq!(ArduinoCoreLpc8xx::commit().len(), 40);
+    }
+
+    #[test]
+    fn override_uses_distinct_cache_path() {
+        // FastLED/fbuild#663: an override must cache to a different
+        // subdir than the default pin so the two installs don't collide.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache_root = tmp.path().join("cache");
+        let default_pkg = ArduinoCoreLpc8xx::with_cache_root(tmp.path(), &cache_root);
+        let override_pkg = ArduinoCoreLpc8xx::with_override_and_cache_root(
+            tmp.path(),
+            "https://github.com/zackees/ArduinoCore-LPC8xx/archive/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef.tar.gz",
+            "override+gdeadbee",
+            &cache_root,
+        );
+        assert_ne!(default_pkg.install_path(), override_pkg.install_path());
+        assert!(!override_pkg.is_installed());
     }
 }


### PR DESCRIPTION
## Summary

Closes #663. PlatformIO honors \`platform_packages = framework-arduino-lpc8xx@<URL>#<sha>\` and re-clones the framework per-pin; fbuild silently dropped that line because \`ArduinoCoreLpc8xx\` exposed only a default constructor over its const-pinned URL + sha256, and the nxplpc orchestrator never read \`platform_packages\` from \`env_config\`. This blocked FastLED/FastLED#3325 (LPC845-BRK JSON-RPC echo regression bisection) on the fbuild backend.

- \`arduino_core_lpc8xx.rs\`: add \`with_override(project_dir, url, version)\` — cache subdir keys on URL + version so the override never collides with the default-pinned install, and sha256 is skipped (consumer is explicitly pinning their own commit).
- \`nxplpc/platform_packages.rs\` (new): parser for the PIO \`platform_packages\` multi-line value. Handles \`owner/repo#ref\` shorthand, \`https://github.com/owner/repo.git#ref\`, raw \`https://github.com/owner/repo#ref\`, and bare archive URLs.
- \`nxplpc/orchestrator.rs\`: read the override after env_config is loaded, log an INFO banner (\`ArduinoCore-LPC8xx OVERRIDE: <url> (default pinned: <sha>)\`) for terminal scrollback, and construct \`with_override\` when set.

Scope is intentionally nxplpc-only; #664 catalogs the same gap across the other 15 framework packages and is the home for the shared-helper generalization.

## Test plan

- [x] \`soldr cargo check -p fbuild-build -p fbuild-packages\` — clean
- [x] \`soldr cargo clippy -p fbuild-build -p fbuild-packages --all-targets -- -D warnings\` — clean
- [x] \`soldr cargo test -p fbuild-build --lib nxplpc::platform_packages\` — 11/11 parser cases (shorthand / git URL / archive URL / multiline / comments / wrong-framework / missing-key / empty-ref) pass
- [x] \`soldr cargo test -p fbuild-packages --lib library::arduino_core_lpc8xx\` — 5/5 pass; new \`override_uses_distinct_cache_path\` confirms override + default install to different paths under the same cache root
- [ ] End-to-end: \`platform_packages = framework-arduino-lpc8xx@zackees/ArduinoCore-LPC8xx#<sha>\` in an \`[env:lpc845brk]\` fixture should fetch and link the consumer-specified commit (acceptance: per-step bisection edit→compile completes in seconds, not minutes). CI will exercise this via the existing lpc8xx acceptance jobs; manual bisection is the downstream FastLED#3325 use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Framework package overrides are now configurable through environment settings, allowing users to specify custom ArduinoCore-LPC8xx versions and sources with support for GitHub, archive URLs, and shorthand specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->