### PR TITLE
chore: gitignore .extern-repos/ (clud-extern-repos checkout location)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,12 @@ tasks/loop-runs/
 # `git worktree add` location used by the nightly workflow.
 .online-data/
 
+# Cross-repo checkouts created by the `clud-extern-repos` skill —
+# dependent-repo clones that live here only for the duration of a
+# multi-repo change. Each subdir is its own independent git repo and
+# must never be committed into fbuild.
+.extern-repos/
+
 # clud project settings
 !.clud/
 !.clud/settings.json


### PR DESCRIPTION
## Summary

`.extern-repos/` is the documented checkout location for the `clud-extern-repos` skill — dependent-repo clones that live here only for the duration of a multi-repo change. Each subdir is its own independent git repo and must never be committed into fbuild.

Until now the directory wasn't gitignored, so cross-repo work showed up as untracked noise (and risked an accidental `git add -A` sucking an entire foreign repo into fbuild's history).

## Test plan

- [x] `git status` after a `gh repo clone foo .extern-repos/foo` no longer shows the checkout as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)