### PR TITLE
ci(hooks): forbidden_commands.py — block pyocd/esptool/dfu-util/picotool/probe-rs (#694)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,11 @@
             "type": "command",
             "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/tool_guard.py",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && uv run --no-project --script ci/hooks/forbidden_commands.py",
+            "timeout": 5
           }
         ]
       }

--- a/ci/hooks/forbidden_commands.py
+++ b/ci/hooks/forbidden_commands.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env -S uv run --no-project --script
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""PreToolUse hook: block direct invocation of low-level deploy/debug tools.
+
+Mirror of FastLED's `ci/hooks/check_forbidden_commands.py` —
+FastLED/fbuild#694, filed in the wake of FastLED/FastLED#3300 / #3325
+/ #3339 (the LPC845-BRK bring-up incident).
+
+## The structural lesson
+
+"Device looks silent" debugging sessions are almost always agents
+reaching for a low-level tool that bypasses the project's accumulated
+knowledge about that board — pyocd typed ad-hoc instead of `fbuild
+deploy <board>` skips CMSIS-DAP / SWD reset dispatch (#687), post-flash
+VCOM unwedge timing (#565), artifact size validation (#690), and the
+per-board handoff timing (#691). The result is a wedged VCOM on
+Windows, silent flash failures past the flash region boundary, and
+race conditions on monitor open. Policy through docs alone doesn't
+hold — agents drift. Policy through hooks does.
+
+## What this blocks
+
+`pyocd`, `esptool` / `esptool.py`, `dfu-util`, `picotool`, `probe-rs`
+when invoked as the bare command in a Bash invocation. False-positive
+hardening — see `is_benign_mention` — prevents docs / commit-body
+mentions from being flagged.
+
+## Override
+
+`FL_AGENT_ALLOW_ALL_CMDS=1` in the environment lets the call through.
+Use only for legitimate debug-the-hook cases. Same env var name as
+FastLED for muscle memory.
+
+## Exit codes
+
+  0 — allow (no output, or emit advisory JSON for the harness)
+  2 — deny (stderr message routed back to Claude)
+"""
+
+import json
+import os
+import re
+import sys
+
+
+# Each forbidden command is a regex against the START of the Bash
+# command string (after stripping leading whitespace + simple `env
+# VAR=val` prefixes). Patterns must be standalone-word matches so
+# `mypyocd-wrapper` or `not-esptool-py` don't false-fire.
+FORBIDDEN_COMMANDS: dict[str, str] = {
+    "pyocd": (
+        "use `fbuild deploy <board>` or `bash autoresearch <board>` — the "
+        "orchestrator dispatches CMSIS-DAP/SWD reset (fbuild#687), handles "
+        "post-flash VCOM unwedge timing (fbuild#565), validates artifact "
+        "size against flash region (fbuild#690), and times the handoff "
+        "(fbuild#691). None of that runs when pyocd is invoked directly."
+    ),
+    "esptool": (
+        "use `fbuild deploy -e <env>` instead — the deploy wrapper handles "
+        "ROM-download-mode detection, USB CDC retry policy, and post-flash "
+        "reset. Direct esptool calls skip all of it."
+    ),
+    "esptool.py": (
+        "use `fbuild deploy -e <env>` instead — same reason as bare esptool."
+    ),
+    "dfu-util": (
+        "use `fbuild deploy -e <env>` once the SAMD/STM32 deploy path lands. "
+        "Direct dfu-util skips artifact-size validation (fbuild#690)."
+    ),
+    "picotool": (
+        "use `fbuild deploy -e <env>` for RP2040. Direct picotool skips "
+        "BOOTSEL re-enumeration timing (fbuild#691) and artifact size "
+        "validation (fbuild#690)."
+    ),
+    "probe-rs": (
+        "use `fbuild deploy -e <env>`. Direct probe-rs skips the same set "
+        "of orchestration steps (fbuild#687/#690/#691). The probe-rs library "
+        "is fine; the standalone CLI is what's banned."
+    ),
+}
+
+OVERRIDE_ENV = "FL_AGENT_ALLOW_ALL_CMDS"
+
+
+def _strip_prefixes(segment: str) -> str:
+    s = re.sub(r"^env(?:\s+[A-Z_][A-Z0-9_]*=\S+)+\s+", "", segment.lstrip())
+    s = re.sub(r"^sudo\s+", "", s)
+    return s
+
+
+def is_benign_mention(command: str, tool: str) -> bool:
+    """Filter out string mentions that aren't actual invocations.
+
+    Cases that must NOT trip the ban:
+
+    - `git commit -m "fix: avoid pyocd race ..."` — commit body
+    - `grep -r 'pyocd' docs/` — searching for the string
+    - `echo "see esptool docs"` — echoing the name
+    - `cat README.md | grep esptool` — reading a doc; `esptool` is an
+      argument to grep, not a process name
+
+    Heuristic: the tool is an invocation iff it's the first token of
+    some pipe / `&&` / `||` / `;` segment of the command (after
+    stripping `env VAR=val …` and `sudo` prefixes). Otherwise it's a
+    mention.
+
+    Lesson from FastLED's first revision of the hook (see #3339 review
+    thread): the first cut over-fired on commit messages.
+    """
+    # Split on common shell separators that introduce a new subcommand.
+    # This isn't a real shell parse — it's enough for the "tool is the
+    # leading word of some segment" check we need.
+    segments = re.split(r"\|{1,2}|&&|;", command)
+    for segment in segments:
+        stripped = _strip_prefixes(segment)
+        if not stripped:
+            continue
+        first_token = stripped.split(None, 1)[0]
+        if first_token == tool:
+            return False
+    return True
+
+
+def find_forbidden(command: str) -> tuple[str, str] | None:
+    """Return `(tool, advice)` if `command` invokes a forbidden tool.
+
+    Iterates banned tools by descending name length so longer names
+    (`esptool.py`) match before their prefixes (`esptool`).
+    """
+    for tool, advice in sorted(
+        FORBIDDEN_COMMANDS.items(), key=lambda kv: -len(kv[0])
+    ):
+        if not re.search(rf"(?<![A-Za-z0-9_.-]){re.escape(tool)}(?![A-Za-z0-9_])", command):
+            continue
+        if is_benign_mention(command, tool):
+            continue
+        return tool, advice
+    return None
+
+
+def main() -> int:
+    if os.environ.get(OVERRIDE_ENV) == "1":
+        # Caller has explicitly opted into the ban override (debug-
+        # the-hook etc.). Allow silently.
+        return 0
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+    command = data.get("tool_input", {}).get("command", "")
+    if not command:
+        return 0
+    hit = find_forbidden(command)
+    if hit is None:
+        return 0
+    tool, advice = hit
+    print(
+        f"forbidden: `{tool}` — {advice}\n"
+        f"override with `{OVERRIDE_ENV}=1` for legitimate debug-the-hook cases.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/hooks/test_forbidden_commands.py
+++ b/ci/hooks/test_forbidden_commands.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env -S uv run --no-project --script
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""Unit tests for forbidden_commands.py.
+
+FastLED/fbuild#694 — pin the false-positive-resistance promises from
+the issue's acceptance criterion ("benign mentions in commit bodies /
+docs are not flagged").
+
+Run directly: `python ci/hooks/test_forbidden_commands.py`.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+
+HOOK_PATH = Path(__file__).resolve().parent / "forbidden_commands.py"
+spec = importlib.util.spec_from_file_location("forbidden_commands", HOOK_PATH)
+assert spec is not None and spec.loader is not None
+forbidden = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(forbidden)
+
+
+class FindForbidden(unittest.TestCase):
+    def test_bare_pyocd_invocation_is_blocked(self) -> None:
+        hit = forbidden.find_forbidden("pyocd flash --target lpc845 firmware.elf")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "pyocd")
+
+    def test_bare_esptool_blocked(self) -> None:
+        hit = forbidden.find_forbidden(
+            "esptool --chip esp32s3 --port COM12 write_flash 0x0 firmware.bin"
+        )
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "esptool")
+
+    def test_esptool_py_dotted_form_blocked(self) -> None:
+        hit = forbidden.find_forbidden("esptool.py --chip esp32 write_flash 0x0 fw.bin")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "esptool.py")
+
+    def test_dfu_util_blocked(self) -> None:
+        hit = forbidden.find_forbidden("dfu-util -a 0 -D firmware.dfu")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "dfu-util")
+
+    def test_picotool_blocked(self) -> None:
+        hit = forbidden.find_forbidden("picotool load firmware.uf2 -f")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "picotool")
+
+    def test_probe_rs_cli_blocked(self) -> None:
+        hit = forbidden.find_forbidden("probe-rs run --chip ESP32S3 firmware.elf")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "probe-rs")
+
+    def test_env_prefix_does_not_bypass(self) -> None:
+        # `env VAR=val pyocd …` is still invoking pyocd.
+        hit = forbidden.find_forbidden("env RUST_LOG=debug pyocd reset --target lpc845")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "pyocd")
+
+    def test_sudo_prefix_does_not_bypass(self) -> None:
+        hit = forbidden.find_forbidden("sudo dfu-util -a 0 -D firmware.dfu")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "dfu-util")
+
+    def test_fbuild_deploy_is_allowed(self) -> None:
+        self.assertIsNone(
+            forbidden.find_forbidden("fbuild deploy -e lpc845brk")
+        )
+
+    def test_unrelated_command_is_allowed(self) -> None:
+        self.assertIsNone(forbidden.find_forbidden("ls -la"))
+        self.assertIsNone(forbidden.find_forbidden("git status"))
+        self.assertIsNone(forbidden.find_forbidden("cargo build"))
+
+
+class BenignMentionFiltering(unittest.TestCase):
+    """The hook MUST NOT block commit bodies, doc grep, echo'd help text.
+
+    Lesson from FastLED's first revision of the hook (see #3339 review
+    thread): it over-fired on commit messages. Pin the false-positives
+    so a future tightening doesn't regress.
+    """
+
+    def test_git_commit_body_mentioning_pyocd_is_allowed(self) -> None:
+        self.assertIsNone(
+            forbidden.find_forbidden(
+                'git commit -m "fix(lpc): avoid pyocd race after reset"'
+            )
+        )
+
+    def test_grep_for_string_pyocd_is_allowed(self) -> None:
+        self.assertIsNone(
+            forbidden.find_forbidden("grep -r 'pyocd' docs/")
+        )
+
+    def test_echo_mentioning_esptool_is_allowed(self) -> None:
+        self.assertIsNone(
+            forbidden.find_forbidden('echo "see esptool docs for chip detection"')
+        )
+
+    def test_cat_through_grep_for_dfu_util_is_allowed(self) -> None:
+        self.assertIsNone(
+            forbidden.find_forbidden("cat README.md | grep dfu-util")
+        )
+
+    def test_quoted_picotool_mention_in_pr_body_is_allowed(self) -> None:
+        self.assertIsNone(
+            forbidden.find_forbidden(
+                "gh pr create --title 'rp2040 fix' --body 'avoid picotool deadlock'"
+            )
+        )
+
+    def test_double_quoted_probe_rs_mention_is_allowed(self) -> None:
+        self.assertIsNone(
+            forbidden.find_forbidden(
+                'echo "probe-rs is the alternative for non-CMSIS-DAP probes"'
+            )
+        )
+
+
+class OverrideEnvVar(unittest.TestCase):
+    """`FL_AGENT_ALLOW_ALL_CMDS=1` must bypass the hook entirely.
+
+    This is the escape hatch the issue's acceptance criterion calls
+    out by name — needs to match FastLED's exactly for muscle memory.
+    """
+
+    def test_override_constant_matches_fastled(self) -> None:
+        self.assertEqual(forbidden.OVERRIDE_ENV, "FL_AGENT_ALLOW_ALL_CMDS")
+
+    def test_main_returns_0_with_override_set(self) -> None:
+        # Simulate the harness handing the hook a forbidden command
+        # via stdin. With the override env var set, the hook must
+        # return exit 0 (allow).
+        import io
+
+        old_env = os.environ.get(forbidden.OVERRIDE_ENV)
+        old_stdin = sys.stdin
+        try:
+            os.environ[forbidden.OVERRIDE_ENV] = "1"
+            sys.stdin = io.StringIO(
+                '{"tool_input": {"command": "pyocd flash firmware.elf"}}'
+            )
+            rc = forbidden.main()
+            self.assertEqual(rc, 0)
+        finally:
+            sys.stdin = old_stdin
+            if old_env is None:
+                os.environ.pop(forbidden.OVERRIDE_ENV, None)
+            else:
+                os.environ[forbidden.OVERRIDE_ENV] = old_env
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Mirror of FastLED's `ci/hooks/check_forbidden_commands.py` (FastLED/FastLED#3336 + #3339). Blocks agents from invoking low-level deploy/debug tools that bypass the fbuild orchestrator's accumulated knowledge — reset method dispatch (#687), VCOM unwedge timing (#565), artifact size validation (#690), per-board handoff timing (#691).

What's blocked: `pyocd`, `esptool`, `esptool.py`, `dfu-util`, `picotool`, `probe-rs`.

Override: `FL_AGENT_ALLOW_ALL_CMDS=1` (matches FastLED's name for muscle memory).

False-positive resistance (18 unit tests):
- Commit bodies mentioning the tool name pass through
- `grep` / `cat | grep` for the string pass through
- Quoted mentions in `echo` / `gh pr` pass through
- `env VAR=val pyocd …` and `sudo dfu-util …` DO trip (still invocations)
- Longest-match: `esptool.py` matches before bare `esptool`

Registered in `.claude/settings.json` as a second `PreToolUse` hook alongside `tool_guard.py`.

Closes #694.