### PR TITLE
chore: bump version to 2.3.0 (minor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.2.31"
+version = "2.3.0"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.2.31"
+version = "2.3.0"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Minor version bump. Picks up the following recent PRs:

- #747 native `fbuild` shipped as a raw wheel script (drops Python launcher; fixes Windows stdout-ordering on `fbuild port scan`)
- #748 src-layout `package-dir` (static analyzers resolve `fbuild.api`)
- #750 daemon WS handler split into reader/writer/inbound
- #751 gitignore `.extern-repos/`
- #752 cargo fmt + test-module extractions so 4 source files fall under the 1000-LOC gate

No public-API changes beyond what's already documented in those PRs. The Autonomous Release action (`release-auto.yml`) will tag `v2.3.0` and publish to PyPI once main has both files at 2.3.0.

## Test plan

- [x] `Cargo.toml` and `pyproject.toml` versions match (release-auto refuses to publish if they don't).
- [ ] After merge: `release-auto` action goes green, `https://pypi.org/project/fbuild/2.3.0/` shows 4 platform wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)