### PR TITLE
chore: bump version to 2.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.3.1"
+version = "2.3.2"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps fbuild to 2.3.2 so the autonomous release workflow can publish the USB VID protobuf cache support.

Validation:
- soldr cargo metadata --format-version 1 --no-deps
- git diff --check -- Cargo.toml pyproject.toml Cargo.lock