### PR TITLE
docs(agents): agents/docs/ MVP + root CLAUDE.md routing table (#695)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 fbuild is a PlatformIO-compatible embedded build tool, organized as a small fixed set of crates (kept as close to a monocrate as possible — see the "Never add a new crate" rule below). See @docs/CLAUDE.md for which architecture doc to read based on what you're working on.
 
+## Agent docs routing (FastLED/fbuild#695)
+
+When operating in this repo on a task that isn't covered by the architectural overview, jump to the right per-topic doc instead of grepping for it:
+
+| Task | Read |
+|---|---|
+| "Which `fbuild` subcommand do I run?" | [`agents/docs/commands-reference.md`](agents/docs/commands-reference.md) |
+| "How does deploy actually get firmware to the board?" | [`agents/docs/deploy-architecture.md`](agents/docs/deploy-architecture.md) |
+| "What DTR/RTS state do I open this CDC port at?" | [`docs/usb-cdc-control-line-matrix.md`](docs/usb-cdc-control-line-matrix.md) |
+| "Which crate owns this code?" | [`crates/CLAUDE.md`](crates/CLAUDE.md) |
+| "Which architecture doc maps to my crate?" | [`docs/CLAUDE.md`](docs/CLAUDE.md) |
+| "Is this serial port the right device?" | `fbuild serial probe list` (FastLED/fbuild#686) |
+
+The four rules an agent must internalize before doing anything else (all listed in "Essential Rules" below): **never bypass `soldr`**, **never bypass `uv`**, **every directory needs a README.md**, **never invoke `pyocd` / `esptool` / `dfu-util` / `picotool` directly — go through `fbuild deploy`** (the last is FastLED/fbuild#694's scope; the hook ban lands separately).
+
 ## Essential Rules
 
 - **Never add a new crate.** fbuild is kept as close to a monocrate as possible. New functionality is folded into an existing crate as a *module*, not introduced as a new crate or workspace member. Per-platform orchestrators live as modules under `fbuild-build`; the running-process broker adoption lives under `fbuild-daemon/src/broker/` (FastLED/fbuild#560) — follow that pattern. If code is needed by two crates that can't depend on each other (e.g. the CLI and the daemon), put the shared, dependency-free pieces in a crate both already depend on (`fbuild-core` / `fbuild-paths`). This is enforced by CI (`crate-gate.yml` → `ci/check_workspace_crates.py`): adding a workspace member fails the build unless you also add it to the approved allowlist with a maintainer-reviewed rationale.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,11 @@
+# agents/
+
+Agent-facing documentation. Mirror of FastLED's `agents/` directory —
+the routing layer that the root `CLAUDE.md` points at when an agent
+needs task-specific guidance (commands, deploy architecture, serial
+DTR/RTS rules) rather than the architectural overview in
+`docs/architecture/`.
+
+See [`docs/`](docs/README.md) for the per-topic files.
+
+Filed in FastLED/fbuild#695.

--- a/agents/docs/README.md
+++ b/agents/docs/README.md
@@ -1,0 +1,22 @@
+# agents/docs/
+
+Per-topic agent-facing docs. The root [`CLAUDE.md`](../../CLAUDE.md)
+routing table sends an agent here by task.
+
+## Files (FastLED/fbuild#695 MVP)
+
+- [`commands-reference.md`](commands-reference.md) — every `fbuild`
+  subcommand with one-line purpose + "use this when …" guidance.
+- [`deploy-architecture.md`](deploy-architecture.md) — the
+  `Deployer` trait, `post_deploy_recovery`, board-family dispatch
+  model.
+
+## Backlog
+
+The full FastLED-equivalent set (rust-standards, crate-structure,
+build-system, testing-commands, debugging, serial-architecture,
+workflow) is intentionally not in the MVP. Each is its own future
+PR; the routing entry in the root `CLAUDE.md` will gain rows as
+they land.
+
+Filed in FastLED/fbuild#695.

--- a/agents/docs/commands-reference.md
+++ b/agents/docs/commands-reference.md
@@ -1,0 +1,86 @@
+# `fbuild` commands reference (agent-facing)
+
+Every `fbuild` subcommand with one-line purpose and "use this when …"
+guidance. Pulled from `fbuild --help` and the in-source docs. **Keep
+this short — it's a routing table, not a manual.** Each row's "see
+more" link goes to the canonical place for that command's deep
+contract (issue tracker, crate-level README, or per-subcommand
+help text).
+
+## Build & deploy
+
+| Command | Use this when | See more |
+|---|---|---|
+| `fbuild build` | You want to compile firmware for the env specified by `-e <env>` and `<project_dir>`. The default path; cache via daemon. | `fbuild help build` |
+| `fbuild deploy` | You want to build AND flash to a connected board. Pass `--monitor` to attach the monitor after flash. | `fbuild help deploy` |
+| `fbuild monitor` | You want to attach the serial monitor to an already-running board without re-flashing. | `fbuild help monitor` |
+| `fbuild reset` | You want to reset the device without re-flashing. | `fbuild help reset` |
+| `fbuild test-emu` | You want to build + run in an emulator (CI-friendly, exits with emulator exit code). | `fbuild help test-emu` |
+
+## Build-graph + size analysis
+
+| Command | Use this when | See more |
+|---|---|---|
+| `fbuild symbols` | You want per-symbol bloat analysis of an ELF or project. Default path for "what's eating my flash?" | `fbuild help symbols`, `docs/symbols.md` |
+| `fbuild bloat graph` | You want a Graphviz back-reference dump for a specific symbol's reachability. | FastLED/fbuild#463 |
+| `fbuild compile-many` | You're CI: building the framework + library archives once and fanning out per-sketch compile + link in parallel. | FastLED/fbuild#238 / #241 / #242 |
+| `fbuild ci` | You're CI and want `pio ci` compatibility — same shape, fbuild backend. | FastLED/fbuild#242 |
+
+## Toolchain & tooling
+
+| Command | Use this when | See more |
+|---|---|---|
+| `fbuild clang-tidy` | Run clang-tidy static analysis on project sources. | `fbuild help clang-tidy` |
+| `fbuild iwyu` | Run `include-what-you-use` analysis. | `fbuild help iwyu` |
+| `fbuild clang-query` | Run a clang-query matcher script over the project. | `fbuild help clang-query` |
+| `fbuild clangd-config` | Emit `.clangd` / `.vscode/settings.json` for the default env. | `fbuild help clangd-config` |
+| `fbuild lib-select` | Drive the LDF-style library-selection resolver and print the selected library set. Use this when debugging "library not found" without a full build. | FastLED/fbuild#202 / #204 |
+
+## Daemon & cache
+
+| Command | Use this when | See more |
+|---|---|---|
+| `fbuild daemon` | Start, stop, or query the long-lived fbuild daemon. | `fbuild help daemon` |
+| `fbuild show` | Show daemon logs or other introspection. | `fbuild help show` |
+| `fbuild device` | List / inspect connected devices the daemon knows about. | `fbuild help device` |
+| `fbuild purge` | Purge cached packages — full purge or LRU-only via `--gc`. | `fbuild help purge` |
+| `fbuild lnk` | Manage `.lnk` resource pointers (fetch / verify / add). | `fbuild help lnk` |
+
+## Serial-port introspection (FastLED/fbuild#686)
+
+| Command | Use this when | See more |
+|---|---|---|
+| `fbuild serial probe list` | You want every visible serial port with VID:PID + board hint annotated. **First thing to run** when an agent's debugging "is COM12 the right port?" | FastLED/fbuild#686 |
+| `fbuild serial probe find --vid-pid V:P` | You want one device path on stdout for a literal VID:PID pair, or exit 1 when not found. Useful from scripts. | FastLED/fbuild#686 |
+| `fbuild serial probe find --env <name>` | You want the right port for a PlatformIO env name (e.g. `lpc845brk` → the LPC11U35 VCOM bridge, NOT the CMSIS-DAP debug probe). Disambiguates multi-USB-endpoint boards. | FastLED/fbuild#686 |
+| `fbuild serial probe read <port>` | You want to open a port with the **correct DTR/RTS for the board family** and dump bytes. Use this instead of ad-hoc `pyserial` / PowerShell `SerialPort` calls. See [docs/usb-cdc-control-line-matrix.md](../../docs/usb-cdc-control-line-matrix.md) for the why. | FastLED/fbuild#686, FastLED/fbuild#689 |
+
+## AI integration
+
+| Command | Use this when | See more |
+|---|---|---|
+| `fbuild mcp` | Start an MCP server for AI-assistant integration. | `fbuild help mcp` |
+
+## Worked example — "agent needs to debug a silent device on COM20"
+
+The right sequence today:
+
+```bash
+# 1. What's actually on COM20?
+$ fbuild serial probe list
+COM20      16C0:0483  ser=15821020          USB Serial Device  [LPC11U35 VCOM bridge (LPC845-BRK USART0) OR PJRC Teensy USB-Serial]
+
+# 2. Confirm that's the LPC bridge (not the CMSIS-DAP debug port)
+$ fbuild serial probe find --env lpc845brk
+COM20
+
+# 3. Read with correct DTR/RTS for a CDC-ACM bridge
+$ fbuild serial probe read COM20 --seconds 4
+…bytes…
+```
+
+**Do NOT reach for** ad-hoc PowerShell `SerialPort` or `python -c "import serial"`
+probes — those default to DTR=False, which the LPC11U35 bridge treats as
+"host not ready" and silently drops every byte. That's the
+FastLED/FastLED#3300 / fbuild#684 trap. The `fbuild serial probe`
+helpers exist specifically so agents stop rediscovering it.

--- a/agents/docs/deploy-architecture.md
+++ b/agents/docs/deploy-architecture.md
@@ -1,0 +1,152 @@
+# Deploy architecture
+
+How firmware actually gets from `fbuild deploy` to a connected board.
+The point of this doc is so an agent adding a new board family knows
+**which pieces to extend** and which ones to leave alone, instead of
+copy-pasting an ESP-shaped path onto a CDC-bridge board and losing an
+afternoon to the FastLED/FastLED#3300 trap.
+
+## High-level flow
+
+```
+fbuild-cli (`deploy` subcommand)
+    │   thin HTTP client — no build/flash logic lives here
+    ▼
+fbuild-daemon (HTTP/WebSocket server)
+    │   request validation, device lease, build orchestration
+    ▼
+fbuild-build::BuildOrchestrator (per-platform impl)
+    │   produces firmware.elf, firmware.bin, build_info.json
+    ▼
+fbuild-deploy::Deployer trait
+    │   board-family-specific flash path
+    │     • ESP32: esptool / espflash via serial
+    │     • LPC8xx: pyOCD / probe-rs via CMSIS-DAP USB
+    │     • Teensy / SAMD / RP2040: 1200-bps touch + UF2 copy
+    ▼
+post_deploy_recovery (Deployer-supplied)
+    │   serial-port re-enumeration wait, board-specific quirks
+    ▼
+fbuild-serial::manager (re-attach monitor)
+    │   open_port with DTR=true, RTS=true per docs/usb-cdc-control-line-matrix.md
+    ▼
+Client receives stream over WebSocket
+```
+
+## The `Deployer` trait
+
+`crates/fbuild-deploy/src/lib.rs::Deployer` is the contract every
+board family implements:
+
+```rust
+trait Deployer {
+    fn deploy(&self, ...) -> Result<()>;
+    fn post_deploy_recovery(&self, port: &str) -> Result<()>;  // default: 3s sleep
+}
+```
+
+`post_deploy_recovery` is the cross-family hook for "the board's USB
+endpoint just disappeared because we reset it; here's how long /
+how to wait for it to come back." Override when:
+
+- The board uses **USB-bootloader** flashing (Teensy / RP2040 / SAMD)
+  — the bootloader's VID:PID is different from the app's. The
+  recovery has to poll for the *app's* VID:PID to reappear.
+- The board uses a **CMSIS-DAP debug probe** (LPC845-BRK) — the
+  debug probe stays enumerated through reset; the VCOM bridge may
+  blink on Windows. Need a board-specific wait.
+- The board is **LPC + CMSIS-DAP** specifically — wedge recovery
+  needs extra retries; see FastLED/fbuild#605 Phase 1.
+
+## Board-family dispatch
+
+`BoardFamily` (in `crates/fbuild-serial/src/boards.rs`) is the
+taxonomy that gates DTR/RTS conventions today. It will eventually
+also gate the `Deployer` selection (FastLED/fbuild#687 — the
+polymorphic `ResetMethod` dispatch registry) and per-family handoff
+timing (FastLED/fbuild#691).
+
+Today the dispatch is more ad-hoc:
+
+- ESP variants → `fbuild-deploy::esp32_native` (espflash) or
+  `fbuild-deploy::esp32_external_uart` (esptool over UART)
+- LPC8xx → `fbuild-deploy::pyocd_cmsis_dap` (placeholder; bring-up
+  in progress in the LPC845-BRK meta, FastLED/fbuild#586)
+- Teensy / SAMD / RP2040 → 1200-bps-touch path (still partial)
+
+The follow-up issues track the full polymorphic version:
+
+- **FastLED/fbuild#687** — `BoardFamily` enum + polymorphic
+  `ResetMethod` dispatch registry. The thing this doc will reference
+  as the canonical source.
+- **FastLED/fbuild#688** — `BootModeClassifier` registry (ESP-only
+  today; generalize to per-family).
+- **FastLED/fbuild#691** — `HandoffTiming` on `BoardFamily`.
+- **FastLED/fbuild#692** — enumerate supported deploy protocols per
+  board; fail fast on unsupported.
+- **FastLED/fbuild#693** — USB-level bootloader re-enumeration
+  detection (complement to #688).
+
+## Worked example — "agent ports a new RP2350 board"
+
+The right sequence today:
+
+1. **VID:PID first.** Add the new board's USB endpoint to
+   `crates/fbuild-serial/src/boards.rs::BOARD_FINGERPRINTS`. If the
+   data port is a *different* USB endpoint from the bootloader, add
+   `ENVIRONMENT_TO_VCOM` too.
+2. **Family classification.** Add the new VID:PID to
+   `family_for_vid_pid`. RP2350 is almost certainly `CdcAcmBridge`
+   (1200-bps touch reset, host-ready idle); inherit the existing
+   RP2040 row's conventions.
+3. **DTR/RTS matrix.** Add a row to
+   [`docs/usb-cdc-control-line-matrix.md`](../../docs/usb-cdc-control-line-matrix.md)
+   for the new chip, with a datasheet citation and capture date.
+4. **Deployer impl.** If the existing `fbuild-deploy::pyocd_cmsis_dap`
+   or RP2040 1200-bps-touch path is reusable, register the new
+   board there. Otherwise add a new sibling module under
+   `crates/fbuild-deploy/src/<family>/`. Implement `Deployer` +
+   override `post_deploy_recovery` if the recovery timing differs.
+5. **Test.** `fbuild serial probe list` should now show the new
+   board's hint. `fbuild serial probe find --env <new-env>` should
+   return the right port. `fbuild deploy --env <new-env>` should
+   complete; `--monitor` should reattach without dropping bytes.
+
+**Do NOT** start by copy-pasting an `esp32_native` deploy path. The
+default ESP DTR/RTS state is `(false, false)` — fatal for any
+CDC-ACM bridge.
+
+## Worked example — "agent debugs deploy failure on COM20"
+
+```
+fbuild deploy -e lpc845brk
+> error: pyocd CMSIS-DAP connect failed: device not found
+```
+
+The deploy path goes through the CMSIS-DAP USB endpoint
+(`(0x1FC9, 0x0132)`), NOT the COM port. Two separate USB devices.
+
+```bash
+# Check what's actually enumerated
+$ fbuild serial probe list
+COM20      16C0:0483  ser=…  [LPC11U35 VCOM bridge (LPC845-BRK USART0) OR PJRC Teensy USB-Serial]
+COM10      1FC9:0132  ser=…  [NXP CMSIS-DAP debug (LPC845-BRK / LPC11U35)]
+```
+
+Both endpoints present — good. pyOCD's failure is its own (probably
+a driver / udev rule issue, not an fbuild bug). The point is:
+**`COM20` is the data port, `COM10` is the deploy port.** Don't try
+to flash via the wrong endpoint.
+
+## See also
+
+- [`commands-reference.md`](commands-reference.md) — every `fbuild`
+  subcommand.
+- [`../../docs/usb-cdc-control-line-matrix.md`](../../docs/usb-cdc-control-line-matrix.md)
+  — DTR/RTS rules per board family (FastLED/fbuild#689).
+- [`../../crates/CLAUDE.md`](../../crates/CLAUDE.md) — crate
+  dependency graph + boundaries.
+- [`../../docs/CLAUDE.md`](../../docs/CLAUDE.md) — architecture-doc
+  routing table.
+
+Filed in FastLED/fbuild#695.

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -1,5 +1,11 @@
 # Crates Architecture
 
+> **Agents:** for task-specific routing (which `fbuild` subcommand,
+> how deploy actually works, DTR/RTS rules), see the root
+> [`../CLAUDE.md`](../CLAUDE.md) routing table and
+> [`../agents/docs/`](../agents/docs/README.md). This doc covers
+> crate boundaries and dependency policy — not "how to do task X".
+
 ## Monocrate policy — do not add new crates
 
 fbuild is kept as close to a monocrate as possible. The set of crates below is

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,12 @@
 # Documentation Guide
 
+> **Agents:** for task-specific routing (which `fbuild` subcommand to
+> run, how deploy actually works, DTR/RTS rules), see the root
+> [`../CLAUDE.md`](../CLAUDE.md) routing table and
+> [`../agents/docs/`](../agents/docs/README.md). This doc maps each
+> *crate* to the right *architecture* doc; the agents/ docs map
+> each *task* to the right command and contract.
+
 Architecture docs are split by subsystem. Read only what's relevant to your current work.
 
 For a full FAQ-style index of every doc in this repo (human + LLM entry point), see [INDEX.md](INDEX.md).


### PR DESCRIPTION
## Summary

FastLED/fbuild#695 — mirror FastLED's `agents/docs/` shape so agents operating in this repo can find task-specific guidance without grepping crate READMEs (which target humans).

## What this PR ships (MVP subset per #695)

### `CLAUDE.md` — new "Agent docs routing" section

Six-row table that points an agent at the right doc by task:

- "Which fbuild subcommand?" → `agents/docs/commands-reference.md`
- "How does deploy work?" → `agents/docs/deploy-architecture.md`
- "What DTR/RTS state?" → `docs/usb-cdc-control-line-matrix.md` (#689)
- "Which crate owns this code?" → `crates/CLAUDE.md`
- "Which arch doc for my crate?" → `docs/CLAUDE.md`
- "Is this the right port?" → `fbuild serial probe list` (#686)

Plus the four hard rules an agent must internalize.

### `agents/docs/commands-reference.md`

Every `fbuild` subcommand with one-line purpose + "use this when …" guidance. Pulled from `fbuild --help` output. Includes a worked example: "agent needs to debug a silent device on COM20" — three commands, no false trails.

### `agents/docs/deploy-architecture.md`

The `Deployer` trait, `post_deploy_recovery` hook, board-family dispatch model. Cross-references the follow-up issues that own the polymorphic dispatch registry (#687), boot-mode classifier (#688), handoff timing (#691), supported-protocols enumeration (#692), USB re-enumeration detection (#693). Two worked examples: "agent ports a new RP2350 board" (5-step recipe) and "agent debugs deploy failure on COM20" (the two-USB-endpoint gotcha).

### Cross-link updates

- `crates/CLAUDE.md` — header note: task-routing lives in root CLAUDE.md + agents/docs/, this doc is for crate boundaries.
- `docs/CLAUDE.md` — same separation note.

### `agents/README.md` + `agents/docs/README.md`

Per-directory READMEs the `readme_guard.py` hook enforces.

## Out of scope (deferred follow-ups)

- Rest of FastLED's full set: rust-standards, build-system, testing-commands, debugging, serial-architecture, workflow. Each is its own PR.
- Cross-link from FastLED-side `agents/docs/` index — cross-repo PR on the FastLED side.

## Test plan

Pure docs change. No unit tests applicable.

- [x] All three docs render correctly (markdown lint clean).
- [x] Cross-link from root CLAUDE.md to agents/docs/ present.
- [x] Cross-link from crates/CLAUDE.md + docs/CLAUDE.md present.
- [x] `readme_guard.py` hook accepts both new directories.
- [ ] Workspace CI green.

Closes #695.