### PR TITLE
feat(serial): rename to esp_hard_reset_blocking + add cdc_vcom_safe_assert (#684)

### DIFF
--- a/crates/fbuild-serial/src/boot_mode.rs
+++ b/crates/fbuild-serial/src/boot_mode.rs
@@ -14,7 +14,7 @@
 //! The matching *recovery* primitive — a single DTR/RTS-driven hard-reset
 //! sequence — lives in [`crate::esp_reset`]. Callers that want to attempt
 //! automatic recovery before propagating the error can invoke
-//! [`crate::esp_reset::hard_reset_blocking`] on the same port that produced
+//! [`crate::esp_reset::esp_hard_reset_blocking`] on the same port that produced
 //! the detection.
 
 /// A detected ESP ROM download-mode signal on the serial stream.

--- a/crates/fbuild-serial/src/esp_reset.rs
+++ b/crates/fbuild-serial/src/esp_reset.rs
@@ -1,4 +1,5 @@
-//! ESP32 hard-reset DTR/RTS sequence.
+//! ESP32 hard-reset DTR/RTS sequence + companion CDC-ACM bridge safety
+//! primitive.
 //!
 //! Most ESP DevKit boards (and the ESP32-S3 USB serial/JTAG bridge) wire DTR
 //! and RTS to BOOT (IO0) and EN/RESET via a transistor inverter pair, so the
@@ -24,14 +25,39 @@
 //! Sequence implemented here keeps DTR=low (so BOOT stays high → boot from
 //! flash) and pulses RTS to toggle EN, matching `esptool`'s
 //! `hard_reset` for classic-hardware UART and USB-CDC bridges.
+//!
+//! # ⚠️ Do NOT call [`esp_hard_reset_blocking`] for CDC-ACM bridge boards
+//!
+//! The post-reset idle state this function leaves (DTR=low, RTS=low) is
+//! "host not ready" for boards that talk through a USB-VCOM bridge chip —
+//! LPC11U35 on LPC845-BRK / LPCXpresso845-MAX / LPC804, FTDI FT232 in CDC
+//! mode, some CH340 firmware revisions. The bridge silently drops every
+//! byte the target MCU transmits and the device looks dead. FastLED's
+//! Python side cost two debugging sessions to this exact failure on the
+//! LPC845-BRK; see FastLED/FastLED#3300 and FastLED/FastLED#3339 for the
+//! root cause, and FastLED/fbuild#684 for the audit that brought the
+//! lesson here.
+//!
+//! For CDC-ACM bridge boards:
+//!
+//! - Reset via SWD/CMSIS-DAP (e.g. pyOCD for LPC8xx), not DTR/RTS.
+//! - If you must re-use [`esp_hard_reset_blocking`] on a CDC board for
+//!   some reason, call [`cdc_vcom_safe_assert`] immediately after to
+//!   restore the host-ready idle state.
+//! - On a fresh port open for a CDC board, call [`cdc_vcom_safe_assert`]
+//!   once after the [`serialport::SerialPort`] is constructed so the
+//!   bridge sees DTR=true (host ready) before the target MCU starts
+//!   emitting. `manager::open_port` already does this unconditionally
+//!   per FastLED/fbuild#532 — safe for ESP (the lines are pulsed below
+//!   in [`esp_hard_reset_blocking`] anyway) and required for CDC bridges.
 
 use std::thread;
 use std::time::Duration;
 
-/// DTR/RTS control surface — exactly what [`hard_reset_blocking`] needs from
-/// a serial port. A blanket impl makes every type that implements
-/// [`serialport::SerialPort`] usable, and a tiny mock impl makes the
-/// sequence unit-testable without real hardware.
+/// DTR/RTS control surface — exactly what [`esp_hard_reset_blocking`]
+/// needs from a serial port. A blanket impl makes every type that
+/// implements [`serialport::SerialPort`] usable, and a tiny mock impl
+/// makes the sequence unit-testable without real hardware.
 pub trait DtrRtsControl {
     fn write_data_terminal_ready(&mut self, level: bool) -> serialport::Result<()>;
     fn write_request_to_send(&mut self, level: bool) -> serialport::Result<()>;
@@ -56,6 +82,10 @@ pub const HARD_RESET_PULSE_MS: u64 = 100;
 /// Drive the DTR/RTS sequence that takes an ESP out of ROM download mode
 /// and into normal firmware boot.
 ///
+/// **For ESP boards only.** See the module-level warning — calling this on
+/// a CDC-ACM bridge board (LPC11U35, FTDI CDC, etc.) leaves DTR=low and
+/// the bridge silently drops every byte the target transmits.
+///
 /// Blocking — intended to run inside `tokio::task::spawn_blocking`, matching
 /// the rest of `fbuild-serial`'s pattern (see
 /// [`crate::manager`] for the precedent: every `serialport` mutation
@@ -74,7 +104,15 @@ pub const HARD_RESET_PULSE_MS: u64 = 100;
 /// Errors from the underlying DTR/RTS writes propagate; the most common
 /// cause is the port being closed mid-call. A `serialport::Error` from
 /// step 1 short-circuits before any pin is pulsed.
-pub fn hard_reset_blocking<P: DtrRtsControl + ?Sized>(port: &mut P) -> serialport::Result<()> {
+///
+/// # Naming
+///
+/// Renamed from `hard_reset_blocking` (FastLED/fbuild#684) — the previous
+/// name implied generality but the function is specifically the ESP
+/// classic-reset sequence. The `esp_` prefix makes the family-scope
+/// explicit so a future contributor adding an LPC- or FTDI-CDC-board
+/// flow does not accidentally call it.
+pub fn esp_hard_reset_blocking<P: DtrRtsControl + ?Sized>(port: &mut P) -> serialport::Result<()> {
     tracing::debug!("esp_reset: DTR=low (BOOT high → boot from flash)");
     port.write_data_terminal_ready(false)?;
     tracing::debug!("esp_reset: RTS=high (EN low → reset hold)");
@@ -86,6 +124,41 @@ pub fn hard_reset_blocking<P: DtrRtsControl + ?Sized>(port: &mut P) -> serialpor
         "esp_reset: ESP hard-reset complete (DTR=low, RTS pulsed {}ms)",
         HARD_RESET_PULSE_MS
     );
+    Ok(())
+}
+
+/// Assert the universal "host attached, please forward bytes" idle state
+/// on a CDC-ACM USB-VCOM bridge — DTR=true, RTS=true.
+///
+/// Required for: LPC11U35 VCOM bridge on LPC845-BRK / LPCXpresso845-MAX /
+/// LPC804, FTDI FT232 in CDC mode, some CH340 firmware revisions, and any
+/// board whose USB endpoint is a bridge chip that treats DTR as a host-
+/// ready signal. Without this assert, the bridge silently drops every byte
+/// the target MCU transmits and the device looks dead.
+///
+/// Safe to call on ESP boards too — DTR=true / RTS=true is not a reset
+/// trigger (the reset sequence is the *pulse* on RTS implemented in
+/// [`esp_hard_reset_blocking`]). It does, however, set BOOT=low (DTR=true
+/// → BOOT pin low via the inverter pair), which is the "enter ROM
+/// bootloader" state on an ESP if the chip is then reset externally. So
+/// don't call this on an ESP path that hasn't already completed boot
+/// from flash. The actual production caller — `manager::open_port` —
+/// asserts these lines unconditionally on every port open per
+/// FastLED/fbuild#532; the chip is already running firmware by then.
+///
+/// Blocking — same calling convention as [`esp_hard_reset_blocking`].
+///
+/// # References
+///
+/// - FastLED/FastLED#3300 — root: LPC845-BRK "silence" that turned out
+///   to be host-side DTR misconfig.
+/// - FastLED/FastLED#3339 — the Python-side fix this primitive mirrors.
+/// - FastLED/fbuild#684 — the audit that brought the lesson here.
+pub fn cdc_vcom_safe_assert<P: DtrRtsControl + ?Sized>(port: &mut P) -> serialport::Result<()> {
+    tracing::debug!("cdc_vcom_safe_assert: DTR=true (host ready for bridge)");
+    port.write_data_terminal_ready(true)?;
+    tracing::debug!("cdc_vcom_safe_assert: RTS=true (host ready for bridge)");
+    port.write_request_to_send(true)?;
     Ok(())
 }
 
@@ -123,9 +196,9 @@ mod tests {
     }
 
     #[test]
-    fn hard_reset_emits_canonical_sequence() {
+    fn esp_hard_reset_emits_canonical_sequence() {
         let mut port = RecordedPort::default();
-        hard_reset_blocking(&mut port).expect("hard_reset should succeed against the mock");
+        esp_hard_reset_blocking(&mut port).expect("esp_hard_reset should succeed against the mock");
         assert_eq!(
             port.events,
             vec![
@@ -140,7 +213,7 @@ mod tests {
     fn pulse_holds_for_at_least_the_minimum_duration() {
         let mut port = RecordedPort::default();
         let start = std::time::Instant::now();
-        hard_reset_blocking(&mut port).expect("ok");
+        esp_hard_reset_blocking(&mut port).expect("ok");
         let elapsed = start.elapsed();
         assert!(
             elapsed >= Duration::from_millis(HARD_RESET_PULSE_MS),
@@ -156,7 +229,7 @@ mod tests {
             fail_on: Some("dtr"),
             ..RecordedPort::default()
         };
-        assert!(hard_reset_blocking(&mut port).is_err());
+        assert!(esp_hard_reset_blocking(&mut port).is_err());
         // Sequence step 1 failed; we must NOT have pulsed EN, otherwise we
         // would have left the chip in reset.
         assert!(
@@ -172,6 +245,44 @@ mod tests {
             fail_on: Some("rts"),
             ..RecordedPort::default()
         };
-        assert!(hard_reset_blocking(&mut port).is_err());
+        assert!(esp_hard_reset_blocking(&mut port).is_err());
+    }
+
+    /// FastLED/fbuild#684 mirror of FastLED/FastLED#3339:
+    /// `cdc_vcom_safe_assert` must end with both DTR=true and RTS=true so
+    /// CDC-ACM bridges (LPC11U35, FTDI CDC) see "host ready" and forward
+    /// the target MCU's bytes instead of silently dropping them.
+    #[test]
+    fn cdc_vcom_safe_assert_sets_both_lines_high() {
+        let mut port = RecordedPort::default();
+        cdc_vcom_safe_assert(&mut port).expect("cdc_vcom_safe_assert should succeed");
+        assert_eq!(
+            port.events,
+            vec![("DTR", true), ("RTS", true)],
+            "CDC-ACM bridges require DTR=true and RTS=true for the bridge \
+             to forward bytes from the target MCU"
+        );
+    }
+
+    #[test]
+    fn cdc_vcom_safe_assert_dtr_failure_short_circuits_before_rts() {
+        let mut port = RecordedPort {
+            fail_on: Some("dtr"),
+            ..RecordedPort::default()
+        };
+        assert!(cdc_vcom_safe_assert(&mut port).is_err());
+        assert!(
+            port.events.is_empty(),
+            "an error on the DTR write must NOT proceed to the RTS write",
+        );
+    }
+
+    #[test]
+    fn cdc_vcom_safe_assert_rts_failure_surfaces() {
+        let mut port = RecordedPort {
+            fail_on: Some("rts"),
+            ..RecordedPort::default()
+        };
+        assert!(cdc_vcom_safe_assert(&mut port).is_err());
     }
 }

--- a/crates/fbuild-serial/src/manager.rs
+++ b/crates/fbuild-serial/src/manager.rs
@@ -343,7 +343,7 @@ impl SharedSerialManager {
     /// already established that the board is stuck in ROM, and a competing
     /// writer would have nothing useful to do anyway.
     ///
-    /// Wraps [`crate::esp_reset::hard_reset_blocking`] in `spawn_blocking`
+    /// Wraps [`crate::esp_reset::esp_hard_reset_blocking`] in `spawn_blocking`
     /// because every `serialport` line-control call is a synchronous
     /// Win32/POSIX syscall — matches the pattern in
     /// [`SharedSerialManager::open_port`].
@@ -381,7 +381,7 @@ impl SharedSerialManager {
                 "esp_hard_reset: starting DTR/RTS recovery sequence"
             );
             let mut guard = handle.blocking_lock();
-            crate::esp_reset::hard_reset_blocking(&mut **guard)
+            crate::esp_reset::esp_hard_reset_blocking(&mut **guard)
         })
         .await;
 


### PR DESCRIPTION
## Summary

Implements the three required acceptance criteria from #684 — mirrors FastLED/FastLED#3339 (the LPC845-BRK "silence" that cost two debugging sessions) on the fbuild side, before a future LPC- or FTDI-CDC-board flow trips the same trap.

The structural mirror in fbuild today is `hard_reset_blocking` in `crates/fbuild-serial/src/esp_reset.rs`. It leaves DTR=low / RTS=low — the canonical ESP "boot from flash" post-reset state, correct for ESP. It is also the universal "host not ready" state for CDC-ACM USB-VCOM bridges (LPC11U35, FTDI CDC, some CH340 revs), which silently drops every byte the target MCU transmits. Latent today because the function is only called from ESP paths, but the generic name + trait surface invites a future contributor to call it from an LPC path and lose an afternoon to "the device looks dead."

## Changes

1. **`hard_reset_blocking` → `esp_hard_reset_blocking`** — the file is already `esp_reset.rs`; the symbol now matches. Pure docs-as-code rename. Updated the two callers in `manager.rs` (one doc-comment, one actual call from `SharedSerialManager::esp_hard_reset`) and the doc reference in `boot_mode.rs`.

2. **New `cdc_vcom_safe_assert(port)` companion** — sets DTR=true + RTS=true, the universal "host attached, please forward bytes" idle state for CDC-ACM bridges. Same `DtrRtsControl` trait surface and blocking calling convention as `esp_hard_reset_blocking`. Doc-comment names the LPC11U35 / FTDI / CH340 audience and links the FastLED #3300 / #3339 history.

3. **Module-level doc-comment warning in `esp_reset.rs`** — explicit "Do NOT call `esp_hard_reset_blocking` for CDC-ACM bridge boards" callout with the failure mode (silent byte drop), the FastLED #3300 reference, the LPC11U35 / FTDI / CH340 list, and the recommended alternative (SWD/CMSIS-DAP reset, or call `cdc_vcom_safe_assert` after if re-using on a CDC board).

## Tests

```
running 7 tests
test esp_reset::tests::esp_hard_reset_emits_canonical_sequence ... ok
test esp_reset::tests::pulse_holds_for_at_least_the_minimum_duration ... ok
test esp_reset::tests::dtr_failure_short_circuits_before_any_rts_pulse ... ok
test esp_reset::tests::rts_failure_surfaces_to_caller ... ok
test esp_reset::tests::cdc_vcom_safe_assert_sets_both_lines_high ... ok
test esp_reset::tests::cdc_vcom_safe_assert_dtr_failure_short_circuits_before_rts ... ok
test esp_reset::tests::cdc_vcom_safe_assert_rts_failure_surfaces ... ok
test result: ok. 7 passed; 0 failed; ...
```

- 4 pre-existing reset-sequence tests renamed in step with the function. Coverage unchanged.
- 3 new tests for `cdc_vcom_safe_assert` (post-condition, early DTR error, RTS error surfacing).

`cargo clippy -p fbuild-serial --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean.

## Out of scope

Optional Phase 2 from #684 (a `BoardFamily` enum gating DTR/RTS per family at `manager::open_port` time) is deliberately not in this PR — the issue itself flags it as "non-trivial refactor; not strictly required for the current bug surface." File a follow-up if/when an LPC-family deploy path lands and the convention needs to be enforced at the type level.

## Test plan

- [x] `cargo test -p fbuild-serial --lib esp_reset::` (7/7)
- [x] `cargo clippy -p fbuild-serial --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Full workspace CI green

Closes #684.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CDC-VCOM bridge board support with proper initialization sequence to prevent data loss.

* **Documentation**
  * Updated safety documentation with warnings for specific board types and recovery procedures.

* **Tests**
  * Expanded test coverage for reset and bridge initialization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->