### PR TITLE
[codex] test: include Arduino header in LPC sketches

### DIFF
--- a/tests/platform/lpc804/lpc804.ino
+++ b/tests/platform/lpc804/lpc804.ino
@@ -6,6 +6,8 @@
 // its own variant core (zackees/ArduinoCore-LPC8xx) provides the real
 // register-level GPIO implementation.
 
+#include <Arduino.h>
+
 #ifndef LED_BUILTIN
 #define LED_BUILTIN 0
 #endif

--- a/tests/platform/lpc845/lpc845.ino
+++ b/tests/platform/lpc845/lpc845.ino
@@ -6,6 +6,8 @@
 // its own variant core (zackees/ArduinoCore-LPC8xx) provides the real
 // register-level GPIO implementation.
 
+#include <Arduino.h>
+
 #ifndef LED_BUILTIN
 #define LED_BUILTIN 0
 #endif

--- a/tests/platform/lpc845_build_flags/src/main.ino
+++ b/tests/platform/lpc845_build_flags/src/main.ino
@@ -5,6 +5,8 @@
 // nxplpc library compile path. A working build proves the orchestrator now
 // folds `ctx.user_flags` into the `LibraryBuildEnv` flag set.
 
+#include <Arduino.h>
+
 extern void check_flag_no_op();
 
 void setup() {

--- a/tests/platform/lpc845brk/lpc845brk.ino
+++ b/tests/platform/lpc845brk/lpc845brk.ino
@@ -1,2 +1,4 @@
+#include <Arduino.h>
+
 void setup() {}
 void loop() {}

--- a/tests/platform/lpcxpresso804/lpcxpresso804.ino
+++ b/tests/platform/lpcxpresso804/lpcxpresso804.ino
@@ -1,2 +1,4 @@
+#include <Arduino.h>
+
 void setup() {}
 void loop() {}

--- a/tests/platform/lpcxpresso845max/lpcxpresso845max.ino
+++ b/tests/platform/lpcxpresso845max/lpcxpresso845max.ino
@@ -1,2 +1,4 @@
+#include <Arduino.h>
+
 void setup() {}
 void loop() {}


### PR DESCRIPTION
## Summary

Adds explicit `#include <Arduino.h>` lines to the LPC `.ino` fixtures under `tests/platform`.

## Why

The LPC build currently preprocesses sketches before the LPC8xx Arduino core include roots are available to the scanner. That means generated `.ino.cpp` files can miss `Arduino.h`, leaving fixture code unable to resolve Arduino symbols such as `pinMode`, `digitalWrite`, `delay`, `HIGH`, `LOW`, and `OUTPUT`.

Making the fixtures include `Arduino.h` directly keeps the tests independent of scanner-side header injection and unblocks the LPC board CI failures.

## Validation

- `git diff --check`
- Verified all six LPC sketch fixtures include `Arduino.h`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Resolved compilation failures across multiple platform test fixtures by ensuring required core library dependencies are properly included in test sketches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->