### PR TITLE
[codex] ci: restore native Windows release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
             macos_cross: false
 
           - target: x86_64-pc-windows-msvc
-            runner: ubuntu-24.04
+            runner: windows-latest
             binary_ext: ".exe"
             linux_cross: false
             macos_cross: false

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -170,7 +170,7 @@ jobs:
             macos_cross: false
 
           - target: x86_64-pc-windows-msvc
-            runner: ubuntu-24.04
+            runner: windows-latest
             binary_ext: ".exe"
             linux_cross: false
             macos_cross: false

--- a/.github/workflows/template_native_build.yml
+++ b/.github/workflows/template_native_build.yml
@@ -89,15 +89,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools pkg-config
 
-      # Windows MSVC release artifacts are built from Linux with cargo-xwin.
+      # Windows MSVC release artifacts can be cross-built from Linux with
+      # cargo-xwin, but native Windows runners use the standard cargo path.
       - name: Install cargo-xwin
-        if: contains(inputs.target, 'pc-windows-msvc')
+        if: runner.os == 'Linux' && contains(inputs.target, 'pc-windows-msvc')
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-xwin
 
       - name: Install xwin system dependencies
-        if: contains(inputs.target, 'pc-windows-msvc')
+        if: runner.os == 'Linux' && contains(inputs.target, 'pc-windows-msvc')
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends clang lld zip
@@ -112,7 +113,7 @@ jobs:
         run: pip install cargo-zigbuild
 
       - name: Fetch Windows Python lib for PyO3 cross-compile
-        if: contains(inputs.target, 'pc-windows-msvc')
+        if: runner.os == 'Linux' && contains(inputs.target, 'pc-windows-msvc')
         shell: bash
         run: |
           set -euo pipefail
@@ -138,7 +139,7 @@ jobs:
       - name: Build release binaries
         shell: bash
         run: |
-          if [[ "${{ inputs.target }}" == *-pc-windows-msvc ]]; then
+          if [ "${{ runner.os }}" = "Linux" ] && [[ "${{ inputs.target }}" == *-pc-windows-msvc ]]; then
             cargo xwin build --release --target ${{ inputs.target }} \
               -p fbuild-cli \
               -p fbuild-daemon
@@ -172,7 +173,7 @@ jobs:
         shell: bash
         run: |
           PYTHON_TARGET_DIR="target/python-extension"
-          if [[ "${{ inputs.target }}" == *-pc-windows-msvc ]]; then
+          if [ "${{ runner.os }}" = "Linux" ] && [[ "${{ inputs.target }}" == *-pc-windows-msvc ]]; then
             PYO3_NO_PYTHON=1 cargo xwin build --release \
               --target-dir "${PYTHON_TARGET_DIR}" \
               --target ${{ inputs.target }} -p fbuild-python \


### PR DESCRIPTION
## Summary

Restores Windows release/build jobs to real Windows runners instead of Linux-hosted `cargo-xwin` cross compilation.

## Changes

- Points the Windows target in `build.yml` at `windows-latest`.
- Points the Windows target in `release-auto.yml` at `windows-latest`.
- Keeps the shared native-build template compatible with Linux-hosted Windows cross builds, but only installs/invokes `cargo-xwin` when the runner is Linux.
- Native Windows runners now fall through to the normal `soldr cargo build` path for CLI, daemon, and Python extension artifacts.

## Validation

- `git diff --check -- .github/workflows/release-auto.yml .github/workflows/build.yml .github/workflows/template_native_build.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build environments to run on appropriate Windows runners instead of Linux-based systems for improved build reliability.
  * Refined cross-compilation workflow conditions to ensure build tools are correctly configured based on the runner environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->