### PR TITLE
release: 2.3.4 (first Linux-cross-mac-arm64 release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbuild-bench-fastled-examples"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "fbuild-library-select",
  "fbuild-packages",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-build"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "async-trait",
  "blake3",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-cli"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "blake3",
  "clap",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-config"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "fbuild-core",
  "include_dir",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-core"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "libc",
  "prost",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-daemon"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-deploy"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "async-trait",
  "espflash",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-header-scan"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "criterion",
  "rayon",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-library-select"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "bincode",
  "blake3",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-packages"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "axum",
  "bzip2",
@@ -1101,14 +1101,14 @@ dependencies = [
 
 [[package]]
 name = "fbuild-paths"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "fbuild-core",
 ]
 
 [[package]]
 name = "fbuild-python"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "base64",
  "fbuild-core",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-serial"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "fbuild-test-support"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "fbuild-config",
  "fbuild-header-scan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = ["dylints/ban_raw_subprocess"]
 libraries = [{ path = "dylints/*" }]
 
 [workspace.package]
-version = "2.3.3"
+version = "2.3.4"
 edition = "2021"
 rust-version = "1.94.1"
 license = "MIT OR Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fbuild"
-version = "2.3.3"
+version = "2.3.4"
 description = "PlatformIO-compatible embedded build tool (Rust implementation)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps to 2.3.4. Triggers autonomous release after merge; this will be the first release where the `aarch64-apple-darwin` lane runs on `ubuntu-latest` via the new Linux cross-compile pipeline from #771.