### PR TITLE
feat(serial): BoardFamily reset_method + dispatch_reset (#687)

### DIFF
--- a/crates/fbuild-daemon/src/handlers/operations/deploy.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/deploy.rs
@@ -852,7 +852,7 @@ pub async fn deploy(
         // Open the port for monitoring
         if let Err(e) = ctx
             .serial_manager
-            .open_port(&monitor_port, baud_rate, &request_id)
+            .open_port(&monitor_port, baud_rate, &request_id, None)
             .await
         {
             return (

--- a/crates/fbuild-daemon/src/handlers/operations/monitor.rs
+++ b/crates/fbuild-daemon/src/handlers/operations/monitor.rs
@@ -243,7 +243,7 @@ pub async fn monitor(
 
     if let Err(e) = ctx
         .serial_manager
-        .open_port(&port, baud_rate, &request_id)
+        .open_port(&port, baud_rate, &request_id, None)
         .await
     {
         return (

--- a/crates/fbuild-daemon/src/handlers/websockets.rs
+++ b/crates/fbuild-daemon/src/handlers/websockets.rs
@@ -87,7 +87,7 @@ async fn handle_serial_ws(mut socket: WebSocket, ctx: Arc<DaemonContext>) {
                     if open_if_needed {
                         if let Err(e) = ctx
                             .serial_manager
-                            .open_port(&port, baud_rate, &client_id)
+                            .open_port(&port, baud_rate, &client_id, None)
                             .await
                         {
                             let err_msg = SerialServerMessage::Error {

--- a/crates/fbuild-serial/src/boards.rs
+++ b/crates/fbuild-serial/src/boards.rs
@@ -198,7 +198,7 @@ impl BoardFamily {
     /// assert_eq!(BoardFamily::CdcAcmBridge.idle_dtr_rts(),              (true,  true));
     /// assert_eq!(BoardFamily::Teensy.idle_dtr_rts(),                    (true,  true));
     /// assert_eq!(BoardFamily::NativeUsbCdcReset1200Bps.idle_dtr_rts(),  (true,  true));
-    /// assert_eq!(BoardFamily::ArduinoAutoResetAutoReset.idle_dtr_rts(),          (true,  true));
+    /// assert_eq!(BoardFamily::ArduinoAutoReset.idle_dtr_rts(),          (true,  true));
     /// ```
     #[must_use]
     pub fn idle_dtr_rts(&self) -> (bool, bool) {
@@ -228,7 +228,7 @@ impl BoardFamily {
     /// assert_eq!(BoardFamily::CdcAcmBridge.reset_method(),             ResetMethod::SwdViaCmsisDap);
     /// assert_eq!(BoardFamily::Teensy.reset_method(),                   ResetMethod::TouchBaud1200);
     /// assert_eq!(BoardFamily::NativeUsbCdcReset1200Bps.reset_method(), ResetMethod::TouchBaud1200);
-    /// assert_eq!(BoardFamily::ArduinoAutoResetAutoReset.reset_method(),         ResetMethod::DtrPulse);
+    /// assert_eq!(BoardFamily::ArduinoAutoReset.reset_method(),         ResetMethod::DtrPulse);
     /// ```
     #[must_use]
     pub fn reset_method(&self) -> ResetMethod {

--- a/crates/fbuild-serial/src/boards.rs
+++ b/crates/fbuild-serial/src/boards.rs
@@ -107,12 +107,17 @@ pub const ENVIRONMENT_TO_VCOM: &[(&str, u16, u16)] = &[
 /// on port open + post-reset paths.
 ///
 /// FastLED/fbuild#684's closing analysis identified this as the right
-/// abstraction; this enum is the minimum needed to satisfy #686's
+/// abstraction. The enum + [`Self::idle_dtr_rts`] satisfies #686's
 /// fourth acceptance criterion ("the probe API picks the right DTR/RTS
-/// for the target board family"). The full polymorphic dispatch
-/// registry that this enum eventually backs (`ResetMethod`,
-/// `BootModeClassifier`, `HandoffTiming`) is the scope of
-/// FastLED/fbuild#687, #688, and #691 respectively.
+/// for the target board family"); the [`Self::reset_method`] +
+/// [`crate::esp_reset::dispatch_reset`] pair satisfies #687's
+/// polymorphic-dispatch criterion.
+///
+/// Co-evolving with FastLED/FastLED#3300 / #3325 / #3339 (the LPC845-BRK
+/// bring-up incident that cost two debugging sessions because the
+/// "is this an ESP or a CDC bridge?" decision had no single point of
+/// consultation). See `docs/usb-cdc-control-line-matrix.md` (#689) for
+/// the per-chip DTR/RTS semantics this enum encodes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoardFamily {
     /// ESP32 native USB CDC (ESP32-S3/C3/C6/H2/P4). The chip enumerates
@@ -127,49 +132,154 @@ pub enum BoardFamily {
     /// host → CP2102 → ESP32 UART instead of host → ESP32 directly.
     Esp32ExternalUart,
 
-    /// Bridge-based USB VCOM (LPC11U35 on LPC845-BRK, RP2040 board
-    /// bridges). Reset is via SWD/CMSIS-DAP, NOT DTR/RTS — calling
+    /// Bridge-based USB VCOM (LPC11U35 on LPC845-BRK, mbed DAPLink
+    /// boards). Reset is via SWD/CMSIS-DAP, NOT DTR/RTS — calling
     /// [`crate::esp_reset::esp_hard_reset_blocking`] on these boards
     /// leaves DTR=low which the bridge treats as "host not ready"
     /// and silently drops every byte the target MCU transmits
     /// (the FastLED/FastLED#3300 failure).
     /// Post-open idle: DTR=true, RTS=true (host-ready for the bridge).
+    ///
+    /// **Future enhancement** (FastLED/fbuild#687 follow-up): carry the
+    /// CMSIS-DAP probe's `(vid, pid)` as a payload so the dispatcher
+    /// can route SWD reset to the right probe endpoint without an
+    /// external lookup. Not in scope for the first cut — adding it
+    /// later is a non-breaking enum-variant evolution under the
+    /// `#[non_exhaustive]` annotation.
     CdcAcmBridge,
 
-    /// Generic Arduino path — FTDI / CP2102 / CH340 as the primary
-    /// USB endpoint on a board with the Arduino auto-reset capacitor.
-    /// DTR-pulse-on-open may reset the chip; the idle state is
-    /// DTR=true / RTS=true so the bridge passes target bytes through.
-    Arduino,
+    /// PJRC Teensy 3.x / 4.x. Reset trigger is the "1200-bps touch"
+    /// idiom: open port at 1200 baud, close → HalfKay bootloader
+    /// engages on disconnect. Post-open idle: DTR=true, RTS=true.
+    ///
+    /// **Naming-collision caveat:** Teensy enumerates as VID 0x16C0,
+    /// PID 0x0483 — *the same pair* as the LPC11U35 VCOM bridge. The
+    /// VID/PID lookup in [`family_for_vid_pid`] returns
+    /// [`Self::CdcAcmBridge`] for that pair (LPC is the more common
+    /// case in this codebase's deployment ecosystem); callers who
+    /// know they're on a Teensy must construct [`Self::Teensy`]
+    /// explicitly.
+    Teensy,
+
+    /// Native USB CDC with a 1200-bps touch reset (SAMD21/SAMD51,
+    /// RP2040, Adafruit UF2 boards). The host opens the port at
+    /// 1200 baud and closes; the device's TinyUSB stack watches for
+    /// the disconnect and reboots into the UF2/BOOTSEL bootloader.
+    /// Post-open idle: DTR=true, RTS=true.
+    NativeUsbCdcReset1200Bps,
+
+    /// Classic Arduino with capacitor-coupled DTR auto-reset
+    /// (UNO / Mega / Nano). Reset trigger is a single
+    /// DTR=true→false transition through the 100nF cap on the
+    /// ATmega's RESET pin. Post-open idle: DTR=true, RTS=true.
+    /// **Be aware of capacitor-charge timing** — opening the port
+    /// resets the target by side-effect; the first ~2 s of output
+    /// is the bootloader's "wait for upload" window.
+    ArduinoAutoReset,
 }
 
 impl BoardFamily {
-    /// The universal "host attached, data flow OK" port-open / post-
-    /// reset idle DTR/RTS state for this board family.
+    /// Universal post-attach / post-reset idle state for this family
+    /// — what `manager::open_port` sets after acquiring the port
+    /// handle.
     ///
-    /// Return shape is `(dtr, rts)` — both `true` means "drive the line
-    /// high", which depending on the bridge chip is either "host
-    /// ready" (CDC-ACM bridge) or "BOOT/EN held high → run firmware"
-    /// (ESP via DevKit autoreset).
+    /// Return shape is `(dtr, rts)` — both `true` means "drive the
+    /// line high", which depending on the bridge chip is either
+    /// "host ready" (CDC-ACM bridge, Teensy, native CDC, Arduino) or
+    /// "BOOT/EN held high → run firmware" (ESP via DevKit autoreset).
     ///
     /// # Examples
     ///
     /// ```
     /// use fbuild_serial::boards::BoardFamily;
     ///
-    /// assert_eq!(BoardFamily::Esp32NativeUsbCdc.idle_dtr_rts(), (false, false));
-    /// assert_eq!(BoardFamily::Esp32ExternalUart.idle_dtr_rts(), (false, false));
-    /// assert_eq!(BoardFamily::CdcAcmBridge.idle_dtr_rts(),     (true,  true));
-    /// assert_eq!(BoardFamily::Arduino.idle_dtr_rts(),          (true,  true));
+    /// assert_eq!(BoardFamily::Esp32NativeUsbCdc.idle_dtr_rts(),         (false, false));
+    /// assert_eq!(BoardFamily::Esp32ExternalUart.idle_dtr_rts(),         (false, false));
+    /// assert_eq!(BoardFamily::CdcAcmBridge.idle_dtr_rts(),              (true,  true));
+    /// assert_eq!(BoardFamily::Teensy.idle_dtr_rts(),                    (true,  true));
+    /// assert_eq!(BoardFamily::NativeUsbCdcReset1200Bps.idle_dtr_rts(),  (true,  true));
+    /// assert_eq!(BoardFamily::ArduinoAutoResetAutoReset.idle_dtr_rts(),          (true,  true));
     /// ```
     #[must_use]
     pub fn idle_dtr_rts(&self) -> (bool, bool) {
         use BoardFamily::*;
         match self {
             Esp32NativeUsbCdc | Esp32ExternalUart => (false, false),
-            CdcAcmBridge | Arduino => (true, true),
+            CdcAcmBridge | Teensy | NativeUsbCdcReset1200Bps | ArduinoAutoReset => (true, true),
         }
     }
+
+    /// Reset primitive this family responds to. The companion to
+    /// [`Self::idle_dtr_rts`] — `idle_dtr_rts` is the state AFTER a
+    /// reset / port-open settles; `reset_method` is HOW the reset
+    /// gets triggered.
+    ///
+    /// FastLED/fbuild#687 — polymorphic dispatch lives in
+    /// [`crate::esp_reset::dispatch_reset`] which calls this to pick
+    /// the implementation primitive.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fbuild_serial::boards::{BoardFamily, ResetMethod};
+    ///
+    /// assert_eq!(BoardFamily::Esp32NativeUsbCdc.reset_method(),        ResetMethod::DtrRtsPulse);
+    /// assert_eq!(BoardFamily::Esp32ExternalUart.reset_method(),        ResetMethod::DtrRtsPulse);
+    /// assert_eq!(BoardFamily::CdcAcmBridge.reset_method(),             ResetMethod::SwdViaCmsisDap);
+    /// assert_eq!(BoardFamily::Teensy.reset_method(),                   ResetMethod::TouchBaud1200);
+    /// assert_eq!(BoardFamily::NativeUsbCdcReset1200Bps.reset_method(), ResetMethod::TouchBaud1200);
+    /// assert_eq!(BoardFamily::ArduinoAutoResetAutoReset.reset_method(),         ResetMethod::DtrPulse);
+    /// ```
+    #[must_use]
+    pub fn reset_method(&self) -> ResetMethod {
+        use BoardFamily::*;
+        use ResetMethod::*;
+        match self {
+            Esp32NativeUsbCdc | Esp32ExternalUart => DtrRtsPulse,
+            CdcAcmBridge => SwdViaCmsisDap,
+            Teensy | NativeUsbCdcReset1200Bps => TouchBaud1200,
+            ArduinoAutoReset => DtrPulse,
+        }
+    }
+
+    /// `true` if this family's reset is driven by serial-port DTR/RTS
+    /// (i.e. [`crate::esp_reset::esp_hard_reset_blocking`] /
+    /// [`crate::esp_reset::dispatch_reset`] can handle it internally).
+    /// Used by `dispatch_reset` to decide between "do the pulse here"
+    /// and "return DelegateToCaller so the caller can dispatch SWD /
+    /// 1200-bps touch elsewhere."
+    #[must_use]
+    pub fn reset_is_serial_native(&self) -> bool {
+        matches!(self.reset_method(), ResetMethod::DtrRtsPulse)
+    }
+}
+
+/// The hardware primitive that resets a board.
+///
+/// FastLED/fbuild#687 — the enum that backs polymorphic reset
+/// dispatch. Not every variant has an implementation in
+/// `fbuild-serial` yet; the unimplemented ones either delegate out
+/// (SWD via pyOCD / probe-rs) or return a typed "caller must do this
+/// elsewhere" from [`crate::esp_reset::dispatch_reset`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetMethod {
+    /// esptool's classic-hardware ClassicReset sequence — DTR=low,
+    /// RTS=high pulse, RTS=low. Implemented in
+    /// [`crate::esp_reset::esp_hard_reset_blocking`].
+    DtrRtsPulse,
+    /// Single DTR=true→false transition. Drives the Arduino auto-reset
+    /// capacitor's edge. **Not yet implemented in fbuild-serial** —
+    /// dispatch returns `DelegateToCaller`. Follow-up issue.
+    DtrPulse,
+    /// Open port at 1200 baud, close → SAMD21/SAMD51 / RP2040 / Teensy
+    /// bootloader engages. **Not yet implemented in fbuild-serial** —
+    /// dispatch returns `DelegateToCaller`. Follow-up issue.
+    TouchBaud1200,
+    /// CMSIS-DAP probe via pyOCD / `probe-rs` — out of
+    /// `fbuild-serial`'s jurisdiction entirely (the SWD path doesn't
+    /// touch the data port). Dispatch always returns
+    /// `DelegateToCaller`.
+    SwdViaCmsisDap,
 }
 
 /// Look up the human-readable hint for a `(vid, pid)` pair.
@@ -239,7 +349,8 @@ pub fn vcom_for_env(env: &str) -> Option<(u16, u16)> {
 /// assert_eq!(family_for_vid_pid(0x303A, 0x1001), Some(BoardFamily::Esp32NativeUsbCdc));
 /// assert_eq!(family_for_vid_pid(0x16C0, 0x0483), Some(BoardFamily::CdcAcmBridge));
 /// assert_eq!(family_for_vid_pid(0x10C4, 0xEA60), Some(BoardFamily::Esp32ExternalUart));
-/// assert_eq!(family_for_vid_pid(0x2341, 0x0043), Some(BoardFamily::Arduino));
+/// assert_eq!(family_for_vid_pid(0x2341, 0x0043), Some(BoardFamily::ArduinoAutoReset));
+/// assert_eq!(family_for_vid_pid(0x2E8A, 0x000A), Some(BoardFamily::NativeUsbCdcReset1200Bps));
 /// assert_eq!(family_for_vid_pid(0xDEAD, 0xBEEF), None);
 /// ```
 #[must_use]
@@ -260,13 +371,14 @@ pub fn family_for_vid_pid(vid: u16, pid: u16) -> Option<BoardFamily> {
         // line-control bits drive ESP32 BOOT/EN through the autoreset
         // transistor pair. Classify as Esp32ExternalUart.
         (0x10C4, _) | (0x1A86, _) | (0x0403, _) => Some(Esp32ExternalUart),
-        // Arduino official
-        (0x2341, _) => Some(Arduino),
-        // RP2040 — treat as CDC bridge for the post-open DTR/RTS=true
-        // safety default; reset is a 1200-baud touch, not DTR/RTS, so
-        // the choice here only matters for "monitor / probe doesn't
-        // drop bytes."
-        (0x2E8A, _) => Some(CdcAcmBridge),
+        // Arduino official — capacitor-coupled DTR auto-reset path
+        (0x2341, _) => Some(ArduinoAutoReset),
+        // RP2040 — native USB CDC; bootloader entry is a 1200-bps touch
+        // (per RP2040 datasheet §USB Controller + pico-sdk's
+        // `pico_stdio_usb`). Classify as NativeUsbCdcReset1200Bps so
+        // the dispatcher routes to the right primitive instead of the
+        // ESP DTR/RTS pulse.
+        (0x2E8A, _) => Some(NativeUsbCdcReset1200Bps),
         _ => None,
     }
 }
@@ -339,7 +451,7 @@ mod tests {
         // CDC) MUST see DTR=true and RTS=true to forward target-MCU
         // bytes. Pin this invariant.
         assert_eq!(BoardFamily::CdcAcmBridge.idle_dtr_rts(), (true, true));
-        assert_eq!(BoardFamily::Arduino.idle_dtr_rts(), (true, true));
+        assert_eq!(BoardFamily::ArduinoAutoReset.idle_dtr_rts(), (true, true));
     }
 
     #[test]
@@ -383,13 +495,13 @@ mod tests {
         // Arduino official
         assert_eq!(
             family_for_vid_pid(0x2341, 0x0043),
-            Some(BoardFamily::Arduino)
+            Some(BoardFamily::ArduinoAutoReset)
         );
 
-        // RP2040 / Pico → CDC bridge
+        // RP2040 / Pico → native CDC with 1200-bps touch reset (#687)
         assert_eq!(
             family_for_vid_pid(0x2E8A, 0x000A),
-            Some(BoardFamily::CdcAcmBridge)
+            Some(BoardFamily::NativeUsbCdcReset1200Bps)
         );
     }
 
@@ -409,8 +521,79 @@ mod tests {
         let lpc = family_for_vid_pid(0x16C0, 0x0483).unwrap();
         assert_eq!(lpc.idle_dtr_rts(), (true, true));
 
-        // RP2040 / Pico
+        // RP2040 / Pico — even though it's NativeUsbCdcReset1200Bps
+        // now (#687), idle is still host-ready
         let pico = family_for_vid_pid(0x2E8A, 0x000A).unwrap();
         assert_eq!(pico.idle_dtr_rts(), (true, true));
+    }
+
+    // ─── FastLED/fbuild#687: ResetMethod + reset_method() invariants ───
+
+    #[test]
+    fn reset_method_maps_each_family_to_its_primitive() {
+        use BoardFamily::*;
+        use ResetMethod::*;
+
+        assert_eq!(Esp32NativeUsbCdc.reset_method(), DtrRtsPulse);
+        assert_eq!(Esp32ExternalUart.reset_method(), DtrRtsPulse);
+        assert_eq!(CdcAcmBridge.reset_method(), SwdViaCmsisDap);
+        assert_eq!(Teensy.reset_method(), TouchBaud1200);
+        assert_eq!(NativeUsbCdcReset1200Bps.reset_method(), TouchBaud1200);
+        assert_eq!(ArduinoAutoReset.reset_method(), DtrPulse);
+    }
+
+    #[test]
+    fn reset_is_serial_native_true_only_for_esp_families() {
+        use BoardFamily::*;
+        assert!(Esp32NativeUsbCdc.reset_is_serial_native());
+        assert!(Esp32ExternalUart.reset_is_serial_native());
+        assert!(!CdcAcmBridge.reset_is_serial_native());
+        assert!(!Teensy.reset_is_serial_native());
+        assert!(!NativeUsbCdcReset1200Bps.reset_is_serial_native());
+        assert!(!ArduinoAutoReset.reset_is_serial_native());
+    }
+
+    /// FastLED/FastLED#3300 regression guard: every NON-Esp family
+    /// MUST end at `(true, true)` idle so a generic open_port that
+    /// doesn't know to pulse DTR/RTS still ends at "host ready". If
+    /// this test fails after a refactor, the open_port path is
+    /// reintroducing the silent-byte-drop bug.
+    #[test]
+    fn non_esp_families_all_idle_at_host_ready() {
+        use BoardFamily::*;
+        for family in [
+            CdcAcmBridge,
+            Teensy,
+            NativeUsbCdcReset1200Bps,
+            ArduinoAutoReset,
+        ] {
+            assert_eq!(
+                family.idle_dtr_rts(),
+                (true, true),
+                "family {family:?} must idle at (true, true) — FastLED/FastLED#3300"
+            );
+        }
+    }
+
+    #[test]
+    fn new_variants_appear_in_family_for_vid_pid_classification() {
+        // RP2040 → NativeUsbCdcReset1200Bps
+        assert_eq!(
+            family_for_vid_pid(0x2E8A, 0x000A),
+            Some(BoardFamily::NativeUsbCdcReset1200Bps)
+        );
+        // Arduino → ArduinoAutoReset
+        assert_eq!(
+            family_for_vid_pid(0x2341, 0x0043),
+            Some(BoardFamily::ArduinoAutoReset)
+        );
+        // Teensy shares VID:PID with LPC11U35 — kept as CdcAcmBridge
+        // (the more common case in this codebase's deployment
+        // ecosystem). Caller wanting Teensy must construct the
+        // variant explicitly.
+        assert_eq!(
+            family_for_vid_pid(0x16C0, 0x0483),
+            Some(BoardFamily::CdcAcmBridge)
+        );
     }
 }

--- a/crates/fbuild-serial/src/esp_reset.rs
+++ b/crates/fbuild-serial/src/esp_reset.rs
@@ -167,6 +167,56 @@ pub fn cdc_vcom_safe_assert<P: DtrRtsControl + ?Sized>(port: &mut P) -> serialpo
     Ok(())
 }
 
+/// Outcome of a polymorphic reset attempt.
+///
+/// FastLED/fbuild#687. `dispatch_reset` returns either `Done` (the
+/// reset completed in `fbuild-serial`) or `DelegateToCaller(method)`
+/// (the caller has to drive the reset somewhere else — e.g.
+/// pyOCD/`probe-rs` for SWD, `serialport::new(...).baud_rate(1200).open()`
+/// then close for 1200-bps touch).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetDispatchOutcome {
+    /// Reset completed by this crate. No further action required.
+    Done,
+    /// `fbuild-serial` does not own this reset path; the caller must
+    /// dispatch the named primitive elsewhere.
+    DelegateToCaller(crate::boards::ResetMethod),
+}
+
+/// Polymorphic reset entry point — pick the right primitive for the
+/// board family and run it.
+///
+/// FastLED/fbuild#687. Today the only primitive `fbuild-serial` owns
+/// is the ESP DTR/RTS pulse ([`esp_hard_reset_blocking`]); the other
+/// three primitives (`DtrPulse`, `TouchBaud1200`, `SwdViaCmsisDap`)
+/// each get their own follow-up issue. Until those land, the
+/// dispatcher returns `DelegateToCaller` so the caller can route the
+/// reset elsewhere.
+///
+/// Acts as the debug-assert that #687 acceptance criterion 3 asks
+/// for: a non-ESP family ends at `DelegateToCaller(other)` instead of
+/// pulsing DTR=low on an LPC VCOM bridge and silently dropping every
+/// target byte (the FastLED/FastLED#3300 trap).
+pub fn dispatch_reset<P: DtrRtsControl + ?Sized>(
+    family: crate::boards::BoardFamily,
+    port: &mut P,
+) -> serialport::Result<ResetDispatchOutcome> {
+    use crate::boards::ResetMethod::*;
+    match family.reset_method() {
+        DtrRtsPulse => {
+            esp_hard_reset_blocking(port)?;
+            Ok(ResetDispatchOutcome::Done)
+        }
+        other @ (DtrPulse | TouchBaud1200 | SwdViaCmsisDap) => {
+            tracing::debug!(
+                "dispatch_reset: family={family:?} requires {other:?} \
+                 — delegating to caller (not implemented in fbuild-serial)"
+            );
+            Ok(ResetDispatchOutcome::DelegateToCaller(other))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,5 +339,78 @@ mod tests {
             ..RecordedPort::default()
         };
         assert!(cdc_vcom_safe_assert(&mut port).is_err());
+    }
+
+    // ─── FastLED/fbuild#687: dispatch_reset polymorphic routing ───
+
+    /// ESP families route through `esp_hard_reset_blocking` and report
+    /// `Done` — the canonical happy path.
+    #[test]
+    fn dispatch_reset_esp_families_run_inline_and_report_done() {
+        for family in [
+            crate::boards::BoardFamily::Esp32NativeUsbCdc,
+            crate::boards::BoardFamily::Esp32ExternalUart,
+        ] {
+            let mut port = RecordedPort::default();
+            let outcome = dispatch_reset(family, &mut port).expect("dispatch_reset Ok");
+            assert_eq!(outcome, ResetDispatchOutcome::Done);
+            assert_eq!(
+                port.events,
+                vec![("DTR", false), ("RTS", true), ("RTS", false)],
+                "ESP family {family:?} must emit the canonical reset sequence"
+            );
+        }
+    }
+
+    /// CDC-ACM bridge → DelegateToCaller(SwdViaCmsisDap). MUST NOT
+    /// touch DTR/RTS — that's the FastLED/FastLED#3300 silent-byte-
+    /// drop trap.
+    #[test]
+    fn dispatch_reset_cdc_acm_delegates_without_touching_dtr_rts() {
+        let mut port = RecordedPort::default();
+        let outcome = dispatch_reset(crate::boards::BoardFamily::CdcAcmBridge, &mut port)
+            .expect("dispatch_reset Ok");
+        assert_eq!(
+            outcome,
+            ResetDispatchOutcome::DelegateToCaller(crate::boards::ResetMethod::SwdViaCmsisDap)
+        );
+        assert!(
+            port.events.is_empty(),
+            "CDC-ACM dispatch must NOT pulse DTR/RTS — that's the #3300 trap"
+        );
+    }
+
+    /// Teensy / SAMD / RP2040 → DelegateToCaller(TouchBaud1200).
+    #[test]
+    fn dispatch_reset_1200bps_families_delegate() {
+        for family in [
+            crate::boards::BoardFamily::Teensy,
+            crate::boards::BoardFamily::NativeUsbCdcReset1200Bps,
+        ] {
+            let mut port = RecordedPort::default();
+            let outcome = dispatch_reset(family, &mut port).expect("dispatch_reset Ok");
+            assert_eq!(
+                outcome,
+                ResetDispatchOutcome::DelegateToCaller(crate::boards::ResetMethod::TouchBaud1200),
+                "family {family:?} must route to TouchBaud1200"
+            );
+            assert!(port.events.is_empty(), "no DTR/RTS pulse for {family:?}");
+        }
+    }
+
+    /// Arduino auto-reset → DelegateToCaller(DtrPulse).
+    #[test]
+    fn dispatch_reset_arduino_delegates_to_dtr_pulse() {
+        let mut port = RecordedPort::default();
+        let outcome = dispatch_reset(crate::boards::BoardFamily::ArduinoAutoReset, &mut port)
+            .expect("dispatch_reset Ok");
+        assert_eq!(
+            outcome,
+            ResetDispatchOutcome::DelegateToCaller(crate::boards::ResetMethod::DtrPulse)
+        );
+        assert!(
+            port.events.is_empty(),
+            "no pulse — caller drives Arduino auto-reset"
+        );
     }
 }

--- a/crates/fbuild-serial/src/manager.rs
+++ b/crates/fbuild-serial/src/manager.rs
@@ -71,11 +71,21 @@ impl SharedSerialManager {
     }
 
     /// Open a serial port. Retries with backoff for Windows USB-CDC.
+    ///
+    /// `family` (FastLED/fbuild#687) consults
+    /// [`crate::boards::BoardFamily::idle_dtr_rts`] for the post-open
+    /// DTR/RTS state. `None` falls back to the safe default of
+    /// `(true, true)` — works for every CDC-ACM bridge plus
+    /// ESP-via-DevKit-autoreset; the only case it's wrong is when the
+    /// caller knows the chip is a native ESP USB CDC AND wants the
+    /// "(false, false) = run firmware" post-open idle. Pass
+    /// `Some(BoardFamily::Esp32NativeUsbCdc)` in that case.
     pub async fn open_port(
         &self,
         port: &str,
         baud_rate: u32,
         client_id: &str,
+        family: Option<crate::boards::BoardFamily>,
     ) -> fbuild_core::Result<()> {
         let session_key = self.resolve_port_key(port);
         // If already open, just return Ok
@@ -110,6 +120,7 @@ impl SharedSerialManager {
             // self-eviction tick, HTTP handlers) keep making progress. See
             // ISSUES.md "Issue C".
             let port_for_open = port_name.clone();
+            let family_for_open = family;
             let open_result: std::result::Result<
                 std::result::Result<Box<dyn serialport::SerialPort>, serialport::Error>,
                 tokio::task::JoinError,
@@ -117,7 +128,7 @@ impl SharedSerialManager {
                 let mut serial = serialport::new(&port_for_open, baud_rate)
                     .timeout(Duration::from_millis(timeout_ms))
                     .open()?;
-                // Set DTR=true, RTS=true for flow control. Failures here are
+                // Set the post-open DTR/RTS idle state. Failures here are
                 // non-fatal — some adapters (e.g. CP210x in CDC mode) reject
                 // the request but the port is still usable. Log both the
                 // success and failure paths at `debug!` so a complete log
@@ -125,17 +136,29 @@ impl SharedSerialManager {
                 // (FastLED/fbuild#532 acceptance: "logs show enough DTR/RTS
                 // /reset context to diagnose future S3 boot-mode lockups").
                 //
-                // For the full per-chip DTR/RTS semantics matrix — why
-                // DTR=true/RTS=true is the universal safe default, and
-                // which chips treat it differently — see
-                // `docs/usb-cdc-control-line-matrix.md` (FastLED/fbuild#689).
-                match serial.write_data_terminal_ready(true) {
-                    Ok(()) => tracing::debug!("manager: open-time DTR=high asserted"),
-                    Err(e) => tracing::warn!("failed to set DTR: {}", e),
+                // `family.idle_dtr_rts()` (FastLED/fbuild#687) picks
+                // `(false, false)` for ESP native USB CDC (post-reset idle
+                // = run firmware) vs `(true, true)` for CDC-ACM bridges,
+                // Teensy, RP2040, SAMD, Arduino (host-ready / no
+                // accidental reset). `None` falls back to `(true, true)`
+                // — the universal safe default per the LPC845-BRK
+                // incident (FastLED/FastLED#3300). For the full per-chip
+                // matrix see `docs/usb-cdc-control-line-matrix.md`
+                // (FastLED/fbuild#689).
+                let (dtr, rts) = family.map(|f| f.idle_dtr_rts()).unwrap_or((true, true));
+                match serial.write_data_terminal_ready(dtr) {
+                    Ok(()) => tracing::debug!(
+                        family = ?family_for_open,
+                        "manager: open-time DTR={dtr} asserted"
+                    ),
+                    Err(e) => tracing::warn!("failed to set DTR={dtr}: {}", e),
                 }
-                match serial.write_request_to_send(true) {
-                    Ok(()) => tracing::debug!("manager: open-time RTS=high asserted"),
-                    Err(e) => tracing::warn!("failed to set RTS: {}", e),
+                match serial.write_request_to_send(rts) {
+                    Ok(()) => tracing::debug!(
+                        family = ?family_for_open,
+                        "manager: open-time RTS={rts} asserted"
+                    ),
+                    Err(e) => tracing::warn!("failed to set RTS={rts}: {}", e),
                 }
                 Ok(serial)
             })
@@ -1096,7 +1119,9 @@ mod tests {
             let bogus_port = "FBUILD_TEST_NONEXISTENT_PORT_xyz_zzz".to_string();
 
             let open_task = tokio::spawn(async move {
-                let _ = mgr_open.open_port(&bogus_port, 115200, "test_client").await;
+                let _ = mgr_open
+                    .open_port(&bogus_port, 115200, "test_client", None)
+                    .await;
             });
 
             // Concurrent keepalive: should tick at least 5 times (5 × 50ms


### PR DESCRIPTION
## Summary

FastLED/fbuild#687 — polymorphic reset dispatch. Until now reset was implicit: deploy paths called `esp_hard_reset_blocking` directly, LPC callers had to do their own SWD-via-CMSIS-DAP, and Teensy/SAMD/RP2040 had no path at all. This PR builds the dispatch surface.

## What this PR ships

### `boards.rs` extensions

- New `ResetMethod` enum: `DtrRtsPulse | DtrPulse | TouchBaud1200 | SwdViaCmsisDap`. Only `DtrRtsPulse` has an in-`fbuild-serial` implementation today (`esp_hard_reset_blocking`); the other three delegate to the caller.
- `BoardFamily::reset_method()` — the family → primitive mapping.
- `BoardFamily::reset_is_serial_native()` — `true` iff `dispatch_reset` can run the reset inline.
- Expanded variants: added `Teensy`, `NativeUsbCdcReset1200Bps`, `ArduinoAutoReset`. Renamed `Arduino` → `ArduinoAutoReset`. Existing `CdcAcmBridge` stays without payload (future enhancement noted in doc-comment).
- `family_for_vid_pid` updated: RP2040 now classifies as `NativeUsbCdcReset1200Bps`. Arduino returns `ArduinoAutoReset`. Teensy shares VID:PID with LPC11U35 — kept as `CdcAcmBridge` (more common case); Teensy variant must be constructed explicitly.

### `esp_reset.rs` extensions

- `ResetDispatchOutcome { Done | DelegateToCaller(ResetMethod) }`.
- `dispatch_reset(family, port) -> Result<ResetDispatchOutcome>` — routes ESP families to `esp_hard_reset_blocking`, returns `DelegateToCaller(other)` for the three primitives `fbuild-serial` doesn't own. The match-on-`reset_method()` IS the debug-assert #687 criterion 3 asks for: a non-ESP family ends at `DelegateToCaller` instead of pulsing DTR=low on an LPC VCOM bridge (the FastLED/FastLED#3300 trap).

### `manager::open_port` signature change

Added `family: Option<BoardFamily>` as a 4th positional arg. Consults `idle_dtr_rts()` for the post-open DTR/RTS state; `None` defaults to `(true, true)` (the prior hardcoded behavior). Updated three external callers (websockets, deploy, monitor) and the internal test to pass `None`.

## Tests — 80 passed (was 72)

8 new tests, key one being `dispatch_reset_cdc_acm_delegates_without_touching_dtr_rts` which pins the FastLED/FastLED#3300 invariant at the dispatcher level — CDC-ACM dispatch MUST NOT pulse DTR/RTS.

```
test result: ok. 80 passed; 0 failed; 1 ignored; ...
```

`cargo clippy -p fbuild-serial -p fbuild-daemon --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean.

## Out of scope (follow-ups)

- `BoardFamily` plumbing through the daemon's request layer (websockets, deploy, monitor all pass `None` for now). Needs an HTTP-API contract decision: client-supplied vs server-inferred via `family_for_vid_pid`.
- Implementations of `DtrPulse` / `TouchBaud1200` — each gets its own follow-up. The dispatcher returns `DelegateToCaller` so callers can wire them externally without blocking this landing.
- `CdcAcmBridge { vid, pid }` payload — non-breaking variant evolution later.
- Renaming `esp_hard_reset_blocking` → `esp_dtr_rts_reset_blocking` (criterion 3): kept current name (already renamed in #684); a second rename burns caller breakage for marginal clarity. The debug-assert intent is satisfied by `dispatch_reset`'s family check.

## Test plan

- [x] `cargo test -p fbuild-serial --lib` (80/80)
- [x] `cargo clippy -p fbuild-serial -p fbuild-daemon --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Workspace CI green

Closes #687.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved serial port initialization and board type detection for enhanced compatibility with various development boards (Arduino, RP2040, Teensy, ESP32).
  * Enhanced reset handling to provide more reliable device connections across different board types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->