### PR TITLE
fix(install): use src-layout package-dir so editable install ships a .pth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,14 +60,19 @@ build-backend = "setuptools.build_meta"
 packages = ["fbuild", "fbuild.api"]
 include-package-data = true
 
-# Map the `fbuild` and `fbuild.api` Python packages to their on-disk
-# location under python/. Without this, `pip install .` would skip the
-# python/ tree entirely, and downstream consumers like FastLED would hit
-# `ModuleNotFoundError: No module named 'fbuild'` on
-# `from fbuild.api import SerialMonitor`.
+# Tell setuptools the package root is `python/` — `python/fbuild/`,
+# `python/fbuild/api/`, and any future submodule are discovered relative
+# to it. The previous per-package map (`fbuild = "python/fbuild"`,
+# `"fbuild.api" = "python/fbuild/api"`) worked for the wheel build but
+# confused setuptools' editable install: it emitted a PEP 660 meta-path
+# finder whose MAPPING only registered the top-level `fbuild` package,
+# so static analyzers (ty, pyright, mypy) saw `Cannot resolve imported
+# module 'fbuild.api'` in downstream consumers even though runtime
+# imports worked via the finder's PathFinder fallback. With this
+# src-layout mapping, setuptools instead emits a plain `.pth` pointing
+# at `python/`, which every static analyzer handles.
 [tool.setuptools.package-dir]
-fbuild = "python/fbuild"
-"fbuild.api" = "python/fbuild/api"
+"" = "python"
 
 # Ship `_native.pyd`/.so that `python/fbuild/__init__.py` imports from.
 # The cargo-built `fbuild[.exe]` CLI binary is NOT package data — it is


### PR DESCRIPTION
## Summary

The per-package `package-dir = {fbuild = "python/fbuild", "fbuild.api" = "python/fbuild/api"}` map made setuptools' editable install emit a PEP 660 meta-path finder whose `MAPPING` only registered `fbuild`. `fbuild.api` resolved at runtime via `importlib.machinery.PathFinder` — fine for `import fbuild.api`, but invisible to static analyzers (ty, pyright, mypy) that walk `top_level.txt` / `.pth` files.

Downstream consumers (FastLED hit this on `from fbuild.api import SerialMonitor`) saw `Cannot resolve imported module 'fbuild.api'` even though runtime imports worked. The Stop-hook lint in FastLED failed on every `bash lint` after switching to an editable fbuild install.

Replace the per-package map with the canonical src-layout pattern `package-dir = {"" = "python"}`. Setuptools now emits a plain `.pth` pointing at `python/`, which every static analyzer handles, and the wheel-build path is unaffected.

## Verification

**Wheel artifact** (`python -m build` of both states, cp310-cp310-win_amd64):
| | Wheel size | Sdist size | Wheel contents |
|---|---:|---:|---|
| Baseline | 10,454,675 B | 2,316,616 B | `fbuild/__init__.py`, `fbuild/_native.pyd`, `fbuild/api/__init__.py`, `fbuild-2.2.31.data/scripts/fbuild.exe`, dist-info |
| This PR | 10,454,675 B | 2,319,427 B | **byte-identical** to baseline |

- Wheel is **byte-for-byte identical**.
- Sdist is +2,811 B / +0.12% — entirely from `fbuild.egg-info/` relocating to `python/fbuild.egg-info/`. Cosmetic.

**Release path (`ci/publish.py`)** is independent of `[tool.setuptools]` — it hand-rolls wheels from the hard-coded `PYTHON_SHIMS_DIR = ROOT / "python"`. Smoke-tested: still finds the same 2 shims (`fbuild/__init__.py`, `fbuild/api/__init__.py`). Same `EXTENSION_NAMES`. No change.

**Perf** (measured against the work in #743 / #744):
- Editable reinstall (FastLED → fbuild via `[tool.uv.sources]`): ~8s before, ~8s after. Within noise.
- Cold install (3.7GB cargo cache nuked): ~8.9s. Dominated by mtime-skip + wheel I/O, both unchanged.
- Warm `uv run python --version`: 110-139ms. Within #743's baseline noise.
- mtime-skip in `BuildWithCargo.run` untouched. Dev-profile gate (#744) untouched. `scripts=` binary shipping (#746) untouched.

## Test plan

- [x] `python -m build` produces byte-identical wheel
- [x] `python -m build` produces structurally-identical sdist
- [x] `ci/publish.py::read_project_meta()` + `PYTHON_SHIMS_DIR.rglob('*.py')` resolves correctly
- [x] FastLED editable install: `__editable__.fbuild-2.2.31.pth` contains `<fbuild>/python`
- [x] `uv run ty check` resolves both `import fbuild` and `from fbuild.api import SerialMonitor`
- [x] `uv run fbuild --version` → `fbuild 2.2.31`
- [x] Runtime: `import fbuild.api` resolves to `python/fbuild/api/__init__.py`
- [ ] CI green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaging configuration to improve how the package is exposed during development installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->