### PR TITLE
chore: bump version to 2.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.3.0"
+version = "2.3.1"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -81,4 +81,3 @@ include-package-data = true
 # wrapper). See #746.
 [tool.setuptools.package-data]
 fbuild = ["_native.pyd", "_native.so"]
-


### PR DESCRIPTION
## Summary

Bumps fbuild from 2.3.0 to 2.3.1 to start a new autonomous release.

## Release notes

- Current PyPI latest is 2.3.0 with all 4 expected files present.
- `v2.3.1` does not exist as a remote tag or GitHub release.
- Per `docs/RELEASING.md`, pushing the version bump to `main` lets `release-auto.yml` build, publish, and create the release tag.

## Validation

- `soldr cargo metadata --format-version 1 --no-deps`
- `git diff --check -- Cargo.toml pyproject.toml Cargo.lock`