### PR TITLE
chore: rename nightly-usb-ids workflow to update-data

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -39,9 +39,9 @@
 #     branch keeps its last good snapshot.
 #   - History is pruned to the most recent 200 commits per the design.
 #
-# Manual trigger: Actions tab → "Nightly online-data refresh" → Run.
+# Manual trigger: Actions tab → "Update data" → Run workflow.
 
-name: Nightly online-data refresh
+name: Update data
 
 on:
   schedule:
@@ -54,7 +54,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: nightly-online-data
+  group: update-data
   cancel-in-progress: false
 
 env:
@@ -64,8 +64,8 @@ env:
   HISTORY_LIMIT: 200
 
 jobs:
-  refresh:
-    name: Refresh online-data datasets
+  update:
+    name: Update online-data datasets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main (default branch)
@@ -293,7 +293,7 @@ jobs:
         if: always()
         run: |
           {
-            echo "## Nightly online-data refresh"
+            echo "## Update online-data"
             echo ""
             echo "| source / step | outcome |"
             echo "|---|---|"

--- a/crates/fbuild-core/examples/dump_usb_ids.rs
+++ b/crates/fbuild-core/examples/dump_usb_ids.rs
@@ -1,7 +1,7 @@
 //! Dump the bundled `usb-ids` database as a JSON object to stdout.
 //!
 //! Used by the `online-data` branch's nightly workflow (see
-//! `.github/workflows/nightly-usb-ids.yml`) as one of the input sources
+//! `.github/workflows/update-data.yml`) as one of the input sources
 //! for the merged `usb-vid.json`. Running this example via
 //! `soldr cargo run --release --example dump_usb_ids -p fbuild-core`
 //! captures the exact data the bundled `usb-ids` crate version we depend

--- a/docs/online-data.md
+++ b/docs/online-data.md
@@ -61,7 +61,7 @@ the merger script and commit results.
 
 ## How a refresh happens
 
-`.github/workflows/nightly-usb-ids.yml` is the only workflow that touches
+`.github/workflows/update-data.yml` is the only workflow that touches
 `online-data`. It lives on `main` because GitHub Actions requires `schedule`
 and `workflow_dispatch` triggers to be defined on the default branch.
 
@@ -92,7 +92,7 @@ Per run:
 9. `git push --force-with-lease origin online-data` (the force is needed
    only when history was pruned).
 
-Manual trigger: Actions → "Nightly USB IDs refresh" → Run workflow.
+Manual trigger: Actions → "Update data" → Run workflow.
 
 ## Fault tolerance contract
 


### PR DESCRIPTION
Workflow now refreshes multiple datasets, so the file name + display name no longer fit. Rename to `update-data.yml` / "Update data". Trade-off: existing run history under the old name is stranded in the Actions UI, but new runs appear under the clearer name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed GitHub Actions workflow to "Update data" for improved clarity.

* **Documentation**
  * Updated documentation and examples to reflect workflow naming changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->