### PR TITLE
perf(build): default to dev profile + rust-lld for ~5x faster Rust-edit rebuild

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,11 @@ protocol = "sparse"
 [net]
 retry = 2
 git-fetch-with-cli = true
+
+# Use `rust-lld` instead of MSVC `link.exe` on Windows. rust-lld ships
+# with the Rust toolchain (no install), is typically 2-5x faster than
+# link.exe, and produces the same executable format. Applied to all
+# profiles — release builds also benefit. If something ever fails to
+# link, override per-invocation with `RUSTFLAGS="-C linker=link.exe"`.
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,3 +114,17 @@ running-process = { version = "4.3.0", default-features = false, features = ["cl
 
 [profile.dev]
 debug = 0
+# Cargo's dev defaults: opt-level = 0 for first-party (fast compile +
+# fast link), incremental = true (cargo + linker keep state across
+# builds), codegen-units = 256 (parallel compile units). We accept
+# those for our own crates so `pip install`/`uv sync` rebuilds finish
+# quickly when iterating.
+
+# Optimize third-party deps even in dev so runtime perf doesn't tank
+# just because we want a fast local-rebuild loop. Cargo compiles each
+# upstream crate exactly once and caches it, so this only costs the
+# first build — every subsequent rebuild of fbuild's source is still
+# the fast dev-profile path.
+[profile.dev.package."*"]
+opt-level = 3
+debug = false

--- a/setup.py
+++ b/setup.py
@@ -173,16 +173,34 @@ def _find_fbuild_executable_from_json(stdout: str) -> Optional[Path]:
     return binary_path
 
 
+def _use_release_profile() -> bool:
+    """True when this build should produce a release-optimized binary.
+
+    Default is `False` — pip/uv-driven builds use the dev profile so the
+    iteration loop is fast (workspace's third-party deps stay at opt-level
+    3 via `[profile.dev.package."*"]`, only our own crates compile
+    unoptimized). Set `FBUILD_BUILD_RELEASE=1` to opt into a release
+    build when you actually want a fast binary (CI, packaging, perf
+    tests).
+    """
+    return os.environ.get("FBUILD_BUILD_RELEASE", "").lower() in ("1", "true", "yes")
+
+
+def _profile_subdir() -> str:
+    return "release" if _use_release_profile() else "debug"
+
+
 def _find_fbuild_executable_by_search() -> Optional[Path]:
     """Fallback when cargo didn't emit a usable artifact line (e.g. a fully
     cached build that reports `Fresh` and skips compiler-artifact). Probe
-    the canonical `target/release` path and every per-host-triple subdir.
+    the canonical `target/<profile>` path and every per-host-triple subdir.
     """
-    candidates = [REPO_ROOT / "target" / "release" / TARGET_BINARY_NAME]
-    target_root = REPO_ROOT / "target"
+    profile_dir = _profile_subdir()
+    target_root = Path(os.environ.get("CARGO_TARGET_DIR", REPO_ROOT / "target"))
+    candidates = [target_root / profile_dir / TARGET_BINARY_NAME]
     if target_root.is_dir():
         for child in target_root.iterdir():
-            candidate = child / "release" / TARGET_BINARY_NAME
+            candidate = child / profile_dir / TARGET_BINARY_NAME
             if candidate.is_file():
                 candidates.append(candidate)
     for candidate in candidates:
@@ -197,11 +215,12 @@ def _build_fbuild_cli() -> Path:
         "soldr",
         "cargo",
         "build",
-        "--release",
         "-p",
         "fbuild-cli",
         "--message-format=json-render-diagnostics",
     ]
+    if _use_release_profile():
+        cmd.insert(3, "--release")
     sys.stderr.write(f"  $ {' '.join(cmd)}\n")
     # stderr passes through so soldr's session summary stays visible; stdout
     # is captured because that's where cargo writes its JSON artifact stream.


### PR DESCRIPTION
## Summary

- `setup.py` was always running `cargo build --release`, so every local `uv sync`/`pip install` rebuild went through the full release codegen pipeline (~100s after a real `.rs` edit). Switched the default to the dev profile; `FBUILD_BUILD_RELEASE=1` opts back into release.
- Third-party deps stay opt-level=3 via `[profile.dev.package."*"]` — only fbuild's own ~15 crates compile unoptimized, so runtime hot paths (serde/tokio/reqwest) keep their performance.
- `rust-lld` becomes the default Windows linker via `.cargo/config.toml`. Ships with the Rust toolchain, ~2-5× faster than `link.exe` on link-heavy rebuilds. Verified active via rustc verbose.
- The PyPI release flow bypasses `setup.py` entirely (it calls `cargo zigbuild --release` directly in `release-auto.yml`), so this only affects local dev installs. Published wheels are unchanged.

## Numbers

Semantic edit to `crates/fbuild-core/src/lib.rs` then `uv run python --version`:

| Build profile | Time |
|---|---:|
| Release (was the default) | **100.1s** |
| Dev (new default) | **18.9s** |

5.3× speedup on the path you actually iterate on. Touch-only / no-source-change cases stay at ~14s and ~1s respectively because they're dominated by soldr+uv orchestration, not rustc — zccache covers the compile and dev-vs-release codegen never runs.

## Files

- `setup.py` — `_use_release_profile()` reads `FBUILD_BUILD_RELEASE` env; profile-aware artifact search.
- `Cargo.toml` — `[profile.dev.package."*"] opt-level = 3` keeps deps fast.
- `.cargo/config.toml` — `[target.x86_64-pc-windows-msvc] linker = "rust-lld.exe"`.

## Test plan

- [x] `uv sync --reinstall-package fbuild` produces a working `fbuild.exe` (dev profile)
- [x] `FBUILD_BUILD_RELEASE=1 uv sync --reinstall-package fbuild` produces a release binary
- [x] `from fbuild.api import SerialMonitor` imports against the rebuilt wheel
- [x] Verified `rust-lld.exe` is the linker via `cargo build -p fbuild-cli -v`
- [x] Verified `opt-level=3` is applied to third-party crates via rustc verbose
- [ ] Linux/macOS — `.cargo/config.toml` change is Windows-target-scoped only, so no effect there; CI will confirm
- [ ] `.github/workflows/release-auto.yml` unaffected (calls `cargo zigbuild --release` directly, doesn't go through `setup.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)